### PR TITLE
Make sure we don't crash on unknown types returned by the backend.

### DIFF
--- a/src/neptune_fetcher/cache.py
+++ b/src/neptune_fetcher/cache.py
@@ -32,8 +32,12 @@ from neptune_fetcher.fields import (
     ObjectState,
     String,
     StringSet,
+    Unsupported,
 )
-from neptune_fetcher.util import getenv_int
+from neptune_fetcher.util import (
+    getenv_int,
+    warn_unsupported_value_type,
+)
 
 # Maximum number of paths to fetch in a single request for fields definitions.
 MAX_PATHS_PER_REQUEST = getenv_int("NEPTUNE_MAX_PATHS_PER_REQUEST", 8000)
@@ -143,4 +147,5 @@ def _extract_value(attr: ProtoAttributeDTO) -> Union[Field, FloatSeries]:
     elif attr.type == "experimentState":
         return ObjectState(FieldType.OBJECT_STATE, "experiment_state")
     else:
-        raise ValueError(f"Unsupported attribute type: {attr.type}, please update the neptune-fetcher")
+        warn_unsupported_value_type(attr.type)
+        return Unsupported(FieldType.UNSUPPORTED, None)

--- a/src/neptune_fetcher/fields.py
+++ b/src/neptune_fetcher/fields.py
@@ -44,6 +44,8 @@ from typing import (
     Union,
 )
 
+from neptune_fetcher.util import warn_unsupported_value_type
+
 if TYPE_CHECKING:
     from pandas import DataFrame
 
@@ -61,6 +63,13 @@ class FieldType(Enum):
     FLOAT_SERIES = "floatSeries"
     STRING_SET = "stringSet"
     OBJECT_STATE = "experimentState"
+
+    UNSUPPORTED = "__unsupported_attribute_type__"
+
+    @classmethod
+    def _missing_(cls, value):
+        warn_unsupported_value_type(value)
+        return cls.UNSUPPORTED
 
 
 @dataclass
@@ -146,6 +155,11 @@ class ObjectState(Field[str]):
 
 class StringSet(Field[Set[str]]):
     ...
+
+
+class Unsupported(Field[None]):
+    def fetch(self) -> None:
+        return None
 
 
 def make_row(entry: FloatPointValue, include_timestamp: bool = True) -> Dict[str, Union[str, float, datetime]]:

--- a/src/neptune_fetcher/read_only_project.py
+++ b/src/neptune_fetcher/read_only_project.py
@@ -62,6 +62,7 @@ from neptune_fetcher.util import (
     NeptuneWarning,
     escape_nql_criterion,
     getenv_int,
+    warn_unsupported_value_type,
 )
 
 logger = logging.getLogger(__name__)
@@ -671,7 +672,8 @@ def _extract_value(attr: ProtoAttributeDTO) -> Any:
     elif attr.type == "experimentState":
         return "experiment_state"
     else:
-        raise ValueError(f"Unsupported attribute type: {attr.type}, please update the client")
+        warn_unsupported_value_type(attr.type)
+        return None
 
 
 def _ensure_default_columns(columns: Optional[List[str]], *, sort_by: str) -> List[str]:

--- a/src/neptune_fetcher/read_only_run.py
+++ b/src/neptune_fetcher/read_only_run.py
@@ -26,15 +26,11 @@ from typing import (
 
 from neptune_fetcher.cache import FieldsCache
 from neptune_fetcher.fetchable import (
-    SUPPORTED_TYPES,
     Fetchable,
     FetchableSeries,
     which_fetchable,
 )
-from neptune_fetcher.fields import (
-    FieldDefinition,
-    FieldType,
-)
+from neptune_fetcher.fields import FieldDefinition
 
 if TYPE_CHECKING:
     from neptune_fetcher.read_only_project import ReadOnlyProject
@@ -132,7 +128,6 @@ class ReadOnlyRun:
                     self._cache,
                 )
                 for definition in definitions
-                if FieldType(definition.type) in SUPPORTED_TYPES
             }
             self._loaded_structure = True
 

