### PR TITLE
Add `ReadOnlyRun.attribute_names` property

### DIFF
--- a/examples/fetch_api.py
+++ b/examples/fetch_api.py
@@ -45,7 +45,7 @@ def main():
     print("Runs dataframe:\n", run_df, "\n###########################################\n")
 
     # Run attributes
-    attributes = list(run.field_names)
+    attributes = list(run.attribute_names)
     print("Run attribute names:\n", attributes, "\n###########################################\n")
 
 

--- a/src/neptune_fetcher/read_only_project.py
+++ b/src/neptune_fetcher/read_only_project.py
@@ -756,14 +756,14 @@ def _find_sort_type(backend, project_id, sort_by):
     else:
         types = backend.find_attribute_type_within_project(project_id, sort_by)
         if len(types) == 0:
-            warnings.warn(f"Could not find sorting column type for field '{sort_by}'.", NeptuneWarning)
+            warnings.warn(f"Could not find sorting column type for attribute '{sort_by}'.", NeptuneWarning)
             return "string"
         elif len(types) == 1:
             return types.pop()
         else:
             sorted_types = sorted(types)
             warnings.warn(
-                f"Found multiple types for sorting field '{sort_by}': {sorted_types}. Using {sorted_types[0]}.",
+                f"Found multiple types for sorting attribute '{sort_by}': {sorted_types}. Using {sorted_types[0]}.",
                 NeptuneWarning,
             )
             return sorted_types[0]

--- a/src/neptune_fetcher/read_only_run.py
+++ b/src/neptune_fetcher/read_only_run.py
@@ -15,6 +15,7 @@
 #
 __all__ = ["ReadOnlyRun"]
 
+import warnings
 from typing import (
     TYPE_CHECKING,
     Generator,
@@ -116,10 +117,18 @@ class ReadOnlyRun:
 
     @property
     def field_names(self) -> Generator[str, None, None]:
-        """Lists names of run attributes.
+        warnings.warn(
+            "`ReadOnlyRun.field_names` is deprecated and will be removed in a future release. "
+            "Use `ReadOnlyRun.attribute_names` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.attribute_names
 
-        Returns a generator of run attributes.
-        """
+    @property
+    def attribute_names(self) -> Generator[str, None, None]:
+        """Returns a generator of names of run attributes."""
+
         yield from self._structure
 
     def prefetch(self, paths: List[str]) -> None:

--- a/tests/e2e/test_log_and_fetch.py
+++ b/tests/e2e/test_log_and_fetch.py
@@ -118,7 +118,7 @@ def test_multiple_series_with_prefetch(run, ro_run):
     run.wait_for_processing()
 
     ro_run = refresh(ro_run)
-    paths = [p for p in ro_run.field_names if p.startswith(path_base)]
+    paths = [p for p in ro_run.attribute_names if p.startswith(path_base)]
     assert len(paths) == len(data), "Not all data was logged"
 
     ro_run.prefetch_series_values(paths, use_threads=True)


### PR DESCRIPTION
This property is identical to `ReadOnlyRun.field_names`, which is now deprecated.

Merge this PR after #122