### PR TITLE
Make e2e tests more lightweight

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -20,17 +20,17 @@ def project():
 
 @fixture
 def all_run_ids():
-    return sorted([f"id-run-{i + 1}" for i in range(10)])
+    return sorted([f"id-run-{i + 1}" for i in range(6)])
 
 
 @fixture
 def all_experiment_ids():
-    return sorted([f"id-exp-{i + 1}" for i in range(10)])
+    return sorted([f"id-exp-{i + 1}" for i in range(6)])
 
 
 @fixture
 def all_experiment_names():
-    return sorted([f"exp{i + 1}" for i in range(10)])
+    return sorted([f"exp{i + 1}" for i in range(6)])
 
 
 @fixture
@@ -46,7 +46,7 @@ def sys_columns():
 @fixture
 def id_to_name():
     """Expected sys/custom_run_id -> sys/name"""
-    d = {f"id-run-{num}": "" for num in range(1, 11)}
-    d |= {f"id-exp-{num}": f"exp{num}" for num in range(1, 11)}
+    d = {f"id-run-{num}": "" for num in range(1, 7)}
+    d |= {f"id-exp-{num}": f"exp{num}" for num in range(1, 7)}
 
     return d

--- a/tests/populate_projects.py
+++ b/tests/populate_projects.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import math
 import os
 import random
@@ -63,17 +64,18 @@ def populate_run(run, run_id, tags=None):
 
 
 def populate_many_metrics(project):
-    for x in range(MM_NUM_RUNS // 2):
-        create_runs(project, x + 1, tags=["head", "tag1"])
+    with concurrent.futures.ProcessPoolExecutor(max_workers=32) as executor:
+        for x in range(MM_NUM_RUNS // 2):
+            executor.submit(create_runs, project, x + 1, tags=["head", "tag1"])
 
-    for x in range(MM_NUM_RUNS // 2, MM_NUM_RUNS):
-        create_runs(project, x + 1, tags=["tail", "tag1"])
+        for x in range(MM_NUM_RUNS // 2, MM_NUM_RUNS):
+            executor.submit(create_runs, project, x + 1, tags=["tail", "tag1"])
 
-    for x in range(MM_NUM_RUNS // 2):
-        create_runs(project, x + 1, tags=["head", "tag2"], experiment_name=f"exp{x+1}")
+        for x in range(MM_NUM_RUNS // 2):
+            executor.submit(create_runs, project, x + 1, tags=["head", "tag2"], experiment_name=f"exp{x+1}")
 
-    for x in range(MM_NUM_RUNS // 2, MM_NUM_RUNS):
-        create_runs(project, x + 1, tags=["tail", "tag2"], experiment_name=f"exp{x+1}")
+        for x in range(MM_NUM_RUNS // 2, MM_NUM_RUNS):
+            executor.submit(create_runs, project, x + 1, tags=["tail", "tag2"], experiment_name=f"exp{x+1}")
 
 
 def create_runs(project, index, tags, experiment_name=None):
@@ -81,6 +83,7 @@ def create_runs(project, index, tags, experiment_name=None):
     kind = "run" if not experiment_name else "exp"
     run_id = f"id-{kind}-{index}"
     with Run(project=project, run_id=run_id, family=run_id, experiment_name=experiment_name) as run:
+        print("Populating run", run_id)
         populate_run(run, run_id, tags=tags)
 
 

--- a/tests/populate_projects.py
+++ b/tests/populate_projects.py
@@ -13,11 +13,11 @@ from neptune_scale import Run
 #    - NEPTUNE_API_TOKEN: the API token to use
 #
 # The data consists of:
-#     - 10 runs
+#     - 6 runs
 #        - custom_run_id and family id: id-run-1...id-run-10
 #        - runs 1-5 are tagged [head, tag1]
 #        - runs 5-10 are tagged [tail, tag1]
-#     - 10 experiments
+#     - 6 experiments
 #        - custom_run_id and family id: id-exp-1...id-exp-10
 #        - named exp1, exp2... etc
 #        - experiments 1-5 are tagged [head, tag2]
@@ -30,9 +30,14 @@ from neptune_scale import Run
 #       - config/foo{number}-unique-{custom_run_id}, from 1 to 100, value is `number`
 #       - metrics/bar{number}-unique-{custom_run_id}, from 1 to 100, value is `number`
 #       - each metric has 10 steps
+#
+# Each run thus has:
+# - 30 config fields, 10 of which are unique to the run
+# - 30 metric fields, 10 of which are unique to the run
+# -
 
-MM_NUM_RUNS = 10
-MM_NUM_FIELD_KIND = 10_000
+MM_NUM_RUNS = 6
+MM_NUM_FIELD_KIND = 10
 MM_NUM_STEPS = 10
 
 
@@ -42,7 +47,7 @@ def populate_run(run, run_id, tags=None):
 
     data = {f"config/foo{x + 1}": f"valfoo{x + 1}" for x in range(MM_NUM_FIELD_KIND)}
     data |= {f"config/bar{x + 1}": x + 1 for x in range(MM_NUM_FIELD_KIND)}
-    data |= {f"config/foo{x + 1}-unique-{run_id}": x + 1 for x in range(100)}
+    data |= {f"config/foo{x + 1}-unique-{run_id}": x + 1 for x in range(10)}
     run.log_configs(data)
 
     step = 0
@@ -50,14 +55,14 @@ def populate_run(run, run_id, tags=None):
         value = math.sin((step + random.random() - 0.5) * 0.1)
         data = {f"metrics/foo{x + 1}": value for x in range(MM_NUM_FIELD_KIND)}
         data |= {f"metrics/bar{x + 1}": value for x in range(MM_NUM_FIELD_KIND)}
-        data |= {f"metrics/bar{x + 1}-unique-{run_id}": value for x in range(100)}
+        data |= {f"metrics/bar{x + 1}-unique-{run_id}": value for x in range(10)}
 
         run.log_metrics(step, data=data)
 
     # Last step will have a predetermined value
     step += 1
     data = {f"metrics/foo{x + 1}": x + 1 for x in range(MM_NUM_FIELD_KIND)}
-    data |= {f"metrics/bar{x + 1}-unique-{run_id}": x + 1 for x in range(100)}
+    data |= {f"metrics/bar{x + 1}-unique-{run_id}": x + 1 for x in range(10)}
     data |= {f"metrics/bar{x + 1}": x + 1 for x in range(MM_NUM_FIELD_KIND)}
 
     run.log_metrics(step, data=data)


### PR DESCRIPTION
This PR reduces the amount of data created in `populate_runs.py` and adjusts tests accordingly.
A set of tests that rely on deterministic `sys/id` are removed, as they will no longer be valid, because `populate_runs.py` now creates runs concurrently.