--- a/src/neptune_fetcher/util.py
+++ b/src/neptune_fetcher/util.py
@@ -58,3 +58,12 @@ def escape_nql_criterion(criterion):
     """
 
     return criterion.replace("\\", r"\\").replace('"', r"\"")
+
+
+def warn_unsupported_value_type(type_: str) -> None:
+    warnings.warn(
+        f"A value of type `{type_}` was returned by your query. This type is not supported by your installation "
+        "of neptune-fetcher and values will evaluate to `None` and empty DataFrames. "
+        "Upgrade neptune-fetcher to access this data.",
+        NeptuneWarning,
+    )

--- a/src/neptune_fetcher/util.py
+++ b/src/neptune_fetcher/util.py
@@ -60,7 +60,19 @@ def escape_nql_criterion(criterion):
     return criterion.replace("\\", r"\\").replace('"', r"\"")
 
 
+# We keep a set of types we've warned the user about to make sure we warn about a type only once.
+# This is necessary because of a bug in pandas, that causes duplicate warnings to be issued everytime after an
+# DataFrame() is created (presumably only empty DF).
+# The bug basically makes `warnings.simplefilter("once", NeptuneWarning)` not work as expected, and would flood
+# the user with warnings in some cases.
+_warned_types = set()
+
+
 def warn_unsupported_value_type(type_: str) -> None:
+    if type_ in _warned_types:
+        return
+
+    _warned_types.add(type_)
     warnings.warn(
         f"A value of type `{type_}` was returned by your query. This type is not supported by your installed version "
         "of neptune-fetcher. Values will evaluate to `None` and empty DataFrames. "

--- a/src/neptune_fetcher/util.py
+++ b/src/neptune_fetcher/util.py
@@ -62,8 +62,8 @@ def escape_nql_criterion(criterion):
 
 def warn_unsupported_value_type(type_: str) -> None:
     warnings.warn(
-        f"A value of type `{type_}` was returned by your query. This type is not supported by your installation "
-        "of neptune-fetcher and values will evaluate to `None` and empty DataFrames. "
+        f"A value of type `{type_}` was returned by your query. This type is not supported by your installed version "
+        "of neptune-fetcher. Values will evaluate to `None` and empty DataFrames. "
         "Upgrade neptune-fetcher to access this data.",
         NeptuneWarning,
     )

--- a/tests/unit/test_unsupported_attributes.py
+++ b/tests/unit/test_unsupported_attributes.py
@@ -1,0 +1,428 @@
+import uuid
+import warnings
+from datetime import datetime
+from typing import (
+    Iterable,
+    List,
+    Optional,
+)
+from unittest.mock import (
+    Mock,
+    patch,
+)
+
+import neptune_retrieval_api
+import pytest
+from neptune_api.models import ProjectDTO
+from neptune_api.types import Response
+from neptune_retrieval_api.models import QueryAttributesBodyDTO
+from neptune_retrieval_api.proto.neptune_pb.api.v1.model.attributes_pb2 import (
+    ProtoQueryAttributesExperimentResultDTO,
+    ProtoQueryAttributesResultDTO,
+)
+from neptune_retrieval_api.proto.neptune_pb.api.v1.model.leaderboard_entries_pb2 import (
+    ProtoAttributeDTO,
+    ProtoAttributesDTO,
+    ProtoFloatSeriesAttributeDTO,
+    ProtoLeaderboardEntriesSearchResultDTO,
+)
+from pytest import fixture
+
+from neptune_fetcher import (
+    ReadOnlyProject,
+    ReadOnlyRun,
+)
+from neptune_fetcher.fetchable import SUPPORTED_TYPES
+from neptune_fetcher.fields import (
+    FieldDefinition,
+    FieldType,
+    FloatPointValue,
+)
+from neptune_fetcher.util import NeptuneWarning
+
+# IMPORTANT:
+# 1) The mocked API calls used in the tests always add two unsupported attributes to the result by default,
+#    unless the test explicitly provides a different list of unsupported attributes (or none at all).
+# 2) The tests know which attributes to expect, based on make_proto_attributes_dto() and the default unsupported
+#    attributes
+# 3) We treat all warnings as errors in this test suite (see warnings_are_errors()), unless pytest.warns is used
+#    explicitly.
+#    Because of this tests like test_list_runs() might seem like they don't do anything special, but they do make
+#    sure than no unnecessary warnings are issued.
+
+DEFAULT_UNSUPPORTED_ATTRS = (("badAttr", "typeFoo"), ("anotherAttr", "typeBar"))
+RUN_ID = str(uuid.uuid4())
+
+
+def make_attr(name, value=None, typ=None) -> ProtoAttributeDTO:
+    """Return an attribute definition with an optional value. Based on the type (or type of value),
+    dynamically determines which protobuf objects to instantiate and which fields to set
+    in the resulting ProtoAttributeDTO object.
+    """
+
+    if typ is None:
+        assert value is not None, "value must be provided if type is not specified"
+        if isinstance(value, str):
+            typ = "string"
+        elif isinstance(value, int):
+            typ = "int"
+        elif isinstance(value, float):
+            typ = "float"
+        else:
+            raise ValueError(f"Unsupported type {type(value)}. Fix your tests or add support for this type.")
+
+    # string -> ProtoStringAttributeDTO. For unknown attrs we default to None, which
+    # means value will not be set
+
+    kwargs = {
+        "name": name,
+        "type": typ,
+    }
+
+    cls_name = f"Proto{typ.capitalize()}AttributeDTO"
+    # Special case
+    if typ == "floatSeries":
+        assert value is not None, "value must be provided for floatSeries"
+        kwargs["float_series_properties"] = ProtoFloatSeriesAttributeDTO(
+            attribute_name=name, attribute_type=typ, last=value
+        )
+        return ProtoAttributeDTO(**kwargs)
+
+    cls = getattr(neptune_retrieval_api.proto.neptune_pb.api.v1.model.leaderboard_entries_pb2, cls_name, None)
+    if cls is None and value is not None:
+        raise ValueError("You provided a value for an unsupported type. Fix your test.")
+
+    if value is not None and cls is not None:
+        # Set the proper field based on the type
+        kwargs[f"{typ}_properties"] = cls(attribute_name=name, attribute_type=typ, value=value)
+
+    return ProtoAttributeDTO(**kwargs)
+
+
+def make_proto_attributes_dto(
+    unsupported_attrs: Optional[Iterable[tuple[str, str]]] = DEFAULT_UNSUPPORTED_ATTRS
+) -> ProtoAttributesDTO:
+    """Return a list valid attributes for a run. Optionally add the provided unsupported attributes to the result,
+    which default to DEFAULT_UNSUPPORTED_ATTRS."""
+
+    unsupported_attrs = unsupported_attrs or []
+    attributes = [make_attr(name, typ=type_) for name, type_ in unsupported_attrs]
+    attributes.append(make_attr("sys/id", RUN_ID))
+    attributes.append(make_attr("sys/custom_run_id", RUN_ID))
+    attributes.append(make_attr("metric", 42, "floatSeries"))
+
+    return ProtoAttributesDTO(experiment_id=RUN_ID, type="run", attributes=attributes)
+
+
+def response(body: ProtoAttributesDTO) -> Response:
+    return Mock(status_code=Mock(value=200), content=body.SerializeToString())
+
+
+class MockApiClient(Mock):
+    # Each (attribute_name, attribute_type) tuple will be used to add attributes
+    # to the result in methods that list attributes. Set it to empty list or None
+    # to only return valid attributes
+    unsupported_attrs = DEFAULT_UNSUPPORTED_ATTRS
+
+    def project_name_lookup(self, name: str) -> ProjectDTO:
+        return ProjectDTO("project", "workspace", 1, "project-id", "TEST", "org_id")
+
+    def search_entries(self, project_id, body) -> ProtoLeaderboardEntriesSearchResultDTO:
+        result = make_proto_attributes_dto(self.unsupported_attrs)
+        # Just return a single result
+        return ProtoLeaderboardEntriesSearchResultDTO(matching_item_count=1, entries=[result])
+
+    def query_attribute_definitions(self, container_id: str) -> List[FieldDefinition]:
+        result = [FieldDefinition(f"attr-{tp}", FieldType(tp.value)) for tp in SUPPORTED_TYPES]
+        result.append(FieldDefinition("sys/id", FieldType("string")))
+
+        unsupported_attrs = self.unsupported_attrs or []
+        for name, type_ in unsupported_attrs:
+            result.append(FieldDefinition(name, FieldType(type_)))
+
+        return result
+
+    def query_attributes_within_project(
+        self, project_id: str, body: QueryAttributesBodyDTO
+    ) -> ProtoQueryAttributesResultDTO:
+        attributes = make_proto_attributes_dto(self.unsupported_attrs).attributes
+        entries = [
+            ProtoQueryAttributesExperimentResultDTO(
+                experimentId=RUN_ID, experimentShortId="RUN-1337", attributes=attributes
+            )
+        ]
+        return ProtoQueryAttributesResultDTO(entries=entries)
+
+    def fetch_multiple_series_values(self, *args, **kwargs) -> list[(str, List[FloatPointValue])]:
+        points = [FloatPointValue(datetime.now(), 42, 1)]
+        return [("metric", points)]
+
+
+@fixture
+def get_attributes_with_paths_filter_proto():
+    # FieldsCache uses neptune_api directly, so we cannot mock on TestApiClient level
+    with patch("neptune_retrieval_api.api.default.get_attributes_with_paths_filter_proto.sync_detailed") as patched:
+        yield patched
+
+
+@fixture(autouse=True)
+def warnings_are_errors():
+    # By default, we will treat all warnings as errors, unless pytest.warns is used
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        yield
+
+
+@fixture
+def backend_cls():
+    with patch("neptune_fetcher.read_only_project.ApiClient", new=MockApiClient) as patched:
+        yield patched
+
+
+@fixture
+def project(backend_cls):
+    return ReadOnlyProject("workspace/project")
+
+
+def _assert_warning(record, *attr_types):
+    """Assert that a warning about unsupported types, for a given type, was issued exactly once."""
+    if not attr_types:
+        # Default to the two unsupported types used in TestApiClient
+        attr_types = [type_ for _, type_ in DEFAULT_UNSUPPORTED_ATTRS]
+
+    for rec, attr_type in zip(record, attr_types):
+        assert f"of type `{attr_type}`" in rec.message.args[0]
+        assert "not supported" in rec.message.args[0]
+
+
+# ReadOnlyRun tests
+
+
+def test_run_no_warning_when_attribute_type_is_known(project, get_attributes_with_paths_filter_proto):
+    project._backend.unsupported_attrs = None
+    attrs = make_proto_attributes_dto(None)
+    get_attributes_with_paths_filter_proto.return_value = response(attrs)
+
+    run = ReadOnlyRun(project, RUN_ID)
+    for a in attrs.attributes:
+        run[a.name].fetch()
+
+    run = ReadOnlyRun(project, RUN_ID, eager_load_fields=False)
+    for a in attrs.attributes:
+        run[a.name].fetch()
+
+
+def test_field_names(project):
+    with pytest.warns(NeptuneWarning) as record:
+        run = ReadOnlyRun(project, RUN_ID)
+        field_names = set(run.field_names)
+
+        # bad attrs should still be present in field names
+        assert "badAttr" in field_names
+        assert "anotherAttr" in field_names
+
+    _assert_warning(record)
+
+    project._backend.unsupported_attrs = None
+
+    run = ReadOnlyRun(project, RUN_ID)
+    field_names = set(run.field_names)
+
+    assert "badAttr" not in field_names
+    assert "anotherAttr" not in field_names
+
+
+def test_run_eager_load_attributes(project):
+    with pytest.warns(NeptuneWarning) as record:
+        run = ReadOnlyRun(project, RUN_ID)
+        assert run["badAttr"].fetch() is None
+        assert run["badAttr"].fetch_last() is None
+        assert run["badAttr"].fetch_values().empty
+
+        assert run["anotherAttr"].fetch() is None
+        assert run["anotherAttr"].fetch_last() is None
+        assert run["anotherAttr"].fetch_values().empty
+
+    _assert_warning(record)
+
+
+def test_run_no_eager_load_attributes(project, get_attributes_with_paths_filter_proto):
+    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto(DEFAULT_UNSUPPORTED_ATTRS))
+
+    with pytest.warns(NeptuneWarning) as record:
+        run = ReadOnlyRun(project, RUN_ID, eager_load_fields=False)
+        assert run["badAttr"].fetch() is None
+        assert run["badAttr"].fetch_last() is None
+        assert run["badAttr"].fetch_values().empty
+
+        assert run["anotherAttr"].fetch() is None
+        assert run["anotherAttr"].fetch_last() is None
+        assert run["anotherAttr"].fetch_values().empty
+
+    _assert_warning(record)
+
+
+def test_run_fetch_missing_attribute(project, get_attributes_with_paths_filter_proto):
+    """Fetch an attribute that does not exist, then make it exist and fetch it again."""
+    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto(None))
+    project._backend.unsupported_attrs = None
+
+    with pytest.raises(KeyError):
+        run = ReadOnlyRun(project, RUN_ID)
+        run["badAttr"].fetch()
+        run["anotherAttr"].fetch()
+
+    project._backend.unsupported_attrs = DEFAULT_UNSUPPORTED_ATTRS
+    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto(DEFAULT_UNSUPPORTED_ATTRS))
+
+    with pytest.warns(NeptuneWarning) as record:
+        assert run["badAttr"].fetch() is None
+        assert run["anotherAttr"].fetch() is None
+
+    _assert_warning(record)
+
+
+def test_prefetch(project, get_attributes_with_paths_filter_proto):
+    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto())
+    with pytest.warns(NeptuneWarning) as record:
+        run = ReadOnlyRun(project, RUN_ID)
+        run.prefetch(["badAttr", "anotherAttr", "sys/id"])
+        assert run["badAttr"].fetch() is None
+        assert run["anotherAttr"].fetch() is None
+        assert run["sys/id"].fetch() == RUN_ID
+
+    _assert_warning(record)
+
+    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto(None))
+    run.prefetch(["badAttr", "anotherAttr", "sys/id"])
+
+
+def test_prefetch_series_values(project, get_attributes_with_paths_filter_proto):
+    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto())
+    with pytest.warns(NeptuneWarning) as record:
+        run = ReadOnlyRun(project, RUN_ID)
+        run.prefetch_series_values(["badAttr", "anotherAttr", "metric"])
+        assert run["badAttr"].fetch() is None
+        assert run["badAttr"].fetch_last() is None
+        assert run["badAttr"].fetch_values().empty
+
+        assert run["anotherAttr"].fetch() is None
+        assert run["anotherAttr"].fetch_last() is None
+        assert run["anotherAttr"].fetch_values().empty
+
+        assert run["metric"].fetch_last() == 42
+
+    _assert_warning(record)
+
+    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto(None))
+    project._backend.unsupported_attrs = None
+
+    with pytest.raises(KeyError):
+        run = ReadOnlyRun(project, RUN_ID)
+        run.prefetch_series_values(["badAttr", "anotherAttr", "metric"])
+
+        run["badAttr"].fetch_values()
+        run["anotherAttr"].fetch_values()
+
+
+# ReadOnlyProject tests
+
+
+def test_fetch_runs_df(project):
+    with pytest.warns(NeptuneWarning) as record:
+        df = project.fetch_runs_df(columns_regex=".*")
+        assert df.shape[0] == 1, "Only one run should be returned"
+        row = df.iloc[0]
+        assert row["sys/id"] == RUN_ID
+        assert row["badAttr"] is None
+        assert row["anotherAttr"] is None
+
+    _assert_warning(record)
+
+    project._backend.unsupported_attrs = None
+    # No warnings should be issued
+    df = project.fetch_runs_df(columns_regex=".*")
+    assert df.shape[0] == 1, "Only one run should be returned"
+    row = df.iloc[0]
+    assert row["sys/id"] == RUN_ID
+    assert "badAttr" not in row
+    assert "anotherAttr" not in row
+
+
+def test_fetch_experiments_df(project):
+    with pytest.warns(NeptuneWarning) as record:
+        df = project.fetch_experiments_df(columns_regex=".*")
+        assert df.shape[0] == 1, "Only one experiment should be returned"
+        row = df.iloc[0]
+        assert row["sys/id"] == RUN_ID
+        assert row["badAttr"] is None
+        assert row["anotherAttr"] is None
+
+    _assert_warning(record)
+
+    project._backend.unsupported_attrs = None
+    # No warnings should be issued
+    df = project.fetch_experiments_df(columns_regex=".*")
+    assert df.shape[0] == 1, "Only one experiment should be returned"
+    row = df.iloc[0]
+    assert row["sys/id"] == RUN_ID
+    assert "badAttr" not in row
+    assert "anotherAttr" not in row
+
+
+def test_fetch_runs(project):
+    with pytest.warns(NeptuneWarning) as record:
+        df = project.fetch_runs()
+        assert df.shape[0] == 1, "Only one run should be returned"
+    _assert_warning(record)
+
+    project._backend.unsupported_attrs = None
+    # No warning should be issued
+    df = project.fetch_runs()
+    assert df.shape[0] == 1, "Only one run should be returned"
+
+
+def test_fetch_experiments(project):
+    with pytest.warns(NeptuneWarning) as record:
+        df = project.fetch_experiments()
+        assert df.shape[0] == 1, "Only one run should be returned"
+    _assert_warning(record)
+
+    project._backend.unsupported_attrs = None
+    # No warning should be issued
+    df = project.fetch_experiments()
+    assert df.shape[0] == 1, "Only one run should be returned"
+
+
+def test_fetch_read_only_runs(project):
+    with pytest.warns(NeptuneWarning) as record:
+        assert len(list(project.fetch_read_only_runs(custom_ids=[RUN_ID]))) == 1
+
+    _assert_warning(record)
+
+    project._backend.unsupported_attrs = None
+    # No warning should be issued
+    assert len(list(project.fetch_read_only_runs(custom_ids=[RUN_ID]))) == 1
+
+
+def test_fetch_read_only_experiments(project):
+    with pytest.warns(NeptuneWarning) as record:
+        assert len(list(project.fetch_read_only_experiments(names=["does-not-matter"]))) == 1
+
+    _assert_warning(record)
+
+    project._backend.unsupported_attrs = None
+    # No warning should be issued
+    assert len(list(project.fetch_read_only_experiments(names=["does-not-matter"]))) == 1
+
+
+def test_list_runs(project):
+    # list_runs() filters on sys attributes, with a hard assumption that they're strings,
+    # so it doesn't care about the unsupported ones. No warning should be issued.
+    assert len(list(project.list_runs())) == 1
+
+
+def test_list_experiments(project):
+    # list_experiments() filters on sys attributes, with a hard assumption that they're strings,
+    # so it doesn't care about the unsupported ones. No warning should be issued.
+    assert len(list(project.list_experiments())) == 1

--- a/tests/unit/test_unsupported_attributes.py
+++ b/tests/unit/test_unsupported_attributes.py
@@ -1,9 +1,8 @@
 import uuid
 import warnings
-from datetime import datetime
 from typing import (
+    Any,
     Iterable,
-    List,
     Optional,
 )
 from unittest.mock import (
@@ -11,20 +10,35 @@ from unittest.mock import (
     patch,
 )
 
-import neptune_retrieval_api
 import pytest
 from neptune_api.models import ProjectDTO
 from neptune_api.types import Response
-from neptune_retrieval_api.models import QueryAttributesBodyDTO
+from neptune_retrieval_api.models import (
+    AttributeDefinitionDTO,
+    AttributeTypeDTO,
+    NextPageDTO,
+    QueryAttributeDefinitionsBodyDTO,
+    QueryAttributeDefinitionsResultDTO,
+)
 from neptune_retrieval_api.proto.neptune_pb.api.v1.model.attributes_pb2 import (
+    ProtoAttributeDefinitionDTO,
+    ProtoAttributesSearchResultDTO,
     ProtoQueryAttributesExperimentResultDTO,
     ProtoQueryAttributesResultDTO,
 )
 from neptune_retrieval_api.proto.neptune_pb.api.v1.model.leaderboard_entries_pb2 import (
     ProtoAttributeDTO,
     ProtoAttributesDTO,
+    ProtoDatetimeAttributeDTO,
     ProtoFloatSeriesAttributeDTO,
     ProtoLeaderboardEntriesSearchResultDTO,
+    ProtoStringAttributeDTO,
+)
+from neptune_retrieval_api.proto.neptune_pb.api.v1.model.series_values_pb2 import (
+    ProtoFloatPointValueDTO,
+    ProtoFloatSeriesValuesDTO,
+    ProtoFloatSeriesValuesResponseDTO,
+    ProtoFloatSeriesValuesSingleSeriesResponseDTO,
 )
 from pytest import fixture
 
@@ -32,71 +46,30 @@ from neptune_fetcher import (
     ReadOnlyProject,
     ReadOnlyRun,
 )
+from neptune_fetcher.api.api_client import ApiClient
 from neptune_fetcher.fetchable import SUPPORTED_TYPES
-from neptune_fetcher.fields import (
-    FieldDefinition,
-    FieldType,
-    FloatPointValue,
-)
 from neptune_fetcher.util import NeptuneWarning
 
 # IMPORTANT:
-# 1) The mocked API calls used in the tests always add two unsupported attributes to the result by default,
-#    unless the test explicitly provides a different list of unsupported attributes (or none at all).
-# 2) The tests know which attributes to expect, based on make_proto_attributes_dto() and the default unsupported
-#    attributes
-# 3) We treat all warnings as errors in this test suite (see warnings_are_errors()), unless pytest.warns with
-#    warnings.simplefilter('once') is used explicitly.
-#    Because of this tests like test_list_runs() might seem like they don't do anything special, but they do make
-#    sure than no unnecessary warnings are issued.
+# - The mocked API calls used in the tests always add two unsupported attributes to the result by default,
+#   unless the test explicitly provides a different list of unsupported attributes (or none at all).
+#   The exception is `query_attribute_definitions_within_project` -- see the comment there.
+# - some of the patched API mock objects define a "good" and "bad" response constants. These are used
+#   for convenience in tests where the defaults are sufficient.
+# - The tests know which attributes to expect, based on make_proto_attributes_dto() and the default unsupported
+#   attributes
+# - We treat all warnings as errors in this test suite (see warnings_are_errors()), unless pytest.warns with
+#   warnings.simplefilter('once') is used explicitly.
+#   Because of this tests like test_list_runs() might seem like they don't do anything special, but they do make
+#   sure than no unnecessary warnings are issued.
 
-DEFAULT_UNSUPPORTED_ATTRS = (("badAttr", "typeFoo"), ("anotherAttr", "typeBar"))
+
+# Default unsupported attributes returned in API mock functions. Note that typeFoo is used twice,
+# to make sure warnings are issued for a given unsupported type only once.
+DEFAULT_UNSUPPORTED_ATTRS = (("badAttr", "typeFoo"), ("anotherAttr", "typeBar"), ("badAttr2", "typeFoo"))
+SUPPORTED_TYPES_STR = {type_.value for type_ in SUPPORTED_TYPES}
 RUN_ID = str(uuid.uuid4())
-
-
-def make_attr(name, value=None, typ=None) -> ProtoAttributeDTO:
-    """Return an attribute definition with an optional value. Based on the type (or type of value),
-    dynamically determines which protobuf objects to instantiate and which fields to set
-    in the resulting ProtoAttributeDTO object.
-    """
-
-    if typ is None:
-        assert value is not None, "value must be provided if type is not specified"
-        if isinstance(value, str):
-            typ = "string"
-        elif isinstance(value, int):
-            typ = "int"
-        elif isinstance(value, float):
-            typ = "float"
-        else:
-            raise ValueError(f"Unsupported type {type(value)}. Fix your tests or add support for this type.")
-
-    # string -> ProtoStringAttributeDTO. For unknown attrs we default to None, which
-    # means value will not be set
-
-    kwargs = {
-        "name": name,
-        "type": typ,
-    }
-
-    cls_name = f"Proto{typ.capitalize()}AttributeDTO"
-    # Special case
-    if typ == "floatSeries":
-        assert value is not None, "value must be provided for floatSeries"
-        kwargs["float_series_properties"] = ProtoFloatSeriesAttributeDTO(
-            attribute_name=name, attribute_type=typ, last=value
-        )
-        return ProtoAttributeDTO(**kwargs)
-
-    cls = getattr(neptune_retrieval_api.proto.neptune_pb.api.v1.model.leaderboard_entries_pb2, cls_name, None)
-    if cls is None and value is not None:
-        raise ValueError("You provided a value for an unsupported type. Fix your test.")
-
-    if value is not None and cls is not None:
-        # Set the proper field based on the type
-        kwargs[f"{typ}_properties"] = cls(attribute_name=name, attribute_type=typ, value=value)
-
-    return ProtoAttributeDTO(**kwargs)
+CREATION_TIME = 1737648980
 
 
 def make_proto_attributes_dto(
@@ -106,62 +79,169 @@ def make_proto_attributes_dto(
     which default to DEFAULT_UNSUPPORTED_ATTRS."""
 
     unsupported_attrs = unsupported_attrs or []
