### PR TITLE
feat: return a dataframe from download_files

### DIFF
--- a/src/neptune_fetcher/alpha/__init__.py
+++ b/src/neptune_fetcher/alpha/__init__.py
@@ -247,7 +247,7 @@ def download_files(
     *,
     destination: Optional[str] = None,
     context: Optional[Context] = None,
-) -> list[_pathlib.Path]:
+) -> _pandas.DataFrame:
     """
     Downloads files associated with selected experiments and attributes.
 
@@ -302,11 +302,10 @@ def download_files(
     else:
         destination_path = _pathlib.Path(destination).resolve()
 
-    results = _download_files.download_files(
+    return _download_files.download_files(
         filter_=experiments,
         attributes=attributes,
         destination=destination_path,
         context=context,
         container_type=_search.ContainerType.EXPERIMENT,
     )
-    return [result[2] for result in results]

--- a/src/neptune_fetcher/alpha/runs.py
+++ b/src/neptune_fetcher/alpha/runs.py
@@ -232,7 +232,7 @@ def download_files(
     *,
     destination: Optional[str] = None,
     context: Optional[_context.Context] = None,
-) -> list[_pathlib.Path]:
+) -> _pandas.DataFrame:
     """
     Downloads files associated with selected experiments and attributes.
 
@@ -287,11 +287,10 @@ def download_files(
     else:
         destination_path = _pathlib.Path(destination).resolve()
 
-    results = _download_files.download_files(
+    return _download_files.download_files(
         filter_=runs,
         attributes=attributes,
         destination=destination_path,
         context=context,
         container_type=_search.ContainerType.RUN,
     )
-    return [result[2] for result in results]


### PR DESCRIPTION
## Summary by Sourcery

Modify download_files to return a pandas DataFrame instead of a list of tuples, improving the output format and usability of file downloads

New Features:
- Introduce a new create_files_dataframe function to convert file download results into a structured pandas DataFrame
- Update download_files method to return a DataFrame with experiments as index and file paths as columns

Enhancements:
- Refactor file download process to generate a more user-friendly output format
- Improve data retrieval by separating data collection and DataFrame creation

Tests:
- Add comprehensive test cases for create_files_dataframe function
- Update existing download_files tests to work with the new DataFrame return type