### PR TITLE
hotfix: Add NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS with default 60s.

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,4 +7,4 @@ pytest-mock
 pytest-retry
 pytest-timeout
 icecream
-git+https://github.com/neptune-ai/neptune-client-scale.git@main
+neptune-scale==0.11.1

--- a/src/neptune_fetcher/api/api_client.py
+++ b/src/neptune_fetcher/api/api_client.py
@@ -41,6 +41,7 @@ from typing import (
     Union,
 )
 
+import httpx
 from neptune_api.api.backend import get_project
 from neptune_api.credentials import Credentials
 from neptune_api.models import ProjectDTO
@@ -330,6 +331,14 @@ def backoff_retry(
         tries += 1
         try:
             response = func(*args, **kwargs)
+        except httpx.TimeoutException as e:
+            response = None
+            last_exc = e
+            logging.warning(
+                "Neptune API request timed out. Retrying...\n"
+                "Check your network connection or increase the timeout by setting the "
+                "NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS environment variable (default: 60 seconds)."
+            )
         except Exception as e:
             response = None
             last_exc = e


### PR DESCRIPTION
## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?