-    attributes = [make_attr(name, typ=type_) for name, type_ in unsupported_attrs]
-    attributes.append(make_attr("sys/id", RUN_ID))
-    attributes.append(make_attr("sys/custom_run_id", RUN_ID))
-    attributes.append(make_attr("metric", 42, "floatSeries"))
+    attributes = [ProtoAttributeDTO(name=name, type=type_) for name, type_ in unsupported_attrs]
+    attributes.append(
+        ProtoAttributeDTO(
+            name="sys/id",
+            type="string",
+            string_properties=ProtoStringAttributeDTO(attribute_name="sys/id", attribute_type="string", value=RUN_ID),
+        )
+    )
+    attributes.append(
+        ProtoAttributeDTO(
+            name="sys/custom_run_id",
+            type="string",
+            string_properties=ProtoStringAttributeDTO(
+                attribute_name="sys/custom_run_id", attribute_type="string", value=RUN_ID
+            ),
+        )
+    )
+    attributes.append(
+        ProtoAttributeDTO(
+            name="sys/creation_time",
+            type="datetime",
+            datetime_properties=ProtoDatetimeAttributeDTO(
+                attribute_name="sys/creation_time", attribute_type="datetime", value=CREATION_TIME
+            ),
+        )
+    )
+    attributes.append(
+        ProtoAttributeDTO(
+            name="series",
+            type="floatSeries",
+            float_series_properties=ProtoFloatSeriesAttributeDTO(
+                attribute_name="sys/creation_time", attribute_type="floatSeries", last=42
+            ),
+        )
+    )
 
     return ProtoAttributesDTO(experiment_id=RUN_ID, type="run", attributes=attributes)
 
 
