### PR TITLE
feat(alpha): prefetch pages asynchronously

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Test
       working-directory: ${{ inputs.working-directory }}
       run: |
-        pytest -v -n 2 "./tests/${{ inputs.test-directory }}" \
+        pytest -v "./tests/${{ inputs.test-directory }}" \
         --timeout=120 --timeout_method=thread \
         --color=yes \
         --junitxml="${{ inputs.working-directory }}/test-results/test-${{ inputs.report-suffix }}.xml"

--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -47,7 +47,7 @@ run_tests() {
   python tests/populate_projects.py
 
   echo "Running tests..."
-  pytest -n auto --junitxml="test-results/test-e2e.xml" tests/e2e
+  pytest --junitxml="test-results/test-e2e.xml" tests/e2e
 
   EXIT_CODE=$?
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,6 +6,5 @@ pytest
 pytest-mock
 pytest-retry
 pytest-timeout
-pytest-xdist
 icecream
 neptune-scale==0.9.1b2

--- a/src/neptune_fetcher/alpha/internal/attribute.py
+++ b/src/neptune_fetcher/alpha/internal/attribute.py
@@ -71,6 +71,7 @@ def fetch_attribute_definitions(
                 experiment_identifiers=experiment_identifiers,
                 attribute_filter=attribute_filter,
                 batch_size=batch_size,
+                executor=executor,
             )
             for item in page.items
         ]
@@ -109,6 +110,7 @@ def _fetch_attribute_definitions_single_filter(
     experiment_identifiers: Iterable[identifiers.ExperimentIdentifier],
     attribute_filter: filter.AttributeFilter,
     batch_size: int,
+    executor: Optional[Executor] = None,
 ) -> Generator[util.Page[AttributeDefinition], None, None]:
     params: dict[str, Any] = {
         "projectIdentifiers": list(project_identifiers),
@@ -144,6 +146,7 @@ def _fetch_attribute_definitions_single_filter(
         process_page=_process_attribute_definitions_page,
         make_new_page_params=_make_new_attribute_definitions_page_params,
         params=params,
+        executor=executor,
     )
 
 

--- a/src/neptune_fetcher/alpha/internal/experiment.py
+++ b/src/neptune_fetcher/alpha/internal/experiment.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools as ft
+from concurrent.futures import Executor
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -47,6 +48,7 @@ def fetch_experiment_sys_attrs(
     project_identifier: identifiers.ProjectIdentifier,
     experiment_filter: Optional[ExperimentFilter] = None,
     batch_size: int = _DEFAULT_BATCH_SIZE,
+    executor: Optional[Executor] = None,
 ) -> Generator[util.Page[ExperimentSysAttrs], None, None]:
     params: dict[str, Any] = {
         "attributeFilters": [{"path": "sys/name"}, {"path": "sys/id"}],
@@ -62,6 +64,7 @@ def fetch_experiment_sys_attrs(
         process_page=_process_experiment_page,
         make_new_page_params=ft.partial(_make_new_experiment_page_params, batch_size=batch_size),
         params=params,
+        executor=executor,
     )
 
 

--- a/tests/e2e/alpha/test_experiment.py
+++ b/tests/e2e/alpha/test_experiment.py
@@ -1,4 +1,5 @@
 import os
+from concurrent.futures import ThreadPoolExecutor
 from datetime import (
     datetime,
     timezone,
@@ -449,6 +450,22 @@ def test_find_experiments_paging(client, project, run, run_with_attributes):
     experiment_names = _extract_names(
         fetch_experiment_sys_attrs(client, project_identifier, experiment_filter=None, batch_size=1)
     )
+
+    # then
+    assert len(experiment_names) > 1
+
+
+def test_find_experiments_paging_executor(client, project, run_with_attributes):
+    # given
+    project_identifier = project.project_identifier
+
+    #  when
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        experiment_names = _extract_names(
+            fetch_experiment_sys_attrs(
+                client, project_identifier, experiment_filter=None, batch_size=1, executor=executor
+            )
+        )
 
     # then
     assert len(experiment_names) > 1


### PR DESCRIPTION
change to util.fetch_pages that makes it optionally take an executor and submit a request for a next page just before returning the previous page from a generator