### PR TITLE
Escape all user input that is part of an NQL query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ venv3.5/
 ENV/
 env.bak/
 venv.bak/
+/*.env
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ print(run["metrics/accuracy"].fetch_values())
 
 ## API reference
 
+### Supported regular expressions
+
+Neptune uses the [RE2](https://github.com/google/re2) regular expression library. For supported regex features and limitations, see the official [syntax guide](https://github.com/google/re2/wiki/syntax).
+
+
 ### `ReadOnlyProject`
 
 Representation of a Neptune project in a limited read-only mode.
@@ -266,7 +271,7 @@ __Parameters:__
 | `sort_by`                  | `str`, optional                               | `sys/creation_time` | Name of the field to sort the results by. The field must represent a simple type (string, float, integer).                                                                                                                                                                                                                                         |
 | `ascending`                | `bool`, optional                              | `False`             | Whether to sort the entries in ascending order of the sorting column values.                                                                                                                                                                                                                                                                       |
 | `progress_bar`             | `bool`, `Type[ProgressBarCallback]`, optional | `None`              | Set to `False `to disable the download progress bar, or pass a type of ProgressBarCallback to [use your own progress bar](https://docs.neptune.ai/usage/querying_metadata/#using-a-custom-progress-bar). If set to `None` or `True`, the default tqdm-based progress bar will be used.                                                             |
-| `query`                    | `str`, optional                               | `None`              | NQL query string. Example: `"(accuracy: float > 0.88) AND (loss: float < 0.2)"`. The query is applied on top of other criteria like, `custom_ids`, `tags` etc, using the logical AND operator. For syntax, see [Neptune Query Language](https://docs.neptune.ai/usage/nql/) in Neptune docs.                                                       |
+| `query`                    | `str`, optional                               | `None`              | NQL query string. Example: `"(accuracy: float > 0.88) AND (loss: float < 0.2)"`. The query is applied on top of other criteria like, `custom_ids`, `tags` etc, using the logical AND operator. See examples below. For syntax, see [Neptune Query Language](https://docs.neptune.ai/usage/nql/) in the Neptune docs.                                                       |
 
 __Returns:__ `pandas.DataFrame`: A pandas DataFrame containing metadata of the fetched runs.
 
@@ -348,7 +353,7 @@ __Parameters__:
 | `sort_by`                  | `str`, optional                               | `sys/creation_time` | Name of the field to sort the results by. The field must represent a simple type (string, float, integer).                                                                                                                                                                                                                                         |
 | `ascending`                | `bool`, optional                              | `False`             | Whether to sort the entries in ascending order of the sorting column values.                                                                                                                                                                                                                                                                       |
 | `progress_bar`             | `bool`, `Type[ProgressBarCallback]`, optional | `None`              | Set to `False `to disable the download progress bar, or pass a type of ProgressBarCallback to [use your own progress bar](https://docs.neptune.ai/usage/querying_metadata/#using-a-custom-progress-bar). If set to `None` or `True`, the default tqdm-based progress bar will be used.                                                             |
-| `query`                    | `str`, optional                               | `None`              | NQL query string. Example: `"(accuracy: float > 0.88) AND (loss: float < 0.2)"`. The query is applied on top of other criteria like, `names_regex`, `tags` etc, using the logical AND operator. For syntax, see [Neptune Query Language](https://docs.neptune.ai/usage/nql/) in Neptune docs.                                                      |                                                          |
+| `query`                    | `str`, optional                               | `None`              | NQL query string. Example: `"(accuracy: float > 0.88) AND (loss: float < 0.2)"`. The query is applied on top of other criteria like, `custom_ids`, `tags` etc, using the logical AND operator. See examples below. For syntax, see [Neptune Query Language](https://docs.neptune.ai/usage/nql/) in the Neptune docs.                                                       |
 
 __Returns:__ `pandas.DataFrame`: A pandas DataFrame containing metadata of the fetched experiments.
 

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ specific_runs_df = my_project.fetch_runs_df(
 )
 ```
 
-Fetch runs with a complex query:
+Fetch runs with a complex query using NQL.
 
 ```python
 runs_df = my_project.fetch_runs_df(
@@ -393,11 +393,20 @@ specific_experiments_df = my_project.fetch_experiments_df(
 )
 ```
 
-Fetch experiments with a complex query:
+Use the Neptune Query Language to fetch experiments with a complex query. Note that for regular strings, the `\` character needs to be escaped:
 
 ```python
 experiments_df = my_project.fetch_experiments_df(
-    query='(last(`accuracy`:floatSeries) > 0.88) AND (`learning_rate`:float < 0.01)'
+    query='(`learning_rate`:float < 0.01) AND (`sys/name`:string MATCHES "experiment-\\\\d+")'
+)
+```
+
+As a less cluttered alternative, pass a raw Python string to the `query` argument:
+
+
+```python
+experiments_df = my_project.fetch_experiments_df(
+    query=r'(`learning_rate`:float < 0.01) AND (`sys/name`:string MATCHES "experiment-\\d+")'
 )
 ```
 

--- a/src/neptune_fetcher/read_only_project.py
+++ b/src/neptune_fetcher/read_only_project.py
@@ -79,7 +79,10 @@ from neptune_fetcher.read_only_run import (
     ReadOnlyRun,
     get_attribute_value_from_entry,
 )
-from neptune_fetcher.util import getenv_int
+from neptune_fetcher.util import (
+    escape_nql_criterion,
+    getenv_int,
+)
 
 logger = get_logger()
 
@@ -773,7 +776,7 @@ def _make_leaderboard_nql(
                             name="sys/custom_run_id",
                             type=NQLAttributeType.STRING,
                             operator=NQLAttributeOperator.EQUALS,
-                            value=custom_id,
+                            value=escape_nql_criterion(custom_id),
                         )
                         for custom_id in custom_ids
                     ],
@@ -795,7 +798,7 @@ def _make_leaderboard_nql(
                         name="sys/name",
                         type=NQLAttributeType.STRING,
                         operator=NQLAttributeOperator.MATCHES,
-                        value=regex,
+                        value=escape_nql_criterion(regex),
                     ),
                 ],
                 aggregator=NQLAggregator.AND,
@@ -813,7 +816,7 @@ def _make_leaderboard_nql(
                         name="sys/name",
                         type=NQLAttributeType.STRING,
                         operator=NQLAttributeOperator.NOT_MATCHES,
-                        value=regex,
+                        value=escape_nql_criterion(regex),
                     ),
                 ],
                 aggregator=NQLAggregator.AND,
@@ -827,7 +830,7 @@ def _make_leaderboard_nql(
                     name="sys/custom_run_id",
                     type=NQLAttributeType.STRING,
                     operator=NQLAttributeOperator.MATCHES,
-                    value=custom_id_regex,
+                    value=escape_nql_criterion(custom_id_regex),
                 ),
             ],
             aggregator=NQLAggregator.AND,

--- a/src/neptune_fetcher/util.py
+++ b/src/neptune_fetcher/util.py
@@ -53,3 +53,11 @@ def fetch_series_values(getter: Callable[..., Any], step_size: int = 10_000) -> 
 
         current_batch_size = len(batch.values)
         last_step_value = batch.values[-1].step if batch.values else None
+
+
+def escape_nql_criterion(criterion):
+    """
+    Escape backslash and (double-)quotes in the string, to match what the NQL engine expects.
+    """
+
+    return criterion.replace("\\", r"\\").replace('"', r"\"")

--- a/tests/e2e/test_dataframe_values.py
+++ b/tests/e2e/test_dataframe_values.py
@@ -43,10 +43,10 @@ def test__nonexistent_column_is_returned_as_null(project, sys_columns):
     # The expected count doesn't include the default columns. It's adjusted in the test code.
     "regex, run_ids, expect_count",
     [
-        ("config/.*unique-id-run-2", None, 10),
+        (r"\Donfig/.*unique-id-run-2", None, 10),
         ("config/.*unique-id-.*-1", None, 20),
         (".*unique-id-run-2", None, 20),  # 10 unique config/* and metrics/*
-        ("metrics/.*|config/.*", ["id-run-5"], 60),  # All columns
+        (r"metrics/.*|config/.*\d$", ["id-run-5"], 60),  # All columns
         ("non_existent_column", None, 0),
     ],
 )

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,0 +1,15 @@
+import pytest
+
+from neptune_fetcher.util import escape_nql_criterion
+
+
+@pytest.mark.parametrize(
+    "regex, expect",
+    (
+        ("\"'", r"\"'"),  # Escaped double quotes
+        ("abc\\", "abc\\\\"),  # Backslash -> double backslash
+        ("a\\d'b\"c\\", "a\\\\d'b\\\"c\\\\"),
+    ),
+)
+def test_escape_nql_criterion(regex, expect):
+    assert escape_nql_criterion(regex) == expect


### PR DESCRIPTION
This PR makes all queries that use NQL under the hood be consistent with how UI works. **This is a breaking change.**

The current behaviour forces users to manually escape backslash and quotes when providing arguments to parameters that expect a regex, example:

```python
# Match all experiments with names "experiment-0", "experiment-1", etc
df = project.fetch_experiments_df(names_regex=r"experiment-\\d")
```

We want the behaviour to be consistent with the UI, eg. not require any escaping:

```python
# Yields the same result as the old version above
df = project.fetch_experiments_df(names_regex=r"experiment-\d")
```

Note that this does not change how filtering attribute names works -- it's already correct, since the change was only required for arguments that make it into NQL.

```python
# No change required
df = project.fetch_experiments_df(columns_regex=r"metrics/foo\d")
```