-def response(body: ProtoAttributesDTO) -> Response:
+class MockApiClient(ApiClient):
+    def __init__(self, *args, **kwargs) -> None:
+        # Override init to avoid an attempt to authenticate
+        self._backend = None
+
+
+def proto_response(body: Any) -> Response:
     return Mock(status_code=Mock(value=200), content=body.SerializeToString())
 
 
-class MockApiClient(Mock):
-    # Each (attribute_name, attribute_type) tuple will be used to add attributes
-    # to the result in methods that list attributes. Set it to empty list or None
-    # to only return valid attributes
-    unsupported_attrs = DEFAULT_UNSUPPORTED_ATTRS
-
-    def project_name_lookup(self, name: str) -> ProjectDTO:
-        return ProjectDTO("project", "workspace", 1, "project-id", "TEST", "org_id")
-
-    def search_entries(self, project_id, body) -> ProtoLeaderboardEntriesSearchResultDTO:
-        result = make_proto_attributes_dto(self.unsupported_attrs)
-        # Just return a single result
-        return ProtoLeaderboardEntriesSearchResultDTO(matching_item_count=1, entries=[result])
-
-    def query_attribute_definitions(self, container_id: str) -> List[FieldDefinition]:
-        result = [FieldDefinition(f"attr-{tp}", FieldType(tp.value)) for tp in SUPPORTED_TYPES]
-        result.append(FieldDefinition("sys/id", FieldType("string")))
-
-        unsupported_attrs = self.unsupported_attrs or []
-        for name, type_ in unsupported_attrs:
-            result.append(FieldDefinition(name, FieldType(type_)))
-
-        return result
-
-    def query_attributes_within_project(
-        self, project_id: str, body: QueryAttributesBodyDTO
-    ) -> ProtoQueryAttributesResultDTO:
-        attributes = make_proto_attributes_dto(self.unsupported_attrs).attributes
-        entries = [
-            ProtoQueryAttributesExperimentResultDTO(
-                experimentId=RUN_ID, experimentShortId="RUN-1337", attributes=attributes
-            )
-        ]
-        return ProtoQueryAttributesResultDTO(entries=entries)
-
-    def fetch_multiple_series_values(self, *args, **kwargs) -> list[(str, List[FloatPointValue])]:
-        points = [FloatPointValue(datetime.now(), 42, 1)]
-        return [("metric", points)]
+def json_response(body: Any) -> Response:
+    return Mock(status_code=Mock(value=200), content=body.to_dict(), parsed=body)
 
 
-@fixture
+@fixture(autouse=True)
 def get_attributes_with_paths_filter_proto():
