### PR TITLE
feat: use the new series api

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ pattern = "default-unprefixed"
 python = "^3.9"
 
 # Base neptune package
-neptune-api = "^0.15.0"
+neptune-api = { git = "https://github.com/neptune-ai/neptune-api.git", branch = "dev/histograms" }
 azure-storage-blob = "^12.7.0"
 pandas = { version = ">=1.4.0" }
 

--- a/src/neptune_fetcher/alpha/internal/retrieval/series.py
+++ b/src/neptune_fetcher/alpha/internal/retrieval/series.py
@@ -96,9 +96,7 @@ def _fetch_series_page(
 ) -> ProtoSeriesValuesResponseDTO:
     body = SeriesValuesRequest.from_dict(params)
     response = util.backoff_retry(
-        get_series_values_proto.sync_detailed,
-        client=client,
-        body=body,
+        get_series_values_proto.sync_detailed, client=client, body=body, use_deprecated_string_fields=False
     )
     return ProtoSeriesValuesResponseDTO.FromString(response.content)
 
@@ -110,11 +108,11 @@ def _process_series_page(
     items: dict[RunAttributeDefinition, list[StringSeriesValue]] = {}
 
     for series in data.series:
-        if series.string_series.values:
+        if series.seriesValues.values:
             run_definition = request_id_to_run_attr_definition[series.requestId]
             values = [
-                StringSeriesValue(value.step, value.value, value.timestamp_millis)
-                for value in series.string_series.values
+                StringSeriesValue(value.step, value.object.stringValue, value.timestamp_millis)
+                for value in series.seriesValues.values
             ]
             items.setdefault(run_definition, []).extend(values)
 

--- a/tests/e2e/alpha/internal/test_split.py
+++ b/tests/e2e/alpha/internal/test_split.py
@@ -161,11 +161,12 @@ def test_fetch_attribute_values_composition(client, project, experiment_identifi
 @pytest.mark.parametrize(
     "exp_limit,attr_limit,success",
     [
-        (1, len(LONG_PATH_SERIES), True),  # no known limit
-        (2, 2043, True),
-        (2, len(LONG_PATH_SERIES), False),
-        (3, 2043, True),
-        (3, len(LONG_PATH_SERIES), False),
+        (1, 2000, True),
+        (1, 2001, False),
+        (2, 1000, True),
+        (2, 1001, False),
+        (3, 666, True),
+        (3, 667, False),
     ],
 )
 def test_fetch_string_series_values_retrieval(client, project, experiment_identifiers, exp_limit, attr_limit, success):


### PR DESCRIPTION
## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Migrate to the new series API for fetching string series values, update tests to reflect revised limits, and switch the Neptune API dependency to the dev/histograms branch.

Enhancements:
- Pass use_deprecated_string_fields=False when requesting series values to use the new API.
- Process series data using the new seriesValues field and object.stringValue property.

Build:
- Update neptune-api dependency in pyproject.toml to point at the dev/histograms Git branch.

Tests:
- Adjust parameterized limits in string series retrieval tests to fixed numeric thresholds instead of dynamic series lengths.