### PR TITLE
fix: retry file download on expired url

### DIFF
--- a/src/neptune_fetcher/alpha/__init__.py
+++ b/src/neptune_fetcher/alpha/__init__.py
@@ -247,7 +247,7 @@ def download_files(
     *,
     destination: Optional[str] = None,
     context: Optional[Context] = None,
-) -> list[_pathlib.Path]:
+) -> _pandas.DataFrame:
     """
     Downloads files associated with selected experiments and attributes.
 
@@ -302,11 +302,10 @@ def download_files(
     else:
         destination_path = _pathlib.Path(destination).resolve()
 
-    results = _download_files.download_files(
+    return _download_files.download_files(
         filter_=experiments,
         attributes=attributes,
         destination=destination_path,
         context=context,
         container_type=_search.ContainerType.EXPERIMENT,
     )
-    return [result[2] for result in results]

--- a/src/neptune_fetcher/alpha/internal/composition/download_files.py
+++ b/src/neptune_fetcher/alpha/internal/composition/download_files.py
@@ -126,8 +126,10 @@ def download_files(
                             (
                                 run_file_tuple[0].run_identifier,
                                 run_file_tuple[0].attribute_definition,
-                                files.download_file(
-                                    signed_url=run_file_tuple[1].url,
+                                files.download_file_retry(
+                                    client=client,
+                                    project_identifier=project,
+                                    signed_file=run_file_tuple[1],
                                     target_path=files.create_target_path(
                                         destination=destination,
                                         experiment_name=sys_id_label_mapping[run_file_tuple[0].run_identifier.sys_id],

--- a/src/neptune_fetcher/alpha/runs.py
+++ b/src/neptune_fetcher/alpha/runs.py
@@ -232,7 +232,7 @@ def download_files(
     *,
     destination: Optional[str] = None,
     context: Optional[_context.Context] = None,
-) -> list[_pathlib.Path]:
+) -> _pandas.DataFrame:
     """
     Downloads files associated with selected experiments and attributes.
 
@@ -287,11 +287,10 @@ def download_files(
     else:
         destination_path = _pathlib.Path(destination).resolve()
 
-    results = _download_files.download_files(
+    return _download_files.download_files(
         filter_=runs,
         attributes=attributes,
         destination=destination_path,
         context=context,
         container_type=_search.ContainerType.RUN,
     )
-    return [result[2] for result in results]


### PR DESCRIPTION
## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Implement automatic retries for file downloads when encountering expired signed URLs and change the `download_files` function to return a pandas DataFrame.

Bug Fixes:
- Retry file downloads automatically if the signed URL has expired by fetching a new URL.

Enhancements:
- Modify `download_files` to return a pandas DataFrame containing downloaded file paths, indexed by run/experiment label.
- Add `create_files_dataframe` utility for formatting file download results into a DataFrame.

Tests:
- Add tests verifying the file download retry mechanism with expired and invalid URLs.
- Add unit tests for the `create_files_dataframe` function.
- Update existing download tests to validate the new DataFrame output format.
- Refactor file download E2E tests to use fixtures for setup.