-    # FieldsCache uses neptune_api directly, so we cannot mock on TestApiClient level
     with patch("neptune_retrieval_api.api.default.get_attributes_with_paths_filter_proto.sync_detailed") as patched:
+        patched.return_value = proto_response(make_proto_attributes_dto())
+        yield patched
+
+
+@fixture(autouse=True)
+def get_multiple_float_series_values_proto():
+    with patch("neptune_retrieval_api.api.default.get_multiple_float_series_values_proto.sync_detailed") as patched:
+        # Just return a series with a single point
+        points = [ProtoFloatPointValueDTO(timestamp_millis=1, step=1, value=42)]
+        values = ProtoFloatSeriesValuesDTO(total_item_count=1, values=points)
+        series = ProtoFloatSeriesValuesSingleSeriesResponseDTO(requestId="1234", series=values)
+
+        patched.return_value = proto_response(ProtoFloatSeriesValuesResponseDTO(series=[series]))
+        yield patched
+
+
+@fixture(autouse=True)
+def query_attribute_definitions_proto():
+    with patch("neptune_retrieval_api.api.default.query_attribute_definitions_proto.sync_detailed") as patched:
+        entries = [ProtoAttributeDefinitionDTO(name=f"attr-{type_}", type=type_) for type_ in SUPPORTED_TYPES_STR]
+        patched.SUPPORTED_TYPES_RESPONSE = proto_response(ProtoAttributesSearchResultDTO(entries=entries))
+
+        entries = entries + [
+            ProtoAttributeDefinitionDTO(name=name, type=type_) for name, type_ in DEFAULT_UNSUPPORTED_ATTRS
+        ]
+        patched.UNSUPPORTED_TYPES_RESPONSE = proto_response(ProtoAttributesSearchResultDTO(entries=entries))
+
+        patched.return_value = patched.UNSUPPORTED_TYPES_RESPONSE
+        yield patched
+
+
+@fixture(autouse=True)
+def query_attributes_within_project_proto():
+    with patch("neptune_retrieval_api.api.default.query_attributes_within_project_proto.sync_detailed") as patched:
+        patched.UNSUPPORTED_TYPES_RESPONSE = proto_response(
+            ProtoQueryAttributesResultDTO(
+                entries=[
+                    ProtoQueryAttributesExperimentResultDTO(
+                        experimentId=RUN_ID,
+                        experimentShortId="RUN-1337",
+                        attributes=make_proto_attributes_dto().attributes,
+                    )
+                ]
+            )
+        )
+        patched.SUPPORTED_TYPES_RESPONSE = proto_response(
+            ProtoQueryAttributesResultDTO(
+                entries=[
+                    ProtoQueryAttributesExperimentResultDTO(
+                        experimentId=RUN_ID,
+                        experimentShortId="RUN-1337",
+                        attributes=make_proto_attributes_dto(None).attributes,
+                    )
+                ]
+            )
+        )
+
+        patched.return_value = patched.UNSUPPORTED_TYPES_RESPONSE
+        yield patched
+
+
+@fixture(autouse=True)
+def query_attribute_definitions_within_project():
+    with patch("neptune_retrieval_api.api.default.query_attribute_definitions_within_project.sync_detailed") as patched:
+        entries = [AttributeDefinitionDTO(f"attr-{type_}", AttributeTypeDTO(type_)) for type_ in SUPPORTED_TYPES_STR]
+        # Need to use Mock for unsupported type, otherwise the Enum will raise an exception
+        entries += [
+            AttributeDefinitionDTO(name=name, type=Mock(value=type_)) for name, type_ in DEFAULT_UNSUPPORTED_ATTRS
+        ]
+        patched.return_value = json_response(
+            QueryAttributeDefinitionsResultDTO(entries=entries, next_page=NextPageDTO())
+        )
+        yield patched
+
+        # Validate if all types passed to filter are supported, even though it's not strictly necessary:
+        # `QueryAttributeDefinitionsBodyDTO.from_dict()` (the `body` argument to this function) will raise an
+        # exception anyway, if an unsupported type is provided.
+        #
+        # However, if at some point we regenerate `neptune-api` with the option to use raw str instead
+        # of Enum, this check will grab our attention to double-check code that depends on this function.
+        for call in patched.call_args_list:
+            assert not call.args
+            body = call.kwargs["body"]
+            for attr_filter in body.attribute_filter:
+                assert attr_filter.attribute_type.value in SUPPORTED_TYPES_STR
+
+
+@fixture(autouse=True)
+def search_leaderboard_entries_proto():
+    with patch("neptune_retrieval_api.api.default.search_leaderboard_entries_proto.sync_detailed") as patched:
+        entries = make_proto_attributes_dto()
+        patched.UNSUPPORTED_TYPES_RESPONSE = proto_response(
+            ProtoLeaderboardEntriesSearchResultDTO(matching_item_count=len(entries.attributes), entries=[entries])
+        )
+        entries = make_proto_attributes_dto(None)
+        patched.SUPPORTED_TYPES_RESPONSE = proto_response(
+            ProtoLeaderboardEntriesSearchResultDTO(matching_item_count=len(entries.attributes), entries=[entries])
+        )
+
+        patched.return_value = patched.UNSUPPORTED_TYPES_RESPONSE
+        yield patched
+
+
+@fixture(autouse=True)
+def get_project():
+    with patch("neptune_api.api.backend.get_project.sync_detailed") as patched:
+        patched.return_value = json_response(ProjectDTO("project", "workspace", 1, "project-id", "TEST", "org-id"))
         yield patched
 
 
