### PR TITLE
Broaden `neptune-api` dependency to 0.11.0-0.12.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ pattern = "default-unprefixed"
 python = "^3.9"
 
 # Base neptune package
-neptune-api = "^0.11.0"
+neptune-api = ">=0.11.0,<0.13.0"
 
 # Optional for default progress update handling
 tqdm = { version = ">=4.66.0" }


### PR DESCRIPTION
This is to allow 0.12.0 to be used, as it introduces the protobuf compatibility layer. The dependency is not strict to 0.12.0, as it does not need to be. Existing installations will only upgrade neptune-api if neptune-client-scale is installed in the same environment, as it depends on 0.12.*