### PR TITLE
chore: update neptune-api to >=0.15.0,<0.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ pattern = "default-unprefixed"
 python = "^3.9"
 
 # Base neptune package
-neptune-api = "^0.15.0"
+neptune-api = ">=0.15.0,<0.17.0"
 azure-storage-blob = "^12.7.0"
 pandas = { version = ">=1.4.0" }
 

--- a/tests/e2e/alpha/internal/test_attributes.py
+++ b/tests/e2e/alpha/internal/test_attributes.py
@@ -182,7 +182,7 @@ def test_list_attributes_depending_on_values_in_experiments(attribute_filter, ex
             r"sys/(name|id)",
             {"sys/name", "sys/id"},
         ),
-        (r"sys/.*id$", {"sys/custom_run_id", "sys/id"}),
+        (r"sys/.*id$", {"sys/custom_run_id", "sys/id", "sys/diagnostics/project_uuid", "sys/diagnostics/run_uuid"}),
         (AttributeFilter(name_matches_all=r"sys/(name|id)"), {"sys/name", "sys/id"}),
     ],
 )


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Restrict neptune-api dependency in pyproject.toml to  3e=0.15.0,<0.17.0