### PR TITLE
Add a test for `fetch_attribute_definitions_split()`.

### DIFF
--- a/tests/e2e/alpha/internal/composition/test_attribute_components.py
+++ b/tests/e2e/alpha/internal/composition/test_attribute_components.py
@@ -1,0 +1,40 @@
+import itertools
+
+from e2e.alpha.internal.conftest import extract_pages
+from e2e.alpha.internal.data import TEST_DATA
+
+from neptune_fetcher.alpha.internal.composition import concurrency
+from neptune_fetcher.alpha.internal.composition.attribute_components import fetch_attribute_values_split
+from neptune_fetcher.alpha.internal.retrieval.attribute_definitions import AttributeDefinition
+
+
+def test_fetch_attribute_values_split_with_long_attribute_names(client, project, executor, experiment_identifier):
+    """Verify that properly split a single request for attributes with long names, which will need to be split
+    because of the limits."""
+
+    experiment = TEST_DATA.experiments[0]
+    long_int_names = [name for name in experiment.config if "long-int" in name]
+    metric_names = experiment.float_series.keys()
+
+    definitions = list(
+        itertools.chain(
+            [AttributeDefinition(name=name, type="int") for name in long_int_names],
+            [AttributeDefinition(name=name, type="float_series") for name in metric_names],
+        )
+    )
+    expected_names = {*itertools.chain(long_int_names, metric_names)}
+
+    output = fetch_attribute_values_split(
+        client,
+        project.project_identifier,
+        executor,
+        [experiment_identifier.sys_id],
+        definitions,
+        downstream=concurrency.return_value,
+    )
+
+    fetched_attributes = extract_pages(concurrency.gather_results(output))
+    fetched_names = {attr.attribute_definition.name for attr in fetched_attributes}
+
+    assert len(fetched_names) == len(expected_names)
+    assert fetched_names == expected_names

--- a/tests/e2e/alpha/internal/data.py
+++ b/tests/e2e/alpha/internal/data.py
@@ -12,11 +12,14 @@ from datetime import (
 
 from neptune_scale.types import File
 
-TEST_DATA_VERSION = "2025-04-29"
+TEST_DATA_VERSION = "2025-05-05"
 PATH = f"test/test-alpha-{TEST_DATA_VERSION}"
-FLOAT_SERIES_PATHS = [f"{PATH}/metrics/float-series-value_{j}" for j in range(5)]
+LONG_FLOAT_SERIES_PATHS = [f"{PATH}/metrics/float-series-value_{j}" + "A" * 512 for j in range(20)]
+FLOAT_SERIES_PATHS = [f"{PATH}/metrics/float-series-value_{j}" for j in range(5)] + LONG_FLOAT_SERIES_PATHS
 STRING_SERIES_PATHS = [f"{PATH}/metrics/string-series-value_{j}" for j in range(2)]
 NUMBER_OF_STEPS = 10
+
+LONG_INT_CONFIGS_PATHS = [f"{PATH}/configs/long-int-value_{j}" + "A" * 512 for j in range(5)]
 
 
 @dataclass
@@ -65,6 +68,8 @@ class TestData:
                     f"{PATH}/datetime-value": datetime(2025, 1, 1, 0, 0, 0, 0, timezone.utc),
                     f"{PATH}/unique-value-{i}": f"unique_{i}",
                 }
+
+                config |= {path: i for i, path in enumerate(LONG_INT_CONFIGS_PATHS)}
 
                 string_sets = {f"{PATH}/string_set-value": [f"string-{i}-{j}" for j in range(5)]}
                 float_series = {


### PR DESCRIPTION
This specifically tests only the case where we have long attribute names and we request all of them in a single call.