@@ -186,8 +266,9 @@ def project(backend_cls):
 
 def _assert_warning(record, *attr_types):
     """Assert that a warning about unsupported types, for a given type, was issued exactly once."""
+
     if not attr_types:
-        # Default to the two unsupported types used in TestApiClient
+        # Default to unsupported types used in TestApiClient
         attr_types = [type_ for _, type_ in DEFAULT_UNSUPPORTED_ATTRS]
 
     attr_types = set(attr_types)
@@ -207,10 +288,15 @@ def _assert_warning(record, *attr_types):
 # ReadOnlyRun tests
 
 
-def test_run_no_warning_when_attribute_type_is_known(project, get_attributes_with_paths_filter_proto):
-    project._backend.unsupported_attrs = None
+def test_run_no_warning_when_attribute_type_is_known(
+    project, query_attribute_definitions_proto, search_leaderboard_entries_proto, get_attributes_with_paths_filter_proto
+):
     attrs = make_proto_attributes_dto(None)
-    get_attributes_with_paths_filter_proto.return_value = response(attrs)
+    search_leaderboard_entries_proto.return_value = proto_response(
+        ProtoLeaderboardEntriesSearchResultDTO(matching_item_count=len(attrs.attributes), entries=[attrs])
+    )
+    query_attribute_definitions_proto.return_value = query_attribute_definitions_proto.SUPPORTED_TYPES_RESPONSE
+    get_attributes_with_paths_filter_proto.return_value = proto_response(attrs)
 
     run = ReadOnlyRun(project, RUN_ID)
     for a in attrs.attributes:
