### PR TITLE
Add NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,4 +7,4 @@ pytest-mock
 pytest-retry
 pytest-timeout
 icecream
-git+https://github.com/neptune-ai/neptune-client-scale.git@kg/handle-api-key-rejected-error
+git+https://github.com/neptune-ai/neptune-client-scale.git@main

--- a/src/neptune_fetcher/api/api_client.py
+++ b/src/neptune_fetcher/api/api_client.py
@@ -41,6 +41,7 @@ from typing import (
     Union,
 )
 
+import httpx
 from neptune_api.api.backend import get_project
 from neptune_api.credentials import Credentials
 from neptune_api.errors import ApiKeyRejectedError
@@ -336,6 +337,14 @@ def backoff_retry(
             raise NeptuneException(
                 "Your API token was rejected by the Neptune backend because it is either unknown or expired."
             ) from e
+        except httpx.TimeoutException as e:
+            response = None
+            last_exc = e
+            logging.warning(
+                "Neptune API request timed out. Retrying...\n"
+                "Check your network connection or increase the timeout by setting the "
+                "NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS environment variable (default: 60 seconds)."
+            )
         except Exception as e:
             response = None
             last_exc = e

--- a/src/neptune_fetcher/api/api_client.py
+++ b/src/neptune_fetcher/api/api_client.py
@@ -87,6 +87,7 @@ from neptune_fetcher.util import (
     get_config_and_token_urls,
 )
 
+logger = logging.getLogger(__name__)
 # Disable httpx logging, httpx logs requests at INFO level
 logging.getLogger("httpx").setLevel(logging.WARN)
 
@@ -340,7 +341,7 @@ def backoff_retry(
         except httpx.TimeoutException as e:
             response = None
             last_exc = e
-            logging.warning(
+            logger.warning(
                 "Neptune API request timed out. Retrying...\n"
                 "Check your network connection or increase the timeout by setting the "
                 "NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS environment variable (default: 60 seconds)."

--- a/src/neptune_fetcher/util.py
+++ b/src/neptune_fetcher/util.py
@@ -13,12 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import logging
 import os
+import time
 import warnings
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import (
     Any,
+    Callable,
     Dict,
     Final,
     Optional,
@@ -32,10 +35,15 @@ from neptune_api import (
 from neptune_api.api.backend import get_client_config
 from neptune_api.auth_helpers import exchange_api_key
 from neptune_api.credentials import Credentials
-from neptune_api.models import (
-    ClientConfig,
-    Error,
-)
+from neptune_api.errors import ApiKeyRejectedError
+from neptune_api.models import ClientConfig
+from neptune_retrieval_api.types import Response
+
+logger = logging.getLogger(__name__)
+
+# Disable httpx logging, httpx logs requests at INFO level
+logging.getLogger("httpx").setLevel(logging.WARN)
+
 
 NEPTUNE_VERIFY_SSL: Final[bool] = os.environ.get("NEPTUNE_VERIFY_SSL", "1").lower() in {"1", "true"}
 # This timeout is applied to each networking call individually: connect, write, and read. Thus, it is
@@ -117,6 +125,18 @@ class TokenRefreshingURLs:
         )
 
 
+def _wrap_httpx_json_response(httpx_response: httpx.Response) -> Response:
+    """Wrap a httpx.Response into an neptune-api Response object that is compatible
+    with backoff_retry(). Use .json() as parsed content in the result."""
+
+    return Response(
+        status_code=HTTPStatus(httpx_response.status_code),
+        content=httpx_response.content,
+        headers=httpx_response.headers,
+        parsed=httpx_response.json(),
+    )
+
+
 def get_config_and_token_urls(
     *, credentials: Credentials, proxies: Optional[Dict[str, str]]
 ) -> tuple[ClientConfig, TokenRefreshingURLs]:
@@ -124,12 +144,18 @@ def get_config_and_token_urls(
     with Client(
         base_url=credentials.base_url, httpx_args={"mounts": proxies}, verify_ssl=NEPTUNE_VERIFY_SSL, timeout=timeout
     ) as client:
-        config = get_client_config.sync(client=client)
-        if config is None or isinstance(config, Error):
-            raise RuntimeError(f"Failed to get client config: {config}")
-        response = client.get_httpx_client().get(config.security.open_id_discovery)
-        token_urls = TokenRefreshingURLs.from_dict(response.json())
-    return config, token_urls
+        try:
+            config_response = backoff_retry(lambda: get_client_config.sync_detailed(client=client))
+            config = config_response.parsed
+
+            urls_response = backoff_retry(
+                lambda: _wrap_httpx_json_response(client.get_httpx_client().get(config.security.open_id_discovery))
+            )
+            token_urls = TokenRefreshingURLs.from_dict(urls_response.parsed)
+
+            return config, token_urls
+        except Exception as e:
+            raise NeptuneException(f"Failed to fetch client configuration: {e}") from e
 
 
 def create_auth_api_client(
@@ -177,3 +203,76 @@ def batched_paths(paths: list[str], batch_size: int, query_size_limit: int) -> l
         batches.append(current_batch)
 
     return batches
+
+
+def backoff_retry(
+    func: Callable, *args, max_tries: int = 5, backoff_factor: float = 0.5, max_backoff: float = 30.0, **kwargs
+) -> Response[Any]:
+    """
+    Retries a function with exponential backoff. The function will be called at most `max_tries` times.
+
+    :param func: The function to retry.
+    :param max_tries: Maximum number of times `func` will be called, including retries.
+    :param backoff_factor: Factor by which the backoff time increases.
+    :param max_backoff: Maximum backoff time.
+    :param args: Positional arguments to pass to the function.
+    :param kwargs: Keyword arguments to pass to the function.
+    :return: The result of the function call.
+    """
+
+    if max_tries < 1:
+        raise ValueError("max_tries must be greater than or equal to 1")
+
+    tries = 0
+    last_exc = None
+    last_response = None
+
+    while True:
+        tries += 1
+        try:
+            response = func(*args, **kwargs)
+        except ApiKeyRejectedError as e:
+            # The API token is explicitly rejected by the backend -- don't retry anymore.
+            raise NeptuneException(
+                "Your API token was rejected by the Neptune backend because it is either unknown or expired."
+            ) from e
+        except httpx.TimeoutException as e:
+            response = None
+            last_exc = e
+            logger.warning(
+                "Neptune API request timed out. Retrying...\n"
+                "Check your network connection or increase the timeout by setting the "
+                "NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS environment variable (default: 60 seconds)."
+            )
+        except Exception as e:
+            response = None
+            last_exc = e
+
+        if response is not None:
+            last_response = response
+
+            code = response.status_code.value
+            if 0 <= code < 300:
+                return response
+
+            # Not a TooManyRequests or InternalServerError code
+            if not (code == 429 or 500 <= code < 600):
+                raise NeptuneException(f"Unexpected server response {response.status_code}: {str(response.content)}")
+
+        if tries == max_tries:
+            break
+
+        # A retryable error occurred, back off and try again
+        backoff_time = min(backoff_factor * (2**tries), max_backoff)
+        time.sleep(backoff_time)
+
+    # No more retries left
+    msg = []
+    if last_exc:
+        msg.append(f"Last exception: {str(last_exc)}")
+    if last_response:
+        msg.append(f"Last response: {last_response.status_code}: {str(last_response.content)}")
+    if not msg:
+        raise NeptuneException("Unknown error occurred when requesting data")
+
+    raise NeptuneException(f"Failed to get response after {tries} retries. " + "\n".join(msg))


### PR DESCRIPTION
Add a new env variable `NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS` that controls `httpx` timeouts. Defaults to 60 sec.