### PR TITLE
fix: colocate e2e tests using same module-scoped experiment fixture

### DIFF
--- a/.github/scripts/run-e2e-tests.sh
+++ b/.github/scripts/run-e2e-tests.sh
@@ -47,7 +47,7 @@ run_tests() {
   python tests/populate_projects.py
 
   echo "Running tests..."
-  pytest -n auto --junitxml="test-results/test-e2e.xml" tests/e2e
+  pytest -n auto --dist loadgroup --junitxml="test-results/test-e2e.xml" tests/e2e
 
   EXIT_CODE=$?
 }

--- a/tests/e2e/alpha/test_attribute.py
+++ b/tests/e2e/alpha/test_attribute.py
@@ -83,6 +83,7 @@ def experiment_identifier(client, project, run_with_attributes) -> ExperimentIde
     return ExperimentIdentifier(project_identifier, sys_id)
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_single_string(client, project, experiment_identifier):
     # given
     project_identifier = project.project_identifier
@@ -97,6 +98,7 @@ def test_find_attributes_single_string(client, project, experiment_identifier):
     assert attributes == [AttributeDefinition("sys/name", "string")]
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_does_not_exist(client, project, experiment_identifier):
     # given
     project_identifier = project.project_identifier
@@ -111,6 +113,7 @@ def test_find_attributes_does_not_exist(client, project, experiment_identifier):
     assert attributes == []
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_two_strings(client, project, experiment_identifier):
     # given
     project_identifier = project.project_identifier
@@ -125,6 +128,7 @@ def test_find_attributes_two_strings(client, project, experiment_identifier):
     assert set(attributes) == {AttributeDefinition("sys/name", "string"), AttributeDefinition("sys/owner", "string")}
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_single_series(client, project, experiment_identifier):
     # given
     project_identifier = project.project_identifier
@@ -140,6 +144,7 @@ def test_find_attributes_single_series(client, project, experiment_identifier):
     assert attributes == [AttributeDefinition(path, "float_series")]
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_all_types(client, project, experiment_identifier):
     # given
     project_identifier = project.project_identifier
@@ -163,6 +168,7 @@ def test_find_attributes_all_types(client, project, experiment_identifier):
     assert set(attributes) == set(all_attrs)
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_no_type_in(client, project, experiment_identifier):
     # given
     project_identifier = project.project_identifier
@@ -177,6 +183,7 @@ def test_find_attributes_no_type_in(client, project, experiment_identifier):
     assert attributes == [AttributeDefinition("sys/name", "string")]
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_regex_matches_all(client, project, experiment_identifier):
     # given
     project_identifier = project.project_identifier
@@ -195,6 +202,7 @@ def test_find_attributes_regex_matches_all(client, project, experiment_identifie
     }
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_regex_matches_none(client, project, experiment_identifier):
     # given
     project_identifier = project.project_identifier
@@ -214,6 +222,7 @@ def test_find_attributes_regex_matches_none(client, project, experiment_identifi
     }
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_multiple_projects(client, project, experiment_identifier):
     # given
     project_identifier = project.project_identifier
@@ -232,6 +241,7 @@ def test_find_attributes_multiple_projects(client, project, experiment_identifie
     assert attributes == [AttributeDefinition("sys/name", "string")]
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_filter_or(client, project, experiment_identifier):
     # given
     project_identifier = project.project_identifier
@@ -260,6 +270,7 @@ def test_find_attributes_filter_or(client, project, experiment_identifier):
         lambda a, b, c: AttributeFilter.any(a, AttributeFilter.any(b, c)),
     ],
 )
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_attributes_filter_triple_or(client, project, experiment_identifier, make_attribute_filter):
     # given
     project_identifier = project.project_identifier

--- a/tests/e2e/alpha/test_experiment.py
+++ b/tests/e2e/alpha/test_experiment.py
@@ -58,6 +58,7 @@ def run_with_attributes(project):
     return run
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_experiments_no_filter(client, project, run_with_attributes):
     # given
     project_identifier = project.project_identifier
@@ -69,6 +70,7 @@ def test_find_experiments_no_filter(client, project, run_with_attributes):
     assert len(experiment_names) > 0
 
 
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_experiments_by_name(client, project, run_with_attributes):
     # given
     project_identifier = project.project_identifier
@@ -152,6 +154,7 @@ def test_find_experiments_by_name_not_found(client, project):
         (ExperimentFilter.exists(Attribute(name="test/does-not-exist-value", type="string")), False),
     ],
 )
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_experiments_by_config_values(client, project, run_with_attributes, experiment_filter, found):
     # given
     project_identifier = project.project_identifier
@@ -273,6 +276,7 @@ def test_find_experiments_by_config_values(client, project, run_with_attributes,
         ),
     ],
 )
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_experiments_by_series_values(client, project, run_with_attributes, experiment_filter, found):
     # given
     project_identifier = project.project_identifier
@@ -427,6 +431,7 @@ def test_find_experiments_by_series_values(client, project, run_with_attributes,
         ),
     ],
 )
+@pytest.mark.xdist_group(EXPERIMENT_NAME)
 def test_find_experiments_by_logical_expression(client, project, run_with_attributes, experiment_filter, found):
     # given
     project_identifier = project.project_identifier

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,5 @@
+def pytest_set_filtered_exceptions() -> list[type[BaseException]]:
+    class DoNotFilterAnythingMarker(Exception):
+        pass
+
+    return [DoNotFilterAnythingMarker]


### PR DESCRIPTION
module-scoped fixture creating a text experiment and writing data to it is recreated on each pytest-xdist worker
I want to group tests that use the same fixture so that it's initialized only once