@@ -221,7 +307,7 @@ def test_run_no_warning_when_attribute_type_is_known(project, get_attributes_wit
         run[a.name].fetch()
 
 
-def test_field_names(project):
+def test_field_names(project, query_attribute_definitions_proto):
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
         run = ReadOnlyRun(project, RUN_ID)
@@ -233,7 +319,7 @@ def test_field_names(project):
 
     _assert_warning(record)
 
-    project._backend.unsupported_attrs = None
+    query_attribute_definitions_proto.return_value = query_attribute_definitions_proto.SUPPORTED_TYPES_RESPONSE
 
     run = ReadOnlyRun(project, RUN_ID)
     field_names = set(run.field_names)
@@ -258,8 +344,6 @@ def test_run_eager_load_attributes(project):
 
 
 def test_run_no_eager_load_attributes(project, get_attributes_with_paths_filter_proto):
-    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto(DEFAULT_UNSUPPORTED_ATTRS))
-
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
         run = ReadOnlyRun(project, RUN_ID, eager_load_fields=False)
@@ -274,18 +358,23 @@ def test_run_no_eager_load_attributes(project, get_attributes_with_paths_filter_
     _assert_warning(record)
 
 
-def test_run_fetch_missing_attribute(project, get_attributes_with_paths_filter_proto):
-    """Fetch an attribute that does not exist, then make it exist and fetch it again."""
-    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto(None))
-    project._backend.unsupported_attrs = None
+def test_run_fetch_missing_attribute(
+    project, get_attributes_with_paths_filter_proto, query_attribute_definitions_proto
+):
+    """Fetch an unsupported attribute that does not exist, then make it exist and fetch it again."""
 
+    get_attributes_with_paths_filter_proto.return_value = proto_response(make_proto_attributes_dto(None))
+    query_attribute_definitions_proto.return_value = query_attribute_definitions_proto.SUPPORTED_TYPES_RESPONSE
+
+    # Attr does not exist yet
     with pytest.raises(KeyError):
         run = ReadOnlyRun(project, RUN_ID)
         run["badAttr"].fetch()
         run["anotherAttr"].fetch()
 
-    project._backend.unsupported_attrs = DEFAULT_UNSUPPORTED_ATTRS
-    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto(DEFAULT_UNSUPPORTED_ATTRS))
+    # Now return it in the response
+    get_attributes_with_paths_filter_proto.return_value = proto_response(make_proto_attributes_dto())
+    query_attribute_definitions_proto.return_value = query_attribute_definitions_proto.UNSUPPORTED_TYPES_RESPONSE
 
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
@@ -296,7 +385,6 @@ def test_run_fetch_missing_attribute(project, get_attributes_with_paths_filter_p
 
 
 def test_prefetch(project, get_attributes_with_paths_filter_proto):
-    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto())
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
         run = ReadOnlyRun(project, RUN_ID)
@@ -307,16 +395,19 @@ def test_prefetch(project, get_attributes_with_paths_filter_proto):
 
     _assert_warning(record)
 
-    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto(None))
+    get_attributes_with_paths_filter_proto.return_value = proto_response(make_proto_attributes_dto(None))
     run.prefetch(["badAttr", "anotherAttr", "sys/id"])
 
 
-def test_prefetch_series_values(project, get_attributes_with_paths_filter_proto):
-    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto())
+@pytest.mark.xfail(
+    reason="Figure out why accessing an existing metric causes an additional 2 warnings detected by pytest"
+)
+def test_series_no_prefetch(
+    project,
+):
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
         run = ReadOnlyRun(project, RUN_ID)
-        run.prefetch_series_values(["badAttr", "anotherAttr", "metric"])
         assert run["badAttr"].fetch() is None
         assert run["badAttr"].fetch_last() is None
         assert run["badAttr"].fetch_values().empty
@@ -325,16 +416,35 @@ def test_prefetch_series_values(project, get_attributes_with_paths_filter_proto)
         assert run["anotherAttr"].fetch_last() is None
         assert run["anotherAttr"].fetch_values().empty
 
-        assert run["metric"].fetch_last() == 42
+        # TODO: figure out why this causes _asert_warning() to fail with receiving 4 warnings instead of 2
+        assert run["series"].fetch_last() == 42
 
     _assert_warning(record)
 
-    get_attributes_with_paths_filter_proto.return_value = response(make_proto_attributes_dto(None))
-    project._backend.unsupported_attrs = None
+
+def test_prefetch_series_values(project, get_attributes_with_paths_filter_proto, query_attribute_definitions_proto):
+    with pytest.warns(NeptuneWarning) as record:
+        warnings.simplefilter("once")
+        run = ReadOnlyRun(project, RUN_ID)
+        run.prefetch_series_values(["badAttr", "anotherAttr", "series"])
+        assert run["badAttr"].fetch() is None
+        assert run["badAttr"].fetch_last() is None
+        assert run["badAttr"].fetch_values().empty
+
+        assert run["anotherAttr"].fetch() is None
+        assert run["anotherAttr"].fetch_last() is None
+        assert run["anotherAttr"].fetch_values().empty
+
+        assert run["series"].fetch_last() == 42
+
+    _assert_warning(record)
+
+    get_attributes_with_paths_filter_proto.return_value = proto_response(make_proto_attributes_dto(None))
+    query_attribute_definitions_proto.return_value = query_attribute_definitions_proto.SUPPORTED_TYPES_RESPONSE
 
     with pytest.raises(KeyError):
         run = ReadOnlyRun(project, RUN_ID)
-        run.prefetch_series_values(["badAttr", "anotherAttr", "metric"])
+        run.prefetch_series_values(["badAttr", "anotherAttr", "series"])
 
         run["badAttr"].fetch_values()
         run["anotherAttr"].fetch_values()
@@ -343,7 +453,7 @@ def test_prefetch_series_values(project, get_attributes_with_paths_filter_proto)
 # ReadOnlyProject tests
 
 
-def test_fetch_runs_df(project):
+def test_fetch_runs_df(project, query_attributes_within_project_proto):
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
         df = project.fetch_runs_df(columns_regex=".*")
@@ -355,7 +465,8 @@ def test_fetch_runs_df(project):
 
     _assert_warning(record)
 
