### PR TITLE
Add `NeptuneInvalidCredentialsError`

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,4 +7,4 @@ pytest-mock
 pytest-retry
 pytest-timeout
 icecream
-git+https://github.com/neptune-ai/neptune-client-scale.git@main
+git+https://github.com/neptune-ai/neptune-client-scale.git@kg/handle-api-key-rejected-error

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ pattern = "default-unprefixed"
 python = "^3.9"
 
 # Base neptune package
-neptune-api = ">=0.11.0,<0.13.0"
+neptune-api = "^0.13.0"
 
 # Optional for default progress update handling
 tqdm = { version = ">=4.66.0" }

--- a/src/neptune_fetcher/alpha/exceptions.py
+++ b/src/neptune_fetcher/alpha/exceptions.py
@@ -80,6 +80,19 @@ or with the `NEPTUNE_API_TOKEN` environment variable.
         )
 
 
+class NeptuneInvalidCredentialsError(NeptuneUserError):
+    def __init__(self) -> None:
+        super().__init__(
+            """
+{h1}NeptuneInvalidCredentialsError: Your Neptune API token was rejected by the server.{end}
+
+Make sure to specify a valid API token with `set_api_token()` function,
+by providing the `context` argument with `project` and `api_token` set to the function call,
+or with the `NEPTUNE_API_TOKEN` environment variable.
+"""
+        )
+
+
 class AttributeTypeInferenceError(NeptuneError):
     def __init__(self, attribute_names: Iterable[str]) -> None:
         super().__init__(

--- a/src/neptune_fetcher/alpha/exceptions.py
+++ b/src/neptune_fetcher/alpha/exceptions.py
@@ -86,9 +86,13 @@ class NeptuneInvalidCredentialsError(NeptuneUserError):
             """
 {h1}NeptuneInvalidCredentialsError: Your Neptune API token was rejected by the server.{end}
 
-Make sure to specify a valid API token with `set_api_token()` function,
-by providing the `context` argument with `project` and `api_token` set to the function call,
-or with the `NEPTUNE_API_TOKEN` environment variable.
+Make sure to specify a valid token in one of the following ways:
+
+- Call the `set_api_token()` function
+- Create a Context with the API token and pass it to the `context` argument of the fetching method
+- Set the `NEPTUNE_API_TOKEN` environment variable
+
+For details, see https://docs-beta.neptune.ai/fetcher_setup
 """
         )
 

--- a/src/neptune_fetcher/api/api_client.py
+++ b/src/neptune_fetcher/api/api_client.py
@@ -43,6 +43,7 @@ from typing import (
 
 from neptune_api.api.backend import get_project
 from neptune_api.credentials import Credentials
+from neptune_api.errors import ApiKeyRejectedError
 from neptune_api.models import ProjectDTO
 from neptune_retrieval_api.api.default import (
     get_multiple_float_series_values_proto,
@@ -330,6 +331,11 @@ def backoff_retry(
         tries += 1
         try:
             response = func(*args, **kwargs)
+        except ApiKeyRejectedError as e:
+            # The API token is explicitly rejected by the backend -- don't retry anymore.
+            raise NeptuneException(
+                "Your API token was rejected by the Neptune backend because it is either unknown or expired."
+            ) from e
         except Exception as e:
             response = None
             last_exc = e


### PR DESCRIPTION
The new error is raised when the backend explicitly rejects the API token as invalid (as opposed to any other token exchange error, eg. HTTP 500). We don't retry requests when this happens, but raise the error immediately instead.

This PR depends on changes in `neptune-api`: https://github.com/neptune-ai/neptune-api/pull/74