### PR TITLE
Docs for metric preview fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.11.0] - 2025-01-09
 
 ### Changes
-- Allow more characters in project names ([#147](https://github.com/neptune-ai/neptune-fetcher/pull/147))
+- Expand the set of allowed characters in project names ([#147](https://github.com/neptune-ai/neptune-fetcher/pull/147))
 
 ## [0.9.5] - 2024-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2025-02-19
+
+### Changes
+- Add support for point previews when fetching metric values ([#226](https://github.com/neptune-ai/neptune-fetcher/pull/226))
+
+## [0.13.0] - 2025-02-11
+
+### Changes
+- Publish alpha version of new Fetcher API ([#202](https://github.com/neptune-ai/neptune-fetcher/pull/202), [#217](https://github.com/neptune-ai/neptune-fetcher/pull/217))
+- Neptune doesn't crash on unknown types returned by the backend ([#155](https://github.com/neptune-ai/neptune-fetcher/pull/155))
+
+## [0.12.0] - 2025-01-21
+
+### Changes
+- Use batching in `fetch_read_only_experiments()` ([#151](https://github.com/neptune-ai/neptune-fetcher/pull/151))
+
+## [0.11.0] - 2025-01-09
+
+### Changes
+- Allow more characters in project names ([#147](https://github.com/neptune-ai/neptune-fetcher/pull/147))
+
 ## [0.9.5] - 2024-11-27
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.14.0] - 2025-02-19
 
 ### Changes
-- Add support for point previews when fetching metric values ([#226](https://github.com/neptune-ai/neptune-fetcher/pull/226))
+- Add support for point previews when fetching metric values ([#226](https://github.com/neptune-ai/neptune-fetcher/pull/226)). **Note:** This change introduces the `include_point_previews` parameter to the `fetch_experiment_metrics()` and `fetch_run_metrics()` functions. The new parameter is in the middle of the list. If you've used the arguments of these functions positionally, ensure that the order is valid or use keywords.
 
 ## [0.13.0] - 2025-02-11
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,24 @@ npt.fetch_experiment_metrics(
 9  exp_hgctc     4          0.007815      0.746344              0.102646          0.055511
 ```
 
+#### Fetch metric previews
+
+To fetch point previews, set the `include_point_previews` argument to `True`:
+
+```python
+npt.fetch_experiment_metrics(
+    experiments=r"exp.*",
+    attributes=r"metrics/.*",
+    include_point_previews=True,
+)
+```
+
+When previews are included, the returned data frame includes additional sub-columns with preview information (`is_preview` and `preview_completion`).
+
+If `False`, only regular, committed points are fetched.
+
+> For details, see [Metric previews][docs-metric-previews] in the documentation.
+
 ### Working with multiple projects
 
 To work with multiple projects simultaneously, you can use contexts. This way, you can set the scope for individual fetching calls or globally for your session.
@@ -1030,6 +1048,7 @@ __Parameters:__
 | `include_inherited` | `bool`                | `True`       | If True (default), values inherited from ancestor runs are included. To only fetch values from the current run, set to False.                                             |
 | `progress_bar`      | `bool`                | `True`       | Set to False to disable the download progress bar.                                                                                                                        |
 | `step_range`        | `tuple[float, float]` | (None, None) | - left: left boundary of the range (inclusive). If None, it\'s open on the left. <br> - right: right boundary of the range (inclusive). If None, it\'s open on the right. |
+| `include_point_previews` | `bool` | `False` | To include [metric previews][docs-metric-previews], set to `True`. When previews are included, the returned data frame includes additional sub-columns with preview information (`is_preview` and `preview_completion`). If `False`, only regular, committed points are fetched. |
 
 __Returns:__ `pandas.DataFrame`
 
@@ -1108,3 +1127,6 @@ groups = run["sys/group_tags"].fetch()
 
 This project is licensed under the Apache License Version 2.0. For more details,
 see [Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+
+
+[docs-metric-previews]: https://docs-beta.neptune.ai/metric_previews


### PR DESCRIPTION
[TW-306: Docs: Metric previews can be fetched](https://linear.app/neptuneai/issue/TW-306/docs-metric-previews-can-be-fetched)

## Before submitting checklist

- [x] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [x] Did you **ask the docs owner** to review all the user-facing changes?