-    project._backend.unsupported_attrs = None
+    query_attributes_within_project_proto.return_value = query_attributes_within_project_proto.SUPPORTED_TYPES_RESPONSE
+
     # No warnings should be issued
     df = project.fetch_runs_df(columns_regex=".*")
     assert df.shape[0] == 1, "Only one run should be returned"
@@ -365,7 +476,33 @@ def test_fetch_runs_df(project):
     assert "anotherAttr" not in row
 
 
-def test_fetch_experiments_df(project):
+def test_fetch_runs_df_sorting_with_bad_column(
+    project, search_leaderboard_entries_proto, query_attribute_definitions_within_project
+):
+    # ApiClient.find_field_type_within_project will query the backend for type of the sorting column,
+    # filtering on a subset of known types that are viable for sorting. We should return an empty result
+    # in that case.
+    query_attribute_definitions_within_project.return_value = json_response(
+        QueryAttributeDefinitionsResultDTO(entries=[], next_page=NextPageDTO())
+    )
+
+    with pytest.warns(NeptuneWarning) as record:
+        warnings.simplefilter("once")
+        project.fetch_runs_df(sort_by="badAttr")
+
+    # The first warning is about the missing sorting column
+    message = record.pop(NeptuneWarning).message
+    assert "Could not find sorting column type for field 'badAttr'" in str(message)
+
+    _assert_warning(record)
+
+    # Make sure we defaulted to a known type once we couldn't find the sorting column
+    query_attribute_definitions_within_project.assert_called_once()
+    body: QueryAttributeDefinitionsBodyDTO = query_attribute_definitions_within_project.call_args[1]["body"]
+    assert all(attr_filter.attribute_type.value in SUPPORTED_TYPES_STR for attr_filter in body.attribute_filter)
+
+
+def test_fetch_experiments_df(project, query_attributes_within_project_proto):
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
         df = project.fetch_experiments_df(columns_regex=".*")
@@ -377,7 +514,8 @@ def test_fetch_experiments_df(project):
 
     _assert_warning(record)
 
-    project._backend.unsupported_attrs = None
+    query_attributes_within_project_proto.return_value = query_attributes_within_project_proto.SUPPORTED_TYPES_RESPONSE
+
     # No warnings should be issued
     df = project.fetch_experiments_df(columns_regex=".*")
     assert df.shape[0] == 1, "Only one experiment should be returned"
@@ -387,52 +525,84 @@ def test_fetch_experiments_df(project):
     assert "anotherAttr" not in row
 
 
-def test_fetch_runs(project):
+def test_fetch_experiments_df_sorting_with_bad_column(
+    project, search_leaderboard_entries_proto, query_attribute_definitions_within_project
+):
+    # ApiClient.find_field_type_within_project will query the backend for type of the sorting column,
+    # filtering on a subset of known types that are viable for sorting. We should return an empty result
+    # in that case.
+    query_attribute_definitions_within_project.return_value = json_response(
+        QueryAttributeDefinitionsResultDTO(entries=[], next_page=NextPageDTO())
+    )
+
+    with pytest.warns(NeptuneWarning) as record:
+        warnings.simplefilter("once")
+        project.fetch_runs_df(sort_by="badAttr")
+
+    # The first warning is about the missing sorting column
+    message = record.pop(NeptuneWarning).message
+    assert "Could not find sorting column type for field 'badAttr'" in str(message)
+
+    _assert_warning(record)
+
+    # Make sure we defaulted to a known type once we couldn't find the sorting column
+    query_attribute_definitions_within_project.assert_called_once()
+    body: QueryAttributeDefinitionsBodyDTO = query_attribute_definitions_within_project.call_args[1]["body"]
+    assert all(attr_filter.attribute_type.value in SUPPORTED_TYPES_STR for attr_filter in body.attribute_filter)
+
+
+def test_fetch_runs(project, query_attributes_within_project_proto):
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
         df = project.fetch_runs()
         assert df.shape[0] == 1, "Only one run should be returned"
     _assert_warning(record)
 
-    project._backend.unsupported_attrs = None
+    query_attributes_within_project_proto.return_value = query_attributes_within_project_proto.SUPPORTED_TYPES_RESPONSE
+
     # No warning should be issued
     df = project.fetch_runs()
     assert df.shape[0] == 1, "Only one run should be returned"
 
 
-def test_fetch_experiments(project):
+def test_fetch_experiments(project, query_attributes_within_project_proto):
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
         df = project.fetch_experiments()
         assert df.shape[0] == 1, "Only one run should be returned"
     _assert_warning(record)
 
-    project._backend.unsupported_attrs = None
+    query_attributes_within_project_proto.return_value = query_attributes_within_project_proto.SUPPORTED_TYPES_RESPONSE
+
     # No warning should be issued
     df = project.fetch_experiments()
     assert df.shape[0] == 1, "Only one run should be returned"
 
 
-def test_fetch_read_only_runs(project):
+def test_fetch_read_only_runs(project, query_attribute_definitions_proto, search_leaderboard_entries_proto):
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
         assert len(list(project.fetch_read_only_runs(custom_ids=[RUN_ID]))) == 1
 
     _assert_warning(record)
 
-    project._backend.unsupported_attrs = None
+    query_attribute_definitions_proto.return_value = query_attribute_definitions_proto.SUPPORTED_TYPES_RESPONSE
+    search_leaderboard_entries_proto.return_value = search_leaderboard_entries_proto.SUPPORTED_TYPES_RESPONSE
+
     # No warning should be issued
     assert len(list(project.fetch_read_only_runs(custom_ids=[RUN_ID]))) == 1
 
 
-def test_fetch_read_only_experiments(project):
+def test_fetch_read_only_experiments(project, query_attribute_definitions_proto, search_leaderboard_entries_proto):
     with pytest.warns(NeptuneWarning) as record:
         warnings.simplefilter("once")
         assert len(list(project.fetch_read_only_experiments(names=["does-not-matter"]))) == 1
 
     _assert_warning(record)
 
-    project._backend.unsupported_attrs = None
+    query_attribute_definitions_proto.return_value = query_attribute_definitions_proto.SUPPORTED_TYPES_RESPONSE
+    search_leaderboard_entries_proto.return_value = search_leaderboard_entries_proto.SUPPORTED_TYPES_RESPONSE
+
     # No warning should be issued
     assert len(list(project.fetch_read_only_experiments(names=["does-not-matter"]))) == 1
 


### PR DESCRIPTION
This PR makes `neptune-fetcher` more resilient to attributes of unknown types returned by the backend. The change makes fetcher accept unknown attribute types:
 * emit a warning when an unknown type is received
 * return `None` / empty `DataFrame` on access to the given attribute

The unit tests suite attempts to test every method for the above behaviour, and also for cases when no unknown attributes are returned -> no warnings should be emitted.