### PR TITLE
WIP

### DIFF
--- a/src/neptune_fetcher/alpha/__init__.py
+++ b/src/neptune_fetcher/alpha/__init__.py
@@ -37,7 +37,9 @@ from typing import (
 
 import pandas as _pandas
 
-from neptune_fetcher.internal import filters as _filters
+from neptune_fetcher.alpha import filters as _filters
+from neptune_fetcher.alpha.internal._filter_translation import filter_to_internal_filter, \
+    attribute_filter_to_internal_attribute_filter, attribute_to_internal_attribute
 from neptune_fetcher.internal import util as _util
 from neptune_fetcher.internal.composition import download_files as _download_files
 from neptune_fetcher.internal.composition import fetch_metrics as _fetch_metrics
@@ -100,7 +102,9 @@ def list_attributes(
     attributes = _util.resolve_attributes_filter(attributes)
 
     return _list_attributes.list_attributes(
-        experiments, attributes, context, container_type=_search.ContainerType.EXPERIMENT
+        filter_=filter_to_internal_filter(experiments),
+        attributes=attribute_filter_to_internal_attribute_filter(attributes),
+        context=context, container_type=_search.ContainerType.EXPERIMENT
     )
 
 
@@ -147,8 +151,8 @@ def fetch_metrics(
     attributes = _util.resolve_attributes_filter(attributes, forced_type=["float_series"])
 
     return _fetch_metrics.fetch_metrics(
-        filter_=experiments_,
-        attributes=attributes,
+        filter_=filter_to_internal_filter(experiments_),
+        attributes=attribute_filter_to_internal_attribute_filter(attributes),
         include_time=include_time,
         step_range=step_range,
         lineage_to_the_root=lineage_to_the_root,
@@ -196,9 +200,9 @@ def fetch_experiments_table(
     sort_by = _util.resolve_sort_by(sort_by)
 
     return _fetch_table.fetch_table(
-        filter_=experiments,
-        attributes=attributes,
-        sort_by=sort_by,
+        filter_=filter_to_internal_filter(experiments),
+        attributes=attribute_filter_to_internal_attribute_filter(attributes),
+        sort_by=attribute_to_internal_attribute(sort_by),
         sort_direction=sort_direction,
         limit=limit,
         type_suffix_in_column_names=type_suffix_in_column_names,
@@ -245,8 +249,8 @@ def fetch_series(
     attributes = _util.resolve_attributes_filter(attributes, forced_type=["string_series"])
 
     return _fetch_series.fetch_series(
-        filter_=experiments_,
-        attributes=attributes,
+        filter_=filter_to_internal_filter(experiments_),
+        attributes=attribute_filter_to_internal_attribute_filter(attributes),
         include_time=include_time,
         step_range=step_range,
         lineage_to_the_root=lineage_to_the_root,
@@ -286,8 +290,8 @@ def download_files(
     destination_path = _util.resolve_destination_path(destination)
 
     return _download_files.download_files(
-        filter_=experiments,
-        attributes=attributes,
+        filter_=filter_to_internal_filter(experiments),
+        attributes=attribute_filter_to_internal_attribute_filter(attributes),
         destination=destination_path,
         context=context,
         container_type=_search.ContainerType.EXPERIMENT,

--- a/src/neptune_fetcher/alpha/filters.py
+++ b/src/neptune_fetcher/alpha/filters.py
@@ -12,12 +12,399 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# src/neptune_fetcher/alpha/filters.py
-
-from neptune_fetcher.internal.filters import (
-    Attribute,
-    AttributeFilter,
-    Filter,
+import abc
+from abc import ABC
+from dataclasses import (
+    dataclass,
+    field,
+)
+from datetime import datetime
+from typing import (
+    Iterable,
+    Literal,
+    Optional,
+    Union,
 )
 
-__all__ = ["Attribute", "AttributeFilter", "Filter"]
+from neptune_fetcher.internal.retrieval import attribute_types as types
+
+__all__ = ["Filter", "AttributeFilter", "Attribute"]
+
+
+ATTRIBUTE_LITERAL = Literal[
+    "float", "int", "string", "bool", "datetime", "float_series", "string_set", "string_series", "file"
+]
+AGGREGATION_LITERAL = Literal["last", "min", "max", "average", "variance"]
+
+
+class BaseAttributeFilter(ABC):
+    def __or__(self, other: "BaseAttributeFilter") -> "BaseAttributeFilter":
+        return BaseAttributeFilter.any(self, other)
+
+    def any(*filters: "BaseAttributeFilter") -> "BaseAttributeFilter":
+        return _AttributeFilterAlternative(filters=filters)
+
+
+@dataclass
+class AttributeFilter(BaseAttributeFilter):
+    """Filter to apply to attributes when fetching runs or experiments.
+
+    Use to select specific metrics or other metadata based on various criteria.
+
+    Args:
+        name_eq (Union[str, list[str], None]): An attribute name or list of names to match exactly.
+            If `None`, this filter is not applied.
+        type_in (list[Literal["float", "int", "string", "bool", "datetime", "float_series", "string_set",
+        "string_series", "file"]]):
+            A list of allowed attribute types. Defaults to all available types.
+            For a reference, see: https://docs-beta.neptune.ai/attribute_types
+        name_matches_all (Union[str, list[str], None]): A regular expression or list of expressions that the attribute
+            name must match. If `None`, this filter is not applied.
+        name_matches_none (Union[str, list[str], None]): A regular expression or list of expressions that the attribute
+            names mustn't match. Attributes matching any of the regexes are excluded.
+            If `None`, this filter is not applied.
+        aggregations (list[Literal["last", "min", "max", "average", "variance"]]): List of
+            aggregation functions to apply when fetching metrics of type FloatSeries or StringSeries.
+            Defaults to ["last"].
+
+    Example:
+
+    ```
+    import neptune_fetcher.alpha as npt
+    from neptune_fetcher.alpha.filters import AttributeFilter
+
+
+    loss_avg_and_var = AttributeFilter(
+        type_in=["float_series"],
+        name_matches_all=[r"loss$"],
+        aggregations=["average", "variance"],
+    )
+
+    npt.fetch_experiments_table(attributes=loss_avg_and_var)
+    ```
+    """
+
+    name_eq: Union[str, list[str], None] = None
+    type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(types.ALL_TYPES))  # type: ignore
+    name_matches_all: Union[str, list[str], None] = None
+    name_matches_none: Union[str, list[str], None] = None
+    aggregations: list[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
+
+    def __post_init__(self) -> None:
+        _validate_string_or_string_list(self.name_eq, "name_eq")
+        _validate_string_or_string_list(self.name_matches_all, "name_matches_all")
+        _validate_string_or_string_list(self.name_matches_none, "name_matches_none")
+
+        _validate_list_of_allowed_values(self.type_in, types.ALL_TYPES, "type_in")  # type: ignore
+        _validate_list_of_allowed_values(self.aggregations, types.ALL_AGGREGATIONS, "aggregations")  # type: ignore
+
+
+@dataclass
+class _AttributeFilterAlternative(BaseAttributeFilter):
+    filters: Iterable[BaseAttributeFilter]
+
+    def __or__(self, other: "BaseAttributeFilter") -> "BaseAttributeFilter":
+        filters = tuple(self.filters) + (other,)
+        return _AttributeFilterAlternative(filters)
+
+
+@dataclass
+class Attribute:
+    """Helper for specifying an attribute and picking a metric aggregation function.
+
+    When fetching experiments or runs, use this class to filter and sort the returned entries.
+
+    Args:
+        name (str): An attribute name to match exactly.
+        aggregation (Literal["last", "min", "max", "average", "variance"], optional):
+            Aggregation function to apply when specifying a metric of type FloatSeries.
+            Defaults to `"last"`, i.e. the last logged value.
+        type (Literal["float", "int", "string", "bool", "datetime", "float_series", "string_set"], optional):
+            Attribute type. Specify it to resolve ambiguity, in case some of the project's runs contain attributes
+            that have the same name but are of a different type.
+            For a reference, see: https://docs-beta.neptune.ai/attribute_types
+
+    Example:
+
+    Select a metric and pick variance as the aggregation:
+
+    ```
+    import neptune_fetcher.alpha as npt
+    from neptune_fetcher.alpha.filters import Attribute, Filter
+
+
+    val_loss_variance = Attribute(
+        name="val/loss",
+        aggregation="variance",
+    )
+    # Construct a filter and pass it to a fetching or listing method
+    tiny_val_loss_variance = Filter.lt(val_loss_variance, 0.01)
+    npt.fetch_experiments_table(experiments=tiny_val_loss_variance)
+    ```
+    """
+
+    name: str
+    aggregation: Optional[AGGREGATION_LITERAL] = None
+    type: Optional[ATTRIBUTE_LITERAL] = None
+
+    def __post_init__(self) -> None:
+        _validate_allowed_value(self.aggregation, types.ALL_AGGREGATIONS, "aggregation")
+        _validate_allowed_value(self.type, types.ALL_TYPES, "type")  # type: ignore
+
+    def to_query(self) -> str:
+        query = f"`{self.name}`"
+
+        if self.type is not None:
+            _type = types.map_attribute_type_python_to_backend(self.type)
+            query += f":{_type}"
+
+        if self.aggregation is not None:
+            query = f"{self.aggregation}({query})"
+
+        return query
+
+    def __str__(self) -> str:
+        return self.to_query()
+
+
+class Filter(ABC):
+    """Filter used to specify criteria when fetching experiments or runs.
+
+    Examples of filters:
+        - Name or attribute must match regular expression.
+        - Attribute value must pass a condition, like "greater than 0.9".
+
+    You can negate a filter or join multiple filters with logical operators.
+
+    Methods available for attribute values:
+    - `name_eq()`: Run or experiment name equals
+    - `name_in()`: Run or experiment name equals any of the provided names
+    - `eq()`: Value equals
+    - `ne()`: Value doesn't equal
+    - `gt()`: Value is greater than
+    - `ge()`: Value is greater than or equal to
+    - `lt()`: Value is less than
+    - `le()`: Value is less than or equal to
+    - `matches_all()`: Value matches regex or all in list of regexes
+    - `matches_none()`: Value doesn't match regex or any of list of regexes
+    - `contains_all()`: Tagset contains all tags, or string contains substrings
+    - `contains_none()`: Tagset doesn't contain any of the tags, or string doesn't contain the substrings
+    - `exists()`: Attribute exists
+
+    Examples:
+
+    ```
+    import neptune_fetcher.alpha as npt
+    from neptune_fetcher.alpha.filters import Filter
+
+    # Fetch metadata from specific experiments
+    specific_experiments = Filter.name_in("flying-123", "swimming-77")
+    npt.fetch_experiments_table(experiments=specific_experiments)
+
+    # Define various criteria
+    owned_by_me = Filter.eq("sys/owner", "vidar")
+    loss_filter = Filter.lt("validation/loss", 0.1)
+    tag_filter = Filter.contains_none("sys/tags", ["test", "buggy"])
+    dataset_check = Filter.exists("dataset_version")
+
+    my_interesting_experiments = owned_by_me & loss_filter & tag_filter & dataset_check
+    npt.fetch_experiments_table(experiments=my_interesting_experiments)
+    ```
+    """
+
+    @staticmethod
+    def eq(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        return _AttributeValuePredicate(operator="==", attribute=attribute, value=value)
+
+    @staticmethod
+    def ne(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        return _AttributeValuePredicate(operator="!=", attribute=attribute, value=value)
+
+    @staticmethod
+    def gt(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        return _AttributeValuePredicate(operator=">", attribute=attribute, value=value)
+
+    @staticmethod
+    def ge(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        return _AttributeValuePredicate(operator=">=", attribute=attribute, value=value)
+
+    @staticmethod
+    def lt(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        return _AttributeValuePredicate(operator="<", attribute=attribute, value=value)
+
+    @staticmethod
+    def le(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        return _AttributeValuePredicate(operator="<=", attribute=attribute, value=value)
+
+    @staticmethod
+    def matches_all(attribute: Union[str, Attribute], regex: Union[str, list[str]]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        if isinstance(regex, str):
+            return _AttributeValuePredicate(operator="MATCHES", attribute=attribute, value=regex)
+        else:
+            filters = [Filter.matches_all(attribute, r) for r in regex]
+            return Filter.all(*filters)
+
+    @staticmethod
+    def matches_none(attribute: Union[str, Attribute], regex: Union[str, list[str]]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        if isinstance(regex, str):
+            return _AttributeValuePredicate(operator="NOT MATCHES", attribute=attribute, value=regex)
+        else:
+            filters = [Filter.matches_none(attribute, r) for r in regex]
+            return Filter.all(*filters)
+
+    @staticmethod
+    def contains_all(attribute: Union[str, Attribute], value: Union[str, list[str]]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        if isinstance(value, str):
+            return _AttributeValuePredicate(operator="CONTAINS", attribute=attribute, value=value)
+        else:
+            filters = [Filter.contains_all(attribute, v) for v in value]
+            return Filter.all(*filters)
+
+    @staticmethod
+    def contains_none(attribute: Union[str, Attribute], value: Union[str, list[str]]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        if isinstance(value, str):
+            return _AttributeValuePredicate(operator="NOT CONTAINS", attribute=attribute, value=value)
+        else:
+            filters = [Filter.contains_none(attribute, v) for v in value]
+            return Filter.all(*filters)
+
+    @staticmethod
+    def exists(attribute: Union[str, Attribute]) -> "Filter":
+        if isinstance(attribute, str):
+            attribute = Attribute(name=attribute)
+        return _AttributePredicate(postfix_operator="EXISTS", attribute=attribute)
+
+    @staticmethod
+    def all(*filters: "Filter") -> "Filter":
+        return _AssociativeOperator(operator="AND", filters=filters)
+
+    @staticmethod
+    def any(*filters: "Filter") -> "Filter":
+        return _AssociativeOperator(operator="OR", filters=filters)
+
+    @staticmethod
+    def negate(filter_: "Filter") -> "Filter":
+        return _PrefixOperator(operator="NOT", filter_=filter_)
+
+    def __and__(self, other: "Filter") -> "Filter":
+        return self.all(self, other)
+
+    def __or__(self, other: "Filter") -> "Filter":
+        return self.any(self, other)
+
+    def __invert__(self) -> "Filter":
+        return self.negate(self)
+
+    @staticmethod
+    def name_eq(name: str) -> "Filter":
+        name_attribute = Attribute(name="sys/name", type="string")
+        return Filter.eq(name_attribute, name)
+
+    @staticmethod
+    def name_in(*names: str) -> "Filter":
+        if len(names) == 1:
+            return Filter.name_eq(names[0])
+        else:
+            filters = [Filter.name_eq(name) for name in names]
+            return Filter.any(*filters)
+
+    @abc.abstractmethod
+    def to_query(self) -> str:
+        ...
+
+    def __str__(self) -> str:
+        return self.to_query()
+
+
+@dataclass
+class _AttributeValuePredicate(Filter):
+    operator: Literal["==", "!=", ">", ">=", "<", "<=", "MATCHES", "NOT MATCHES", "CONTAINS", "NOT CONTAINS"]
+    attribute: Attribute
+    value: Union[bool, int, float, str, datetime]
+
+    def __post_init__(self) -> None:
+        allowed_operators = {"==", "!=", ">", ">=", "<", "<=", "MATCHES", "NOT MATCHES", "CONTAINS", "NOT CONTAINS"}
+        _validate_allowed_value(self.operator, allowed_operators, "operator")
+
+        if not isinstance(self.value, (bool, int, float, str, datetime)):
+            raise TypeError(f"Invalid value type: {type(self.value).__name__}. Expected int, float, str, or datetime.")
+
+    def to_query(self) -> str:
+        return f"{self.attribute} {self.operator} {self._right_query()}"
+
+    def _right_query(self) -> str:
+        if isinstance(self.value, datetime):
+            return f'"{self.value.astimezone().isoformat()}"'
+        value = str(self.value)
+        value = value.replace("\\", r"\\").replace('"', r"\"")
+        return f'"{value}"'
+
+
+@dataclass
+class _AttributePredicate(Filter):
+    postfix_operator: Literal["EXISTS"]
+    attribute: Attribute
+
+    def to_query(self) -> str:
+        return f"{self.attribute} {self.postfix_operator}"
+
+
+@dataclass
+class _AssociativeOperator(Filter):
+    operator: Literal["AND", "OR"]
+    filters: Iterable[Filter]
+
+    def to_query(self) -> str:
+        filter_queries = [f"({child})" for child in self.filters]
+        return f" {self.operator} ".join(filter_queries)
+
+
+@dataclass
+class _PrefixOperator(Filter):
+    operator: Literal["NOT"]
+    filter_: Filter
+
+    def to_query(self) -> str:
+        return f"{self.operator} ({self.filter_})"
+
+
+def _validate_string_or_string_list(value: Optional[Union[str, list[str]]], field_name: str) -> None:
+    """Validate that a value is either None, a string, or a list of strings."""
+    if value is not None:
+        if isinstance(value, list):
+            if not all(isinstance(item, str) for item in value):
+                raise ValueError(f"{field_name} must be a string or list of strings")
+        elif not isinstance(value, str):
+            raise ValueError(f"{field_name} must be a string or list of strings")
+
+
+def _validate_list_of_allowed_values(value: list[str], allowed_values: set[str], field_name: str) -> None:
+    """Validate that a value is a list containing only allowed values."""
+    if not isinstance(value, list) or not all(isinstance(v, str) and v in allowed_values for v in value):
+        raise ValueError(f"{field_name} must be a list of valid values: {sorted(allowed_values)}")
+
+
+def _validate_allowed_value(value: Optional[str], allowed_values: set[str], field_name: str) -> None:
+    """Validate that a value is either None or one of the allowed values."""
+    if value is not None and (not isinstance(value, str) or value not in allowed_values):
+        raise ValueError(f"{field_name} must be one of: {sorted(allowed_values)}")

--- a/src/neptune_fetcher/alpha/internal/_filter_translation.py
+++ b/src/neptune_fetcher/alpha/internal/_filter_translation.py
@@ -1,0 +1,14 @@
+from neptune_fetcher.alpha.filters import Filter, AttributeFilter, Attribute
+from neptune_fetcher.internal.filters import FilterInternal, AttributeFilterInternal, AttributeInternal
+
+
+def filter_to_internal_filter(f: Filter) -> FilterInternal:
+    ...
+
+
+def attribute_filter_to_internal_attribute_filter(af: AttributeFilter) -> AttributeFilterInternal:
+    ...
+
+
+def attribute_to_internal_attribute(a: Attribute) -> AttributeInternal:
+    ...

--- a/src/neptune_fetcher/alpha/runs.py
+++ b/src/neptune_fetcher/alpha/runs.py
@@ -32,7 +32,7 @@ from typing import (
 import pandas as _pandas
 
 from neptune_fetcher.internal import context as _context
-from neptune_fetcher.internal import filters as _filters
+from neptune_fetcher.alpha import filters as _filters
 from neptune_fetcher.internal import util as _util
 from neptune_fetcher.internal.composition import download_files as _download_files
 from neptune_fetcher.internal.composition import fetch_metrics as _fetch_metrics

--- a/src/neptune_fetcher/internal/composition/attribute_components.py
+++ b/src/neptune_fetcher/internal/composition/attribute_components.py
@@ -41,7 +41,7 @@ from neptune_fetcher.internal.retrieval import (
 def fetch_attribute_definitions_split(
     client: AuthenticatedClient,
     project_identifier: identifiers.ProjectIdentifier,
-    attribute_filter: filters.BaseAttributeFilter,
+    attribute_filter: filters.InternalBaseAttributeFilter,
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
     sys_ids: list[identifiers.SysId],
@@ -67,7 +67,7 @@ def fetch_attribute_definitions_split(
 def fetch_attribute_definition_aggregations_split(
     client: AuthenticatedClient,
     project_identifier: identifiers.ProjectIdentifier,
-    attribute_filter: filters.BaseAttributeFilter,
+    attribute_filter: filters.InternalBaseAttributeFilter,
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
     sys_ids: list[identifiers.SysId],
@@ -96,8 +96,8 @@ def fetch_attribute_definition_aggregations_split(
 def fetch_attribute_definitions_complete(
     client: AuthenticatedClient,
     project_identifier: identifiers.ProjectIdentifier,
-    filter_: Optional[filters.Filter],
-    attribute_filter: filters.BaseAttributeFilter,
+    filter_: Optional[filters.FilterInternal],
+    attribute_filter: filters.InternalBaseAttributeFilter,
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
     container_type: search.ContainerType,

--- a/src/neptune_fetcher/internal/composition/attributes.py
+++ b/src/neptune_fetcher/internal/composition/attributes.py
@@ -45,7 +45,7 @@ def fetch_attribute_definitions(
     client: AuthenticatedClient,
     project_identifiers: Iterable[identifiers.ProjectIdentifier],
     run_identifiers: Optional[Iterable[identifiers.RunIdentifier]],
-    attribute_filter: filters.BaseAttributeFilter,
+    attribute_filter: filters.InternalBaseAttributeFilter,
     executor: Executor,
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_DEFINITIONS_BATCH_SIZE.get(),
 ) -> Generator[util.Page[att_defs.AttributeDefinition], None, None]:
@@ -64,7 +64,7 @@ def fetch_attribute_definition_aggregations(
     client: AuthenticatedClient,
     project_identifiers: Iterable[identifiers.ProjectIdentifier],
     run_identifiers: Iterable[identifiers.RunIdentifier],
-    attribute_filter: filters.BaseAttributeFilter,
+    attribute_filter: filters.InternalBaseAttributeFilter,
     executor: Executor,
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_DEFINITIONS_BATCH_SIZE.get(),
 ) -> Generator[tuple[util.Page[att_defs.AttributeDefinition], util.Page[AttributeDefinitionAggregation]], None, None]:
@@ -109,12 +109,12 @@ def _fetch_attribute_definitions(
     client: AuthenticatedClient,
     project_identifiers: Iterable[identifiers.ProjectIdentifier],
     run_identifiers: Optional[Iterable[identifiers.RunIdentifier]],
-    attribute_filter: filters.BaseAttributeFilter,
+    attribute_filter: filters.InternalBaseAttributeFilter,
     batch_size: int,
     executor: Executor,
-) -> Generator[tuple[util.Page[att_defs.AttributeDefinition], filters.AttributeFilter], None, None]:
+) -> Generator[tuple[util.Page[att_defs.AttributeDefinition], filters.AttributeFilterInternal], None, None]:
     def go_fetch_single(
-        filter_: filters.AttributeFilter,
+        filter_: filters.AttributeFilterInternal,
     ) -> Generator[util.Page[att_defs.AttributeDefinition], None, None]:
         return att_defs.fetch_attribute_definitions_single_filter(
             client=client,

--- a/src/neptune_fetcher/internal/composition/download_files.py
+++ b/src/neptune_fetcher/internal/composition/download_files.py
@@ -37,8 +37,8 @@ from neptune_fetcher.internal.context import (
     validate_context,
 )
 from neptune_fetcher.internal.filters import (
-    AttributeFilter,
-    Filter,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.retrieval import (
     attribute_definitions,
@@ -49,8 +49,8 @@ from neptune_fetcher.internal.retrieval.search import ContainerType
 
 
 def download_files(
-    filter_: Optional[Filter],
-    attributes: AttributeFilter,
+    filter_: Optional[FilterInternal],
+    attributes: AttributeFilterInternal,
     destination: pathlib.Path,
     context: Optional[Context],
     container_type: ContainerType,

--- a/src/neptune_fetcher/internal/composition/fetch_metrics.py
+++ b/src/neptune_fetcher/internal/composition/fetch_metrics.py
@@ -41,8 +41,8 @@ from neptune_fetcher.internal.context import (
     validate_context,
 )
 from neptune_fetcher.internal.filters import (
-    AttributeFilter,
-    Filter,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.identifiers import RunIdentifier as ExpId
 from neptune_fetcher.internal.output_format import create_metrics_dataframe
@@ -66,8 +66,8 @@ _PATHS_PER_BATCH: int = 10_000
 
 
 def fetch_metrics(
-    filter_: Filter,
-    attributes: AttributeFilter,
+    filter_: FilterInternal,
+    attributes: AttributeFilterInternal,
     include_time: Optional[Literal["absolute"]],
     step_range: Tuple[Optional[float], Optional[float]],
     lineage_to_the_root: bool,
@@ -157,8 +157,8 @@ def _validate_include_time(include_time: Optional[Literal["absolute"]]) -> None:
 
 
 def _fetch_flat_dataframe_metrics(
-    filter_: Filter,
-    attributes: AttributeFilter,
+    filter_: FilterInternal,
+    attributes: AttributeFilterInternal,
     client: AuthenticatedClient,
     project: identifiers.ProjectIdentifier,
     executor: Executor,

--- a/src/neptune_fetcher/internal/composition/fetch_series.py
+++ b/src/neptune_fetcher/internal/composition/fetch_series.py
@@ -34,8 +34,8 @@ from neptune_fetcher.internal.context import (
     validate_context,
 )
 from neptune_fetcher.internal.filters import (
-    AttributeFilter,
-    Filter,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.output_format import create_series_dataframe
 from neptune_fetcher.internal.retrieval import (
@@ -49,8 +49,8 @@ __all__ = ("fetch_series",)
 
 
 def fetch_series(
-    filter_: Filter,
-    attributes: AttributeFilter,
+    filter_: FilterInternal,
+    attributes: AttributeFilterInternal,
     include_time: Optional[Literal["absolute"]],
     step_range: Tuple[Optional[float], Optional[float]],
     lineage_to_the_root: bool,

--- a/src/neptune_fetcher/internal/composition/fetch_table.py
+++ b/src/neptune_fetcher/internal/composition/fetch_table.py
@@ -35,9 +35,9 @@ from neptune_fetcher.internal.composition import (
 )
 from neptune_fetcher.internal.composition.attributes import AttributeDefinitionAggregation
 from neptune_fetcher.internal.filters import (
-    Attribute,
-    AttributeFilter,
-    Filter,
+    AttributeInternal,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.retrieval import attribute_definitions as att_defs
 from neptune_fetcher.internal.retrieval import attribute_values as att_vals
@@ -50,9 +50,9 @@ __all__ = ("fetch_table",)
 
 
 def fetch_table(
-    filter_: Optional[Filter],
-    attributes: AttributeFilter,
-    sort_by: Attribute,
+    filter_: Optional[FilterInternal],
+    attributes: AttributeFilterInternal,
+    sort_by: AttributeInternal,
     sort_direction: Literal["asc", "desc"],
     limit: Optional[int],
     type_suffix_in_column_names: bool,

--- a/src/neptune_fetcher/internal/composition/list_attributes.py
+++ b/src/neptune_fetcher/internal/composition/list_attributes.py
@@ -34,8 +34,8 @@ from neptune_fetcher.internal.context import (
     validate_context,
 )
 from neptune_fetcher.internal.filters import (
-    AttributeFilter,
-    Filter,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.retrieval import attribute_definitions as att_defs
 from neptune_fetcher.internal.retrieval import (
@@ -45,8 +45,8 @@ from neptune_fetcher.internal.retrieval import (
 
 
 def list_attributes(
-    filter_: Optional[Filter],
-    attributes: AttributeFilter,
+    filter_: Optional[FilterInternal],
+    attributes: AttributeFilterInternal,
     context: Optional[Context],
     container_type: search.ContainerType,
 ) -> list[str]:

--- a/src/neptune_fetcher/internal/composition/list_containers.py
+++ b/src/neptune_fetcher/internal/composition/list_containers.py
@@ -21,14 +21,14 @@ from neptune_fetcher.internal.composition import (
     concurrency,
     type_inference,
 )
-from neptune_fetcher.internal.filters import Filter
+from neptune_fetcher.internal.filters import FilterInternal
 from neptune_fetcher.internal.retrieval import search
 
 __all__ = ("list_containers",)
 
 
 def list_containers(
-    filter_: Optional[Filter],
+    filter_: Optional[FilterInternal],
     context: Optional[_context.Context],
     container_type: search.ContainerType,
 ) -> list[str]:

--- a/src/neptune_fetcher/internal/composition/type_inference.py
+++ b/src/neptune_fetcher/internal/composition/type_inference.py
@@ -44,7 +44,7 @@ from neptune_fetcher.internal.retrieval.attribute_types import (
 def infer_attribute_types_in_filter(
     client: AuthenticatedClient,
     project_identifier: identifiers.ProjectIdentifier,
-    filter_: Optional[filters.Filter],
+    filter_: Optional[filters.FilterInternal],
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
     container_type: search.ContainerType = search.ContainerType.EXPERIMENT,  # TODO: remove the default
@@ -78,8 +78,8 @@ def infer_attribute_types_in_filter(
 def infer_attribute_types_in_sort_by(
     client: AuthenticatedClient,
     project_identifier: identifiers.ProjectIdentifier,
-    filter_: Optional[filters.Filter],
-    sort_by: filters.Attribute,
+    filter_: Optional[filters.FilterInternal],
+    sort_by: filters.AttributeInternal,
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
     container_type: search.ContainerType = search.ContainerType.EXPERIMENT,  # TODO: remove the default
@@ -108,7 +108,7 @@ def infer_attribute_types_in_sort_by(
 
 
 def _infer_attribute_types_from_attribute(
-    attributes: Iterable[filters.Attribute],
+    attributes: Iterable[filters.AttributeInternal],
 ) -> None:
     for attribute in attributes:
         matches = []
@@ -123,13 +123,13 @@ def _infer_attribute_types_from_attribute(
 def _infer_attribute_types_from_api(
     client: AuthenticatedClient,
     project_identifier: identifiers.ProjectIdentifier,
-    filter_: Optional[filters.Filter],
-    attributes: Iterable[filters.Attribute],
+    filter_: Optional[filters.FilterInternal],
+    attributes: Iterable[filters.AttributeInternal],
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
     container_type: search.ContainerType,
 ) -> None:
-    attribute_filter_by_name = filters.AttributeFilter(name_eq=list({attr.name for attr in attributes}))
+    attribute_filter_by_name = filters.AttributeFilterInternal(name_eq=list({attr.name for attr in attributes}))
 
     output = _components.fetch_attribute_definitions_complete(
         client=client,
@@ -161,20 +161,20 @@ def _infer_attribute_types_from_api(
 
 
 def _filter_untyped(
-    attributes: Iterable[filters.Attribute],
-) -> list[filters.Attribute]:
+    attributes: Iterable[filters.AttributeInternal],
+) -> list[filters.AttributeInternal]:
     return [attr for attr in attributes if attr.type is None]
 
 
-def _walk_attributes(experiment_filter: filters.Filter) -> Iterable[filters.Attribute]:
-    if isinstance(experiment_filter, filters._AttributeValuePredicate):
+def _walk_attributes(experiment_filter: filters.FilterInternal) -> Iterable[filters.AttributeInternal]:
+    if isinstance(experiment_filter, filters._AttributeValuePredicateInternal):
         yield experiment_filter.attribute
-    elif isinstance(experiment_filter, filters._AttributePredicate):
+    elif isinstance(experiment_filter, filters._AttributePredicateInternal):
         yield experiment_filter.attribute
-    elif isinstance(experiment_filter, filters._AssociativeOperator):
+    elif isinstance(experiment_filter, filters._AssociativeOperatorInternal):
         for child in experiment_filter.filters:
             yield from _walk_attributes(child)
-    elif isinstance(experiment_filter, filters._PrefixOperator):
+    elif isinstance(experiment_filter, filters._PrefixOperatorInternal):
         yield from _walk_attributes(experiment_filter.filter_)
     else:
         raise RuntimeError(f"Unexpected filter type: {type(experiment_filter)}")

--- a/src/neptune_fetcher/internal/filters.py
+++ b/src/neptune_fetcher/internal/filters.py
@@ -28,7 +28,7 @@ from typing import (
 
 from neptune_fetcher.internal.retrieval import attribute_types as types
 
-__all__ = ["Filter", "AttributeFilter", "Attribute"]
+__all__ = ["FilterInternal", "AttributeFilterInternal", "AttributeInternal"]
 
 
 ATTRIBUTE_LITERAL = Literal[
@@ -37,16 +37,16 @@ ATTRIBUTE_LITERAL = Literal[
 AGGREGATION_LITERAL = Literal["last", "min", "max", "average", "variance"]
 
 
-class BaseAttributeFilter(ABC):
-    def __or__(self, other: "BaseAttributeFilter") -> "BaseAttributeFilter":
-        return BaseAttributeFilter.any(self, other)
+class InternalBaseAttributeFilter(ABC):
+    def __or__(self, other: "InternalBaseAttributeFilter") -> "InternalBaseAttributeFilter":
+        return InternalBaseAttributeFilter.any(self, other)
 
-    def any(*filters: "BaseAttributeFilter") -> "BaseAttributeFilter":
-        return _AttributeFilterAlternative(filters=filters)
+    def any(*filters: "InternalBaseAttributeFilter") -> "InternalBaseAttributeFilter":
+        return _AttributeFilterAlternativeInternal(filters=filters)
 
 
 @dataclass
-class AttributeFilter(BaseAttributeFilter):
+class AttributeFilterInternal(InternalBaseAttributeFilter):
     """Filter to apply to attributes when fetching runs or experiments.
 
     Use to select specific metrics or other metadata based on various criteria.
@@ -100,16 +100,16 @@ class AttributeFilter(BaseAttributeFilter):
 
 
 @dataclass
-class _AttributeFilterAlternative(BaseAttributeFilter):
-    filters: Iterable[BaseAttributeFilter]
+class _AttributeFilterAlternativeInternal(InternalBaseAttributeFilter):
+    filters: Iterable[InternalBaseAttributeFilter]
 
-    def __or__(self, other: "BaseAttributeFilter") -> "BaseAttributeFilter":
+    def __or__(self, other: "InternalBaseAttributeFilter") -> "InternalBaseAttributeFilter":
         filters = tuple(self.filters) + (other,)
-        return _AttributeFilterAlternative(filters)
+        return _AttributeFilterAlternativeInternal(filters)
 
 
 @dataclass
-class Attribute:
+class AttributeInternal:
     """Helper for specifying an attribute and picking a metric aggregation function.
 
     When fetching experiments or runs, use this class to filter and sort the returned entries.
@@ -167,7 +167,7 @@ class Attribute:
         return self.to_query()
 
 
-class Filter(ABC):
+class FilterInternal(ABC):
     """Filter used to specify criteria when fetching experiments or runs.
 
     Examples of filters:
@@ -213,120 +213,120 @@ class Filter(ABC):
     """
 
     @staticmethod
-    def eq(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+    def eq(attribute: Union[str, AttributeInternal], value: Union[int, float, str, datetime]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
-        return _AttributeValuePredicate(operator="==", attribute=attribute, value=value)
+            attribute = AttributeInternal(name=attribute)
+        return _AttributeValuePredicateInternal(operator="==", attribute=attribute, value=value)
 
     @staticmethod
-    def ne(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+    def ne(attribute: Union[str, AttributeInternal], value: Union[int, float, str, datetime]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
-        return _AttributeValuePredicate(operator="!=", attribute=attribute, value=value)
+            attribute = AttributeInternal(name=attribute)
+        return _AttributeValuePredicateInternal(operator="!=", attribute=attribute, value=value)
 
     @staticmethod
-    def gt(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+    def gt(attribute: Union[str, AttributeInternal], value: Union[int, float, str, datetime]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
-        return _AttributeValuePredicate(operator=">", attribute=attribute, value=value)
+            attribute = AttributeInternal(name=attribute)
+        return _AttributeValuePredicateInternal(operator=">", attribute=attribute, value=value)
 
     @staticmethod
-    def ge(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+    def ge(attribute: Union[str, AttributeInternal], value: Union[int, float, str, datetime]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
-        return _AttributeValuePredicate(operator=">=", attribute=attribute, value=value)
+            attribute = AttributeInternal(name=attribute)
+        return _AttributeValuePredicateInternal(operator=">=", attribute=attribute, value=value)
 
     @staticmethod
-    def lt(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+    def lt(attribute: Union[str, AttributeInternal], value: Union[int, float, str, datetime]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
-        return _AttributeValuePredicate(operator="<", attribute=attribute, value=value)
+            attribute = AttributeInternal(name=attribute)
+        return _AttributeValuePredicateInternal(operator="<", attribute=attribute, value=value)
 
     @staticmethod
-    def le(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
+    def le(attribute: Union[str, AttributeInternal], value: Union[int, float, str, datetime]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
-        return _AttributeValuePredicate(operator="<=", attribute=attribute, value=value)
+            attribute = AttributeInternal(name=attribute)
+        return _AttributeValuePredicateInternal(operator="<=", attribute=attribute, value=value)
 
     @staticmethod
-    def matches_all(attribute: Union[str, Attribute], regex: Union[str, list[str]]) -> "Filter":
+    def matches_all(attribute: Union[str, AttributeInternal], regex: Union[str, list[str]]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
+            attribute = AttributeInternal(name=attribute)
         if isinstance(regex, str):
-            return _AttributeValuePredicate(operator="MATCHES", attribute=attribute, value=regex)
+            return _AttributeValuePredicateInternal(operator="MATCHES", attribute=attribute, value=regex)
         else:
-            filters = [Filter.matches_all(attribute, r) for r in regex]
-            return Filter.all(*filters)
+            filters = [FilterInternal.matches_all(attribute, r) for r in regex]
+            return FilterInternal.all(*filters)
 
     @staticmethod
-    def matches_none(attribute: Union[str, Attribute], regex: Union[str, list[str]]) -> "Filter":
+    def matches_none(attribute: Union[str, AttributeInternal], regex: Union[str, list[str]]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
+            attribute = AttributeInternal(name=attribute)
         if isinstance(regex, str):
-            return _AttributeValuePredicate(operator="NOT MATCHES", attribute=attribute, value=regex)
+            return _AttributeValuePredicateInternal(operator="NOT MATCHES", attribute=attribute, value=regex)
         else:
-            filters = [Filter.matches_none(attribute, r) for r in regex]
-            return Filter.all(*filters)
+            filters = [FilterInternal.matches_none(attribute, r) for r in regex]
+            return FilterInternal.all(*filters)
 
     @staticmethod
-    def contains_all(attribute: Union[str, Attribute], value: Union[str, list[str]]) -> "Filter":
+    def contains_all(attribute: Union[str, AttributeInternal], value: Union[str, list[str]]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
+            attribute = AttributeInternal(name=attribute)
         if isinstance(value, str):
-            return _AttributeValuePredicate(operator="CONTAINS", attribute=attribute, value=value)
+            return _AttributeValuePredicateInternal(operator="CONTAINS", attribute=attribute, value=value)
         else:
-            filters = [Filter.contains_all(attribute, v) for v in value]
-            return Filter.all(*filters)
+            filters = [FilterInternal.contains_all(attribute, v) for v in value]
+            return FilterInternal.all(*filters)
 
     @staticmethod
-    def contains_none(attribute: Union[str, Attribute], value: Union[str, list[str]]) -> "Filter":
+    def contains_none(attribute: Union[str, AttributeInternal], value: Union[str, list[str]]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
+            attribute = AttributeInternal(name=attribute)
         if isinstance(value, str):
-            return _AttributeValuePredicate(operator="NOT CONTAINS", attribute=attribute, value=value)
+            return _AttributeValuePredicateInternal(operator="NOT CONTAINS", attribute=attribute, value=value)
         else:
-            filters = [Filter.contains_none(attribute, v) for v in value]
-            return Filter.all(*filters)
+            filters = [FilterInternal.contains_none(attribute, v) for v in value]
+            return FilterInternal.all(*filters)
 
     @staticmethod
-    def exists(attribute: Union[str, Attribute]) -> "Filter":
+    def exists(attribute: Union[str, AttributeInternal]) -> "FilterInternal":
         if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
-        return _AttributePredicate(postfix_operator="EXISTS", attribute=attribute)
+            attribute = AttributeInternal(name=attribute)
+        return _AttributePredicateInternal(postfix_operator="EXISTS", attribute=attribute)
 
     @staticmethod
-    def all(*filters: "Filter") -> "Filter":
-        return _AssociativeOperator(operator="AND", filters=filters)
+    def all(*filters: "FilterInternal") -> "FilterInternal":
+        return _AssociativeOperatorInternal(operator="AND", filters=filters)
 
     @staticmethod
-    def any(*filters: "Filter") -> "Filter":
-        return _AssociativeOperator(operator="OR", filters=filters)
+    def any(*filters: "FilterInternal") -> "FilterInternal":
+        return _AssociativeOperatorInternal(operator="OR", filters=filters)
 
     @staticmethod
-    def negate(filter_: "Filter") -> "Filter":
-        return _PrefixOperator(operator="NOT", filter_=filter_)
+    def negate(filter_: "FilterInternal") -> "FilterInternal":
+        return _PrefixOperatorInternal(operator="NOT", filter_=filter_)
 
-    def __and__(self, other: "Filter") -> "Filter":
+    def __and__(self, other: "FilterInternal") -> "FilterInternal":
         return self.all(self, other)
 
-    def __or__(self, other: "Filter") -> "Filter":
+    def __or__(self, other: "FilterInternal") -> "FilterInternal":
         return self.any(self, other)
 
-    def __invert__(self) -> "Filter":
+    def __invert__(self) -> "FilterInternal":
         return self.negate(self)
 
     @staticmethod
-    def name_eq(name: str) -> "Filter":
-        name_attribute = Attribute(name="sys/name", type="string")
-        return Filter.eq(name_attribute, name)
+    def name_eq(name: str) -> "FilterInternal":
+        name_attribute = AttributeInternal(name="sys/name", type="string")
+        return FilterInternal.eq(name_attribute, name)
 
     @staticmethod
-    def name_in(*names: str) -> "Filter":
+    def name_in(*names: str) -> "FilterInternal":
         if len(names) == 1:
-            return Filter.name_eq(names[0])
+            return FilterInternal.name_eq(names[0])
         else:
-            filters = [Filter.name_eq(name) for name in names]
-            return Filter.any(*filters)
+            filters = [FilterInternal.name_eq(name) for name in names]
+            return FilterInternal.any(*filters)
 
     @abc.abstractmethod
     def to_query(self) -> str:
@@ -337,9 +337,9 @@ class Filter(ABC):
 
 
 @dataclass
-class _AttributeValuePredicate(Filter):
+class _AttributeValuePredicateInternal(FilterInternal):
     operator: Literal["==", "!=", ">", ">=", "<", "<=", "MATCHES", "NOT MATCHES", "CONTAINS", "NOT CONTAINS"]
-    attribute: Attribute
+    attribute: AttributeInternal
     value: Union[bool, int, float, str, datetime]
 
     def __post_init__(self) -> None:
@@ -361,18 +361,18 @@ class _AttributeValuePredicate(Filter):
 
 
 @dataclass
-class _AttributePredicate(Filter):
+class _AttributePredicateInternal(FilterInternal):
     postfix_operator: Literal["EXISTS"]
-    attribute: Attribute
+    attribute: AttributeInternal
 
     def to_query(self) -> str:
         return f"{self.attribute} {self.postfix_operator}"
 
 
 @dataclass
-class _AssociativeOperator(Filter):
+class _AssociativeOperatorInternal(FilterInternal):
     operator: Literal["AND", "OR"]
-    filters: Iterable[Filter]
+    filters: Iterable[FilterInternal]
 
     def to_query(self) -> str:
         filter_queries = [f"({child})" for child in self.filters]
@@ -380,9 +380,9 @@ class _AssociativeOperator(Filter):
 
 
 @dataclass
-class _PrefixOperator(Filter):
+class _PrefixOperatorInternal(FilterInternal):
     operator: Literal["NOT"]
-    filter_: Filter
+    filter_: FilterInternal
 
     def to_query(self) -> str:
         return f"{self.operator} ({self.filter_})"

--- a/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
+++ b/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
@@ -49,11 +49,11 @@ from neptune_fetcher.internal.retrieval import util  # noqa: E402
 
 
 def split_attribute_filters(
-    _attribute_filter: filters.BaseAttributeFilter,
-) -> list[filters.AttributeFilter]:
-    if isinstance(_attribute_filter, filters.AttributeFilter):
+    _attribute_filter: filters.InternalBaseAttributeFilter,
+) -> list[filters.AttributeFilterInternal]:
+    if isinstance(_attribute_filter, filters.AttributeFilterInternal):
         return [_attribute_filter]
-    elif isinstance(_attribute_filter, filters._AttributeFilterAlternative):
+    elif isinstance(_attribute_filter, filters._AttributeFilterAlternativeInternal):
         return list(it.chain.from_iterable(split_attribute_filters(child) for child in _attribute_filter.filters))
     else:
         raise RuntimeError(f"Unexpected filter type: {type(_attribute_filter)}")
@@ -63,7 +63,7 @@ def fetch_attribute_definitions_single_filter(
     client: AuthenticatedClient,
     project_identifiers: Iterable[identifiers.ProjectIdentifier],
     run_identifiers: Optional[Iterable[identifiers.RunIdentifier]],
-    attribute_filter: filters.AttributeFilter,
+    attribute_filter: filters.AttributeFilterInternal,
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_DEFINITIONS_BATCH_SIZE.get(),
 ) -> Generator[util.Page[AttributeDefinition], None, None]:
     params: dict[str, Any] = {

--- a/src/neptune_fetcher/internal/retrieval/search.py
+++ b/src/neptune_fetcher/internal/retrieval/search.py
@@ -37,8 +37,8 @@ from neptune_fetcher.internal import (
     identifiers,
 )
 from neptune_fetcher.internal.filters import (
-    Attribute,
-    Filter,
+    AttributeInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.retrieval import util
 from neptune_fetcher.internal.retrieval.attribute_types import map_attribute_type_python_to_backend
@@ -122,8 +122,8 @@ class FetchSysAttrs(Protocol[T]):
         self,
         client: AuthenticatedClient,
         project_identifier: identifiers.ProjectIdentifier,
-        filter_: Optional[Filter] = None,
-        sort_by: Attribute = Attribute("sys/creation_time", type="datetime"),
+        filter_: Optional[FilterInternal] = None,
+        sort_by: AttributeInternal = AttributeInternal("sys/creation_time", type="datetime"),
         sort_direction: Literal["asc", "desc"] = "desc",
         limit: Optional[int] = None,
         batch_size: int = env.NEPTUNE_FETCHER_SYS_ATTRS_BATCH_SIZE.get(),
@@ -140,8 +140,8 @@ def _create_fetch_sys_attrs(
     def fetch_sys_attrs(
         client: AuthenticatedClient,
         project_identifier: identifiers.ProjectIdentifier,
-        filter_: Optional[Filter] = None,
-        sort_by: Attribute = Attribute("sys/creation_time", type="datetime"),
+        filter_: Optional[FilterInternal] = None,
+        sort_by: AttributeInternal = AttributeInternal("sys/creation_time", type="datetime"),
         sort_direction: Literal["asc", "desc"] = "desc",
         limit: Optional[int] = None,
         batch_size: int = env.NEPTUNE_FETCHER_SYS_ATTRS_BATCH_SIZE.get(),

--- a/src/neptune_fetcher/internal/util.py
+++ b/src/neptune_fetcher/internal/util.py
@@ -1,3 +1,13 @@
+
+
+
+
+
+# This entire file is alpha-specific and needs to be moved to top-level.
+
+
+
+
 #
 # Copyright (c) 2025, Neptune Labs Sp. z o.o.
 #
@@ -18,7 +28,8 @@ from typing import (
     Union,
 )
 
-from neptune_fetcher.internal import filters as _filters
+
+from neptune_fetcher.alpha import filters as _filters
 
 
 def resolve_runs_filter(runs: Optional[Union[str, list[str], _filters.Filter]]) -> Optional[_filters.Filter]:

--- a/tests/e2e/alpha/runs/test_runs_fetch_runs_table.py
+++ b/tests/e2e/alpha/runs/test_runs_fetch_runs_table.py
@@ -10,9 +10,9 @@ import pytest
 import neptune_fetcher.alpha.runs as runs
 from neptune_fetcher.alpha import Context
 from neptune_fetcher.internal.filters import (
-    Attribute,
-    AttributeFilter,
-    Filter,
+    AttributeInternal,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 
 
@@ -49,7 +49,7 @@ from neptune_fetcher.internal.filters import (
         ),
         (
             r"^linear_history_root$",
-            AttributeFilter(name_matches_all=r"foo0$", aggregations=["last", "min", "max", "average", "variance"]),
+            AttributeFilterInternal(name_matches_all=r"foo0$", aggregations=["last", "min", "max", "average", "variance"]),
             {
                 "run": ["linear_history_root"],
                 ("foo0:float_series", "last"): [0.1 * 9],
@@ -61,8 +61,8 @@ from neptune_fetcher.internal.filters import (
         ),
         (
             "^linear_history_root$",
-            AttributeFilter(name_matches_all="foo0$", aggregations=["last", "min", "max", "average", "variance"])
-            | AttributeFilter(name_matches_all=".*-value$"),
+            AttributeFilterInternal(name_matches_all="foo0$", aggregations=["last", "min", "max", "average", "variance"])
+            | AttributeFilterInternal(name_matches_all=".*-value$"),
             {
                 "run": ["linear_history_root"],
                 ("int-value:int", ""): [1],
@@ -79,7 +79,7 @@ from neptune_fetcher.internal.filters import (
         ),
         (
             r"^linear_history_root$|^linear_history_fork2$",
-            AttributeFilter(name_matches_all=r"foo0$", aggregations=["last", "variance"]),
+            AttributeFilterInternal(name_matches_all=r"foo0$", aggregations=["last", "variance"]),
             {
                 "run": ["linear_history_root", "linear_history_fork2"],
                 ("foo0:float_series", "last"): [0.1 * 9, 0.7 * 19],
@@ -92,9 +92,9 @@ from neptune_fetcher.internal.filters import (
             },
         ),
         (
-            ["linear_history_root", "linear_history_fork2"],
-            AttributeFilter(name_matches_all=r"foo0$", aggregations=["last", "variance"]),
-            {
+                ["linear_history_root", "linear_history_fork2"],
+                AttributeFilterInternal(name_matches_all=r"foo0$", aggregations=["last", "variance"]),
+                {
                 "run": ["linear_history_root", "linear_history_fork2"],
                 ("foo0:float_series", "last"): [0.1 * 9, 0.7 * 19],
                 ("foo0:float_series", "variance"): [
@@ -121,9 +121,9 @@ from neptune_fetcher.internal.filters import (
             },
         ),
         (
-            Filter.matches_all("sys/custom_run_id", r"forked_history_root|forked_history_fork1"),
+                FilterInternal.matches_all("sys/custom_run_id", r"forked_history_root|forked_history_fork1"),
             r".*-value$",
-            {
+                {
                 "run": ["forked_history_root", "forked_history_fork1"],
                 ("int-value:int", ""): [1, 2],
                 ("float-value:float", ""): [1.0, 2.0],
@@ -136,10 +136,10 @@ from neptune_fetcher.internal.filters import (
             },
         ),
         (
-            Filter.eq("sys/name", "exp_with_linear_history"),
-            # matches runs with experiment_name 'exp_with_linear_history'
+                FilterInternal.eq("sys/name", "exp_with_linear_history"),
+                # matches runs with experiment_name 'exp_with_linear_history'
             r".*-value$",
-            {
+                {
                 "run": ["linear_history_fork1", "linear_history_fork2", "linear_history_root"],
                 ("int-value:int", ""): [2, 3, 1],
                 ("float-value:float", ""): [2.0, 3.0, 1.0],
@@ -153,9 +153,9 @@ from neptune_fetcher.internal.filters import (
             },
         ),
         (
-            Filter.exists(Attribute("str-value", type="string")),  # matches runs that have config 'str-value'
+                FilterInternal.exists(AttributeInternal("str-value", type="string")),  # matches runs that have config 'str-value'
             r".*-value$",
-            {
+                {
                 "run": [
                     "forked_history_fork1",
                     "forked_history_fork2",
@@ -191,7 +191,7 @@ def test_fetch_runs_table(
     df = runs.fetch_runs_table(
         runs=runs_filter,
         attributes=attributes_filter,
-        sort_by=Attribute("sys/custom_run_id", type="string"),
+        sort_by=AttributeInternal("sys/custom_run_id", type="string"),
         sort_direction="desc",
         context=new_project_context,
         type_suffix_in_column_names=type_suffix_in_column_names,

--- a/tests/e2e/alpha/runs/test_runs_list.py
+++ b/tests/e2e/alpha/runs/test_runs_list.py
@@ -3,8 +3,8 @@ import pytest
 import neptune_fetcher.alpha.runs as runs
 from neptune_fetcher.alpha import Context
 from neptune_fetcher.internal.filters import (
-    Attribute,
-    Filter,
+    AttributeInternal,
+    FilterInternal,
 )
 from tests.e2e.alpha.generator import (
     ALL_STATIC_RUNS,
@@ -18,7 +18,7 @@ from tests.e2e.alpha.generator import (
         ".*",
         None,
         [run.custom_run_id for run in ALL_STATIC_RUNS],
-        Filter.name_in(*[run.experiment_name for run in ALL_STATIC_RUNS]),
+        FilterInternal.name_in(*[run.experiment_name for run in ALL_STATIC_RUNS]),
     ],
 )
 def test_list_all_runs(new_project_context: Context, all_filter):
@@ -32,10 +32,10 @@ def test_list_all_runs(new_project_context: Context, all_filter):
     [
         "linear.*",
         [run.custom_run_id for run in LINEAR_HISTORY_TREE],
-        Filter.name_in(*[run.experiment_name for run in LINEAR_HISTORY_TREE]),
-        Filter.eq("linear-history", True),
-        Filter.eq(Attribute(name="linear-history", type="bool"), True),
-        Filter.eq(Attribute(name="linear-history"), True),
+        FilterInternal.name_in(*[run.experiment_name for run in LINEAR_HISTORY_TREE]),
+        FilterInternal.eq("linear-history", True),
+        FilterInternal.eq(AttributeInternal(name="linear-history", type="bool"), True),
+        FilterInternal.eq(AttributeInternal(name="linear-history"), True),
         # TODO string set filter
         # Filter.eq(Attribute(name="sys/tags", type="string_set"), ["linear"]),
     ],
@@ -51,7 +51,7 @@ def test_list_linear_history_runs(new_project_context: Context, linear_history_f
     [
         "abc",
         ["abc"],
-        Filter.eq(Attribute(name="non-existent", type="bool"), True),
+        FilterInternal.eq(AttributeInternal(name="non-existent", type="bool"), True),
     ],
 )
 def test_list_runs_empty_filter(new_project_context: Context, linear_history_filter):

--- a/tests/e2e/alpha/runs/test_runs_list_attributes.py
+++ b/tests/e2e/alpha/runs/test_runs_list_attributes.py
@@ -3,9 +3,9 @@ import pytest
 import neptune_fetcher.alpha.runs as runs
 from neptune_fetcher.alpha import Context
 from neptune_fetcher.internal.filters import (
-    Attribute,
-    AttributeFilter,
-    Filter,
+    AttributeInternal,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from tests.e2e.alpha.generator import (
     ALL_STATIC_RUNS,
@@ -18,12 +18,12 @@ from tests.e2e.alpha.generator import (
     [
         (".*", ALL_STATIC_RUNS),
         (None, ALL_STATIC_RUNS),
-        (Filter.name_in(*[run.experiment_name for run in ALL_STATIC_RUNS]), ALL_STATIC_RUNS),
+        (FilterInternal.name_in(*[run.experiment_name for run in ALL_STATIC_RUNS]), ALL_STATIC_RUNS),
         ([run.custom_run_id for run in ALL_STATIC_RUNS], ALL_STATIC_RUNS),
         ("linear.*", LINEAR_HISTORY_TREE),
-        (Filter.name_in(*[run.experiment_name for run in LINEAR_HISTORY_TREE]), LINEAR_HISTORY_TREE),
-        (Filter.eq("linear-history", True), LINEAR_HISTORY_TREE),
-        (Filter.eq(Attribute(name="linear-history", type="bool"), True), LINEAR_HISTORY_TREE),
+        (FilterInternal.name_in(*[run.experiment_name for run in LINEAR_HISTORY_TREE]), LINEAR_HISTORY_TREE),
+        (FilterInternal.eq("linear-history", True), LINEAR_HISTORY_TREE),
+        (FilterInternal.eq(AttributeInternal(name="linear-history", type="bool"), True), LINEAR_HISTORY_TREE),
     ],
 )
 def test_list_attributes(new_project_context: Context, filter_, expected):
@@ -37,28 +37,28 @@ def test_list_attributes(new_project_context: Context, filter_, expected):
     "_attr_filter, expected",
     [
         # DateTime attributes
-        (AttributeFilter(name_eq="datetime-value", type_in=["datetime"]), {"datetime-value"}),
+        (AttributeFilterInternal(name_eq="datetime-value", type_in=["datetime"]), {"datetime-value"}),
         # Numeric series
-        (AttributeFilter(name_eq="unique1/0", type_in=["float_series"]), {"unique1/0"}),
-        (AttributeFilter(name_eq="foo0", type_in=["float_series"]), {"foo0"}),
-        (AttributeFilter(name_eq="foo1", type_in=["float_series"]), {"foo1"}),
+        (AttributeFilterInternal(name_eq="unique1/0", type_in=["float_series"]), {"unique1/0"}),
+        (AttributeFilterInternal(name_eq="foo0", type_in=["float_series"]), {"foo0"}),
+        (AttributeFilterInternal(name_eq="foo1", type_in=["float_series"]), {"foo1"}),
         # Primitive types
-        (AttributeFilter(type_in=["int"]), {"int-value"}),
-        (AttributeFilter(type_in=["float"]), {"float-value"}),
-        (AttributeFilter(type_in=["string"]), {"str-value"}),
-        (AttributeFilter(type_in=["bool"]), {"bool-value"}),
+        (AttributeFilterInternal(type_in=["int"]), {"int-value"}),
+        (AttributeFilterInternal(type_in=["float"]), {"float-value"}),
+        (AttributeFilterInternal(type_in=["string"]), {"str-value"}),
+        (AttributeFilterInternal(type_in=["bool"]), {"bool-value"}),
         # Multiple types
-        (AttributeFilter(type_in=["float", "int"]), {"float-value", "int-value"}),
+        (AttributeFilterInternal(type_in=["float", "int"]), {"float-value", "int-value"}),
         # Name patterns
-        (AttributeFilter(name_matches_all="unique.*"), {"unique1/0", "unique2/0"}),
-        (AttributeFilter(name_matches_all="foo.*"), {"foo0", "foo1"}),
+        (AttributeFilterInternal(name_matches_all="unique.*"), {"unique1/0", "unique2/0"}),
+        (AttributeFilterInternal(name_matches_all="foo.*"), {"foo0", "foo1"}),
         # Combined filters
-        (AttributeFilter(name_matches_all=".*value.*", type_in=["float"]), {"float-value"}),
-        (AttributeFilter(name_matches_all=".*value.*", type_in=["int"]), {"int-value"}),
+        (AttributeFilterInternal(name_matches_all=".*value.*", type_in=["float"]), {"float-value"}),
+        (AttributeFilterInternal(name_matches_all=".*value.*", type_in=["int"]), {"int-value"}),
         (
-            AttributeFilter(name_matches_all=".*value.*", type_in=["float"])
-            | AttributeFilter(name_matches_all=".*value.*", type_in=["int"]),
-            {"float-value", "int-value"},
+                AttributeFilterInternal(name_matches_all=".*value.*", type_in=["float"])
+                | AttributeFilterInternal(name_matches_all=".*value.*", type_in=["int"]),
+                {"float-value", "int-value"},
         ),
     ],
 )

--- a/tests/e2e/alpha/test_attributes.py
+++ b/tests/e2e/alpha/test_attributes.py
@@ -5,9 +5,9 @@ import pytest
 
 from neptune_fetcher.alpha import list_attributes
 from neptune_fetcher.internal.filters import (
-    Attribute,
-    AttributeFilter,
-    Filter,
+    AttributeInternal,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from tests.e2e.data import (
     FLOAT_SERIES_PATHS,
@@ -26,7 +26,7 @@ def _drop_sys_attr_names(attributes: Iterable[str]) -> list[str]:
 
 # Convenience filter to limit searches to experiments belonging to this test,
 # in case the run has some extra experiments.
-EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
+EXPERIMENTS_IN_THIS_TEST = FilterInternal.name_in(*TEST_DATA.experiment_names)
 
 
 @pytest.mark.parametrize(
@@ -62,13 +62,13 @@ EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
             },
         ),
         (rf"{PATH}/unique-value-[0-9]", {f"{PATH}/unique-value-{i}" for i in range(6)}),
-        (AttributeFilter(name_matches_all=PATH), TEST_DATA.all_attribute_names),
-        (AttributeFilter(name_eq=f"{PATH}/float-value"), {f"{PATH}/float-value"}),
+        (AttributeFilterInternal(name_matches_all=PATH), TEST_DATA.all_attribute_names),
+        (AttributeFilterInternal(name_eq=f"{PATH}/float-value"), {f"{PATH}/float-value"}),
         (
-            AttributeFilter.any(AttributeFilter(name_matches_all="^(foo)"), AttributeFilter(name_matches_all=PATH)),
-            TEST_DATA.all_attribute_names,
+                AttributeFilterInternal.any(AttributeFilterInternal(name_matches_all="^(foo)"), AttributeFilterInternal(name_matches_all=PATH)),
+                TEST_DATA.all_attribute_names,
         ),
-        (AttributeFilter(name_matches_none=".*"), []),
+        (AttributeFilterInternal(name_matches_none=".*"), []),
     ],
 )
 def test_list_attributes_known_in_all_experiments_with_name_filter_excluding_sys(
@@ -82,11 +82,11 @@ def test_list_attributes_known_in_all_experiments_with_name_filter_excluding_sys
 @pytest.mark.parametrize(
     "name_filter",
     (
-        None,
+            None,
         "",
         ".*",
-        AttributeFilter(name_matches_all=".*"),
-        AttributeFilter(),
+            AttributeFilterInternal(name_matches_all=".*"),
+            AttributeFilterInternal(),
     ),
 )
 def test_list_attributes_all_names_from_all_experiments_excluding_sys(name_filter):
@@ -102,8 +102,8 @@ def test_list_attributes_all_names_from_all_experiments_excluding_sys(name_filte
         ".*unknown.*",
         "sys/abcdef",
         " ",
-        AttributeFilter(name_eq=".*"),
-        AttributeFilter(name_matches_all="unknown"),
+        AttributeFilterInternal(name_eq=".*"),
+        AttributeFilterInternal(name_matches_all="unknown"),
     ),
 )
 def test_list_attributes_unknown_name(filter_):
@@ -127,15 +127,15 @@ def test_list_attributes_unknown_name(filter_):
         ),
         (
             rf"{PATH}/unique-value-.*",
-            Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "string-0-0"),
+            FilterInternal.contains_all(AttributeInternal(f"{PATH}/string_set-value", type="string_set"), "string-0-0"),
             {f"{PATH}/unique-value-0"},
         ),
         (
-            rf"{PATH}/unique-value-.*",
-            Filter.contains_none(
-                Attribute(f"{PATH}/string_set-value", type="string_set"), ["string-0-0", "string-1-0", "string-4-0"]
+                rf"{PATH}/unique-value-.*",
+                FilterInternal.contains_none(
+                AttributeInternal(f"{PATH}/string_set-value", type="string_set"), ["string-0-0", "string-1-0", "string-4-0"]
             ),
-            {f"{PATH}/unique-value-{i}" for i in (2, 3, 5)},
+                {f"{PATH}/unique-value-{i}" for i in (2, 3, 5)},
         ),
         (
             [f"{PATH}/int-value", f"{PATH}/float-value"],
@@ -143,28 +143,28 @@ def test_list_attributes_unknown_name(filter_):
             {f"{PATH}/int-value", f"{PATH}/float-value"},
         ),
         (
-            AttributeFilter(name_matches_none="sys/.*", name_matches_all=".*"),
-            Filter.gt(Attribute(f"{PATH}/int-value", type="int"), 1234) & EXPERIMENTS_IN_THIS_TEST,
-            [],
+                AttributeFilterInternal(name_matches_none="sys/.*", name_matches_all=".*"),
+                FilterInternal.gt(AttributeInternal(f"{PATH}/int-value", type="int"), 1234) & EXPERIMENTS_IN_THIS_TEST,
+                [],
         ),
         (
-            AttributeFilter(name_matches_none="sys/.*", name_matches_all=".*"),
-            Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_12345") & EXPERIMENTS_IN_THIS_TEST,
-            [],
+                AttributeFilterInternal(name_matches_none="sys/.*", name_matches_all=".*"),
+                FilterInternal.eq(AttributeInternal(f"{PATH}/str-value", type="string"), "hello_12345") & EXPERIMENTS_IN_THIS_TEST,
+                [],
         ),
         (
             f"{PATH}/unique-value",
-            Filter.lt(Attribute(f"{PATH}/int-value", type="int"), 3) & EXPERIMENTS_IN_THIS_TEST,
+            FilterInternal.lt(AttributeInternal(f"{PATH}/int-value", type="int"), 3) & EXPERIMENTS_IN_THIS_TEST,
             {f"{PATH}/unique-value-{i}" for i in range(3)},
         ),
         (
             f"{PATH}/unique-value",
-            Filter.eq(Attribute(f"{PATH}/bool-value", type="bool"), False) & EXPERIMENTS_IN_THIS_TEST,
+            FilterInternal.eq(AttributeInternal(f"{PATH}/bool-value", type="bool"), False) & EXPERIMENTS_IN_THIS_TEST,
             {f"{PATH}/unique-value-{i}" for i in (1, 3, 5)},
         ),
         (
             f"{PATH}/unique-value",
-            Filter.eq(Attribute(f"{PATH}/bool-value", type="bool"), False) & EXPERIMENTS_IN_THIS_TEST,
+            FilterInternal.eq(AttributeInternal(f"{PATH}/bool-value", type="bool"), False) & EXPERIMENTS_IN_THIS_TEST,
             {f"{PATH}/unique-value-{i}" for i in (1, 3, 5)},
         ),
     ],
@@ -183,7 +183,7 @@ def test_list_attributes_depending_on_values_in_experiments(attribute_filter, ex
             {"sys/name", "sys/id"},
         ),
         (r"sys/.*id$", {"sys/custom_run_id", "sys/id", "sys/diagnostics/project_uuid", "sys/diagnostics/run_uuid"}),
-        (AttributeFilter(name_matches_all=r"sys/(name|id)"), {"sys/name", "sys/id"}),
+        (AttributeFilterInternal(name_matches_all=r"sys/(name|id)"), {"sys/name", "sys/id"}),
     ],
 )
 def test_list_attributes_sys_attrs(attribute_filter, expected):

--- a/tests/e2e/alpha/test_experiments.py
+++ b/tests/e2e/alpha/test_experiments.py
@@ -12,9 +12,9 @@ from neptune_fetcher.alpha import (
 )
 from neptune_fetcher.internal import env
 from neptune_fetcher.internal.filters import (
-    Attribute,
-    AttributeFilter,
-    Filter,
+    AttributeInternal,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from tests.e2e.data import (
     FLOAT_SERIES_PATHS,
@@ -29,8 +29,8 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
 @pytest.mark.parametrize("sort_direction", ["asc", "desc"])
 def test__fetch_experiments_table(project, run_with_attributes, sort_direction):
     df = fetch_experiments_table(
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments]),
-        sort_by=Attribute("sys/name", type="string"),
+        experiments=FilterInternal.name_in(*[exp.name for exp in TEST_DATA.experiments]),
+        sort_by=AttributeInternal("sys/name", type="string"),
         sort_direction=sort_direction,
         context=_context(project),
     )
@@ -52,10 +52,10 @@ def test__fetch_experiments_table(project, run_with_attributes, sort_direction):
     [
         f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
         [TEST_DATA.exp_name(0), TEST_DATA.exp_name(1), TEST_DATA.exp_name(2)],
-        Filter.name_in(TEST_DATA.exp_name(0), TEST_DATA.exp_name(1), TEST_DATA.exp_name(2)),
-        Filter.name_eq(TEST_DATA.exp_name(0))
-        | Filter.name_eq(TEST_DATA.exp_name(1))
-        | Filter.name_eq(TEST_DATA.exp_name(2)),
+        FilterInternal.name_in(TEST_DATA.exp_name(0), TEST_DATA.exp_name(1), TEST_DATA.exp_name(2)),
+        FilterInternal.name_eq(TEST_DATA.exp_name(0))
+        | FilterInternal.name_eq(TEST_DATA.exp_name(1))
+        | FilterInternal.name_eq(TEST_DATA.exp_name(2)),
     ],
 )
 @pytest.mark.parametrize(
@@ -63,14 +63,14 @@ def test__fetch_experiments_table(project, run_with_attributes, sort_direction):
     [
         f"{PATH}/int-value|{PATH}/float-value|{PATH}/metrics/step",
         [f"{PATH}/int-value", f"{PATH}/float-value", f"{PATH}/metrics/step"],
-        AttributeFilter.any(
-            AttributeFilter(f"{PATH}/int-value", type_in=["int"]),
-            AttributeFilter(f"{PATH}/float-value", type_in=["float"]),
-            AttributeFilter(f"{PATH}/metrics/step", type_in=["float_series"]),
+        AttributeFilterInternal.any(
+            AttributeFilterInternal(f"{PATH}/int-value", type_in=["int"]),
+            AttributeFilterInternal(f"{PATH}/float-value", type_in=["float"]),
+            AttributeFilterInternal(f"{PATH}/metrics/step", type_in=["float_series"]),
         ),
-        AttributeFilter(f"{PATH}/int-value", type_in=["int"])
-        | AttributeFilter(f"{PATH}/float-value", type_in=["float"])
-        | AttributeFilter(f"{PATH}/metrics/step", type_in=["float_series"]),
+        AttributeFilterInternal(f"{PATH}/int-value", type_in=["int"])
+        | AttributeFilterInternal(f"{PATH}/float-value", type_in=["float"])
+        | AttributeFilterInternal(f"{PATH}/metrics/step", type_in=["float_series"]),
     ],
 )
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
@@ -78,7 +78,7 @@ def test__fetch_experiments_table_with_attributes_filter(
     project, run_with_attributes, attr_filter, experiment_filter, type_suffix_in_column_names
 ):
     df = fetch_experiments_table(
-        sort_by=Attribute("sys/name", type="string"),
+        sort_by=AttributeInternal("sys/name", type="string"),
         sort_direction="asc",
         experiments=experiment_filter,
         attributes=attr_filter,
@@ -108,20 +108,20 @@ def test__fetch_experiments_table_with_attributes_filter(
 @pytest.mark.parametrize(
     "attr_filter",
     [
-        AttributeFilter(
+        AttributeFilterInternal(
             f"{PATH}/metrics/step", type_in=["float_series"], aggregations=["last", "min", "max", "average", "variance"]
         )
-        | AttributeFilter(FLOAT_SERIES_PATHS[0], type_in=["float_series"], aggregations=["average", "variance"])
-        | AttributeFilter(FLOAT_SERIES_PATHS[1], type_in=["float_series"]),
+        | AttributeFilterInternal(FLOAT_SERIES_PATHS[0], type_in=["float_series"], aggregations=["average", "variance"])
+        | AttributeFilterInternal(FLOAT_SERIES_PATHS[1], type_in=["float_series"]),
     ],
 )
 def test__fetch_experiments_table_with_attributes_filter_for_metrics(
     project, run_with_attributes, attr_filter, type_suffix_in_column_names
 ):
     df = fetch_experiments_table(
-        sort_by=Attribute("sys/name", type="string"),
+        sort_by=AttributeInternal("sys/name", type="string"),
         sort_direction="asc",
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        experiments=FilterInternal.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
         attributes=attr_filter,
         type_suffix_in_column_names=type_suffix_in_column_names,
         context=_context(project),
@@ -167,17 +167,17 @@ def test__fetch_experiments_table_with_attributes_filter_for_metrics(
 @pytest.mark.parametrize(
     "attr_filter",
     [
-        AttributeFilter(f"{PATH}/metrics/string-series-value_0", type_in=["string_series"], aggregations=["last"])
-        | AttributeFilter(f"{PATH}/metrics/string-series-value_1", type_in=["string_series"])
+        AttributeFilterInternal(f"{PATH}/metrics/string-series-value_0", type_in=["string_series"], aggregations=["last"])
+        | AttributeFilterInternal(f"{PATH}/metrics/string-series-value_1", type_in=["string_series"])
     ],
 )
 def test__fetch_experiments_table_with_attributes_filter_for_series(
     project, run_with_attributes, attr_filter, type_suffix_in_column_names
 ):
     df = fetch_experiments_table(
-        sort_by=Attribute("sys/name", type="string"),
+        sort_by=AttributeInternal("sys/name", type="string"),
         sort_direction="asc",
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:2]]),
+        experiments=FilterInternal.name_in(*[exp.name for exp in TEST_DATA.experiments[:2]]),
         attributes=attr_filter,
         type_suffix_in_column_names=type_suffix_in_column_names,
         context=_context(project),
@@ -203,15 +203,15 @@ def test__fetch_experiments_table_with_attributes_filter_for_series(
 
 @pytest.mark.parametrize(
     "attr_filter",
-    [AttributeFilter(f"{PATH}/metrics/string-series-value_0", type_in=["string_series"], aggregations=["min"])],
+    [AttributeFilterInternal(f"{PATH}/metrics/string-series-value_0", type_in=["string_series"], aggregations=["min"])],
 )
 def test__fetch_experiments_table_with_attributes_filter_for_series_wrong_aggregation(
     project, run_with_attributes, attr_filter
 ):
     df = fetch_experiments_table(
-        sort_by=Attribute("sys/name", type="string"),
+        sort_by=AttributeInternal("sys/name", type="string"),
         sort_direction="asc",
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:2]]),
+        experiments=FilterInternal.name_in(*[exp.name for exp in TEST_DATA.experiments[:2]]),
         attributes=attr_filter,
         type_suffix_in_column_names=True,
         context=_context(project),
@@ -223,8 +223,8 @@ def test__fetch_experiments_table_with_attributes_filter_for_series_wrong_aggreg
 @pytest.mark.parametrize(
     "attr_filter",
     [
-        AttributeFilter(name_matches_all=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}"),
-        AttributeFilter(
+        AttributeFilterInternal(name_matches_all=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}"),
+        AttributeFilterInternal(
             name_matches_all=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}",
             name_matches_none=".*value_[5-9].*",
         ),
@@ -235,9 +235,9 @@ def test__fetch_experiments_table_with_attributes_regex_filter_for_metrics(
     project, run_with_attributes, attr_filter, type_suffix_in_column_names
 ):
     df = fetch_experiments_table(
-        sort_by=Attribute("sys/name", type="string"),
+        sort_by=AttributeInternal("sys/name", type="string"),
         sort_direction="asc",
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        experiments=FilterInternal.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
         attributes=attr_filter,
         type_suffix_in_column_names=type_suffix_in_column_names,
         context=_context(project),
@@ -275,7 +275,7 @@ def _context(project):
         (".*", TEST_DATA.experiment_names),
         ("", TEST_DATA.experiment_names),
         ("test_alpha", TEST_DATA.experiment_names),
-        (Filter.matches_all(Attribute("sys/name", type="string"), ".*"), TEST_DATA.experiment_names),
+        (FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), ".*"), TEST_DATA.experiment_names),
     ],
 )
 def test_list_experiments_with_regex_and_filters_matching_all(project, regex, expected_subset):
@@ -308,120 +308,120 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
 @pytest.mark.parametrize(
     "filter_, expected",
     [
-        (Filter.eq(Attribute("sys/name", type="string"), ""), []),
-        (Filter.name_in(*TEST_DATA.experiment_names), TEST_DATA.experiment_names),
+        (FilterInternal.eq(AttributeInternal("sys/name", type="string"), ""), []),
+        (FilterInternal.name_in(*TEST_DATA.experiment_names), TEST_DATA.experiment_names),
         (
-            Filter.matches_all(Attribute("sys/name", type="string"), [f"alpha.*{TEST_DATA_VERSION}", "_3"]),
-            [f"test_alpha_3" f"_{TEST_DATA_VERSION}"],
+                FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), [f"alpha.*{TEST_DATA_VERSION}", "_3"]),
+                [f"test_alpha_3" f"_{TEST_DATA_VERSION}"],
         ),
         (TEST_DATA.experiment_names, TEST_DATA.experiment_names),
         (
-            Filter.matches_none(Attribute("sys/name", type="string"), ["alpha_3", "alpha_4", "alpha_5"])
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [
+                FilterInternal.matches_none(AttributeInternal("sys/name", type="string"), ["alpha_3", "alpha_4", "alpha_5"])
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [
                 f"test_alpha_0_{TEST_DATA_VERSION}",
                 f"test_alpha_1_{TEST_DATA_VERSION}",
                 f"test_alpha_2_{TEST_DATA_VERSION}",
             ],
         ),
-        (Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_123"), []),
+        (FilterInternal.eq(AttributeInternal(f"{PATH}/str-value", type="string"), "hello_123"), []),
         (
-            Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_1")
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [f"test_alpha_1_{TEST_DATA_VERSION}"],
+                FilterInternal.eq(AttributeInternal(f"{PATH}/str-value", type="string"), "hello_1")
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [f"test_alpha_1_{TEST_DATA_VERSION}"],
         ),
         (
-            (
-                Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_1")
-                | Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_2")
+                (
+                        FilterInternal.eq(AttributeInternal(f"{PATH}/str-value", type="string"), "hello_1")
+                        | FilterInternal.eq(AttributeInternal(f"{PATH}/str-value", type="string"), "hello_2")
             )
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [f"test_alpha_1_{TEST_DATA_VERSION}", f"test_alpha_2_{TEST_DATA_VERSION}"],
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [f"test_alpha_1_{TEST_DATA_VERSION}", f"test_alpha_2_{TEST_DATA_VERSION}"],
         ),
         (
-            Filter.ne(Attribute(f"{PATH}/str-value", type="string"), "hello_1")
-            & Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_2")
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [f"test_alpha_2_{TEST_DATA_VERSION}"],
+                FilterInternal.ne(AttributeInternal(f"{PATH}/str-value", type="string"), "hello_1")
+                & FilterInternal.eq(AttributeInternal(f"{PATH}/str-value", type="string"), "hello_2")
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [f"test_alpha_2_{TEST_DATA_VERSION}"],
         ),
-        (Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 12345), []),
+        (FilterInternal.eq(AttributeInternal(f"{PATH}/int-value", type="int"), 12345), []),
         (
-            Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 2)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [f"test_alpha_2_{TEST_DATA_VERSION}"],
-        ),
-        (
-            Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 2)
-            | Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 3)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [f"test_alpha_2_{TEST_DATA_VERSION}", f"test_alpha_3_{TEST_DATA_VERSION}"],
-        ),
-        (Filter.eq(Attribute(f"{PATH}/float-value", type="float"), 1.2345), []),
-        (
-            Filter.eq(Attribute(f"{PATH}/float-value", type="float"), 3)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [f"test_alpha_3_{TEST_DATA_VERSION}"],
+                FilterInternal.eq(AttributeInternal(f"{PATH}/int-value", type="int"), 2)
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [f"test_alpha_2_{TEST_DATA_VERSION}"],
         ),
         (
-            Filter.eq(Attribute(f"{PATH}/bool-value", type="bool"), False)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [
+                FilterInternal.eq(AttributeInternal(f"{PATH}/int-value", type="int"), 2)
+                | FilterInternal.eq(AttributeInternal(f"{PATH}/int-value", type="int"), 3)
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [f"test_alpha_2_{TEST_DATA_VERSION}", f"test_alpha_3_{TEST_DATA_VERSION}"],
+        ),
+        (FilterInternal.eq(AttributeInternal(f"{PATH}/float-value", type="float"), 1.2345), []),
+        (
+                FilterInternal.eq(AttributeInternal(f"{PATH}/float-value", type="float"), 3)
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [f"test_alpha_3_{TEST_DATA_VERSION}"],
+        ),
+        (
+                FilterInternal.eq(AttributeInternal(f"{PATH}/bool-value", type="bool"), False)
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [
                 f"test_alpha_1_{TEST_DATA_VERSION}",
                 f"test_alpha_3_{TEST_DATA_VERSION}",
                 f"test_alpha_5_{TEST_DATA_VERSION}",
             ],
         ),
         (
-            Filter.eq(Attribute(f"{PATH}/bool-value", type="bool"), True)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [
+                FilterInternal.eq(AttributeInternal(f"{PATH}/bool-value", type="bool"), True)
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [
                 f"test_alpha_0_{TEST_DATA_VERSION}",
                 f"test_alpha_2_{TEST_DATA_VERSION}",
                 f"test_alpha_4_{TEST_DATA_VERSION}",
             ],
         ),
-        (Filter.gt(Attribute(f"{PATH}/datetime-value", type="datetime"), datetime.now()), []),
+        (FilterInternal.gt(AttributeInternal(f"{PATH}/datetime-value", type="datetime"), datetime.now()), []),
         (
-            Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "no-such-string"),
-            [],
+                FilterInternal.contains_all(AttributeInternal(f"{PATH}/string_set-value", type="string_set"), "no-such-string"),
+                [],
         ),
         (
-            Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), ["string-1-0", "string-1-1"])
-            & Filter.matches_all(Attribute("sys/name", type="string"), TEST_DATA_VERSION),
-            [f"test_alpha_1_{TEST_DATA_VERSION}"],
+                FilterInternal.contains_all(AttributeInternal(f"{PATH}/string_set-value", type="string_set"), ["string-1-0", "string-1-1"])
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), TEST_DATA_VERSION),
+                [f"test_alpha_1_{TEST_DATA_VERSION}"],
         ),
         (
-            (
-                Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "string-1-0")
-                | Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "string-0-0")
+                (
+                        FilterInternal.contains_all(AttributeInternal(f"{PATH}/string_set-value", type="string_set"), "string-1-0")
+                        | FilterInternal.contains_all(AttributeInternal(f"{PATH}/string_set-value", type="string_set"), "string-0-0")
             )
-            & Filter.matches_all(Attribute("sys/name", type="string"), TEST_DATA_VERSION),
-            [f"test_alpha_0_{TEST_DATA_VERSION}", f"test_alpha_1_{TEST_DATA_VERSION}"],
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), TEST_DATA_VERSION),
+                [f"test_alpha_0_{TEST_DATA_VERSION}", f"test_alpha_1_{TEST_DATA_VERSION}"],
         ),
         (
-            Filter.contains_none(
-                Attribute(f"{PATH}/string_set-value", type="string_set"),
+                FilterInternal.contains_none(
+                AttributeInternal(f"{PATH}/string_set-value", type="string_set"),
                 ["string-1-0", "string-2-0", "string-3-0"],
             )
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [
                 f"test_alpha_0_{TEST_DATA_VERSION}",
                 f"test_alpha_4_{TEST_DATA_VERSION}",
                 f"test_alpha_5_{TEST_DATA_VERSION}",
             ],
         ),
         (
-            Filter.contains_none(
-                Attribute(f"{PATH}/string_set-value", type="string_set"),
+                FilterInternal.contains_none(
+                AttributeInternal(f"{PATH}/string_set-value", type="string_set"),
                 ["string-1-0", "string-2-0", "string-3-0"],
             )
-            & Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "string-0-0")
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
-            [f"test_alpha_0_{TEST_DATA_VERSION}"],
+                & FilterInternal.contains_all(AttributeInternal(f"{PATH}/string_set-value", type="string_set"), "string-0-0")
+                & FilterInternal.matches_all(AttributeInternal("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+                [f"test_alpha_0_{TEST_DATA_VERSION}"],
         ),
         (
-            Filter.eq(Attribute("sys/name", type="string"), f"test_alpha_0_{TEST_DATA_VERSION}"),
-            [f"test_alpha_0_{TEST_DATA_VERSION}"],
+                FilterInternal.eq(AttributeInternal("sys/name", type="string"), f"test_alpha_0_{TEST_DATA_VERSION}"),
+                [f"test_alpha_0_{TEST_DATA_VERSION}"],
         ),
         # (     TODO - FILE nto supported in nql
         #     Filter.exists(Attribute(f"{PATH}/files/file-value.txt", type="file")),

--- a/tests/e2e/alpha/test_fetch_metrics.py
+++ b/tests/e2e/alpha/test_fetch_metrics.py
@@ -16,8 +16,8 @@ import pytest
 from neptune_fetcher.alpha import fetch_metrics
 from neptune_fetcher.internal.context import get_context
 from neptune_fetcher.internal.filters import (
-    AttributeFilter,
-    Filter,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.output_format import create_metrics_dataframe
 from tests.e2e.data import (
@@ -87,11 +87,11 @@ def create_expected_data(
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
 @pytest.mark.parametrize("step_range", [(0, 5), (0, None), (None, 5), (None, None), (100, 200)])
 @pytest.mark.parametrize("tail_limit", [None, 3, 5])
-@pytest.mark.parametrize("attr_filter", [AttributeFilter(name_matches_all=[r".*"], type_in=["float_series"]), ".*"])
+@pytest.mark.parametrize("attr_filter", [AttributeFilterInternal(name_matches_all=[r".*"], type_in=["float_series"]), ".*"])
 @pytest.mark.parametrize(
     "exp_filter",
     [
-        lambda: Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        lambda: FilterInternal.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
         lambda: f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
         lambda: [exp.name for exp in TEST_DATA.experiments[:3]],
     ],

--- a/tests/e2e/alpha/test_fetch_series.py
+++ b/tests/e2e/alpha/test_fetch_series.py
@@ -17,8 +17,8 @@ from neptune_fetcher.alpha import fetch_series
 from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.context import get_context
 from neptune_fetcher.internal.filters import (
-    AttributeFilter,
-    Filter,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.identifiers import (
     RunIdentifier,
@@ -100,11 +100,11 @@ def create_expected_data(
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
 @pytest.mark.parametrize("step_range", [(0.0, 5), (0, None), (None, 5), (None, None), (100, 200)])
 @pytest.mark.parametrize("tail_limit", [None, 3, 5])
-@pytest.mark.parametrize("attr_filter", [AttributeFilter(name_matches_all=[r".*"], type_in=["string_series"]), ".*"])
+@pytest.mark.parametrize("attr_filter", [AttributeFilterInternal(name_matches_all=[r".*"], type_in=["string_series"]), ".*"])
 @pytest.mark.parametrize(
     "exp_filter",
     [
-        lambda: Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        lambda: FilterInternal.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
         lambda: f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
         lambda: [exp.name for exp in TEST_DATA.experiments[:3]],
     ],

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -24,7 +24,7 @@ from neptune_fetcher.api.api_client import (
 )
 from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.composition import concurrency
-from neptune_fetcher.internal.filters import Filter
+from neptune_fetcher.internal.filters import FilterInternal
 from neptune_fetcher.internal.retrieval.search import fetch_experiment_sys_attrs
 from tests.e2e.data import (
     NOW,
@@ -198,7 +198,7 @@ def run_with_attributes(project, client):
             fetch_experiment_sys_attrs(
                 client,
                 identifiers.ProjectIdentifier(project_id),
-                Filter.name_in(experiment.name),
+                FilterInternal.name_in(experiment.name),
             )
         )
         if existing.items:
@@ -234,7 +234,7 @@ def run_with_attributes(project, client):
             fetch_experiment_sys_attrs(
                 client,
                 identifiers.ProjectIdentifier(project.project_identifier),
-                Filter.name_in(*TEST_DATA.experiment_names),
+                FilterInternal.name_in(*TEST_DATA.experiment_names),
             )
         )
 

--- a/tests/e2e/internal/composition/test_attributes.py
+++ b/tests/e2e/internal/composition/test_attributes.py
@@ -10,7 +10,7 @@ from datetime import (
 import pytest
 
 from neptune_fetcher.internal.composition.attributes import fetch_attribute_definitions
-from neptune_fetcher.internal.filters import AttributeFilter
+from neptune_fetcher.internal.filters import AttributeFilterInternal
 from neptune_fetcher.internal.identifiers import RunIdentifier
 from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
 
@@ -30,7 +30,7 @@ def run_with_attributes(client, project):
     from neptune_scale import Run
 
     from neptune_fetcher.internal import identifiers
-    from neptune_fetcher.internal.filters import Filter
+    from neptune_fetcher.internal.filters import FilterInternal
     from neptune_fetcher.internal.retrieval.search import fetch_experiment_sys_attrs
 
     project_identifier = project.project_identifier
@@ -39,7 +39,7 @@ def run_with_attributes(client, project):
         fetch_experiment_sys_attrs(
             client,
             identifiers.ProjectIdentifier(project_identifier),
-            Filter.name_in(EXPERIMENT_NAME),
+            FilterInternal.name_in(EXPERIMENT_NAME),
         )
     )
     if existing.items:
@@ -84,12 +84,12 @@ def run_with_attributes(client, project):
 
 @pytest.fixture(scope="module")
 def experiment_identifier(client, project, run_with_attributes) -> RunIdentifier:
-    from neptune_fetcher.internal.filters import Filter
+    from neptune_fetcher.internal.filters import FilterInternal
     from neptune_fetcher.internal.retrieval.search import fetch_experiment_sys_attrs
 
     project_identifier = project.project_identifier
 
-    experiment_filter = Filter.name_in(EXPERIMENT_NAME)
+    experiment_filter = FilterInternal.name_in(EXPERIMENT_NAME)
     experiment_attrs = _extract_pages(
         fetch_experiment_sys_attrs(client, project_identifier=project_identifier, filter_=experiment_filter)
     )
@@ -102,8 +102,8 @@ def test_fetch_attribute_definitions_filter_or(client, executor, project, experi
     # given
     project_identifier = project.project_identifier
 
-    attribute_filter_1 = AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_a$", type_in=["int"])
-    attribute_filter_2 = AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["float"])
+    attribute_filter_1 = AttributeFilterInternal(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_a$", type_in=["int"])
+    attribute_filter_2 = AttributeFilterInternal(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["float"])
 
     #  when
     attribute_filter = attribute_filter_1 | attribute_filter_2
@@ -131,8 +131,8 @@ def test_fetch_attribute_definitions_filter_or(client, executor, project, experi
     "make_attribute_filter",
     [
         lambda a, b, c: a | b | c,
-        lambda a, b, c: AttributeFilter.any(a, b, c),
-        lambda a, b, c: AttributeFilter.any(a, AttributeFilter.any(b, c)),
+        lambda a, b, c: AttributeFilterInternal.any(a, b, c),
+        lambda a, b, c: AttributeFilterInternal.any(a, AttributeFilterInternal.any(b, c)),
     ],
 )
 def test_fetch_attribute_definitions_filter_triple_or(
@@ -141,9 +141,9 @@ def test_fetch_attribute_definitions_filter_triple_or(
     # given
     project_identifier = project.project_identifier
 
-    attribute_filter_1 = AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_a$", type_in=["int"])
-    attribute_filter_2 = AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["float"])
-    attribute_filter_3 = AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["int"])
+    attribute_filter_1 = AttributeFilterInternal(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_a$", type_in=["int"])
+    attribute_filter_2 = AttributeFilterInternal(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["float"])
+    attribute_filter_3 = AttributeFilterInternal(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["int"])
     attribute_filter = make_attribute_filter(attribute_filter_1, attribute_filter_2, attribute_filter_3)
 
     #  when
@@ -173,7 +173,7 @@ def test_fetch_attribute_definitions_paging_executor(client, executor, project, 
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+    attribute_filter = AttributeFilterInternal(name_matches_all="sys/.*_time", type_in=["datetime"])
 
     attributes = _extract_pages(
         fetch_attribute_definitions(
@@ -202,10 +202,10 @@ def test_fetch_attribute_definitions_should_deduplicate_items(client, executor, 
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter_0 = AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+    attribute_filter_0 = AttributeFilterInternal(name_matches_all="sys/.*_time", type_in=["datetime"])
     attribute_filter = attribute_filter_0
     for i in range(10):
-        attribute_filter = attribute_filter | AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+        attribute_filter = attribute_filter | AttributeFilterInternal(name_matches_all="sys/.*_time", type_in=["datetime"])
 
     attributes = _extract_pages(
         fetch_attribute_definitions(

--- a/tests/e2e/internal/composition/test_download_files.py
+++ b/tests/e2e/internal/composition/test_download_files.py
@@ -7,8 +7,8 @@ import pytest
 
 from neptune_fetcher.internal.composition.download_files import download_files
 from neptune_fetcher.internal.filters import (
-    AttributeFilter,
-    Filter,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.retrieval.search import ContainerType
 from tests.e2e.data import (
@@ -29,8 +29,8 @@ def temp_dir():
 def test_download_files_missing(client, project, experiment_identifier, temp_dir):
     # when
     result_df = download_files(
-        filter_=Filter.name_in(EXPERIMENT_NAME),
-        attributes=AttributeFilter(name_eq=[f"{PATH}/files/object-does-not-exist"]),
+        filter_=FilterInternal.name_in(EXPERIMENT_NAME),
+        attributes=AttributeFilterInternal(name_eq=[f"{PATH}/files/object-does-not-exist"]),
         destination=temp_dir,
         context=None,
         container_type=ContainerType.EXPERIMENT,
@@ -54,8 +54,8 @@ def test_download_files_no_permission(client, project, experiment_identifier, te
 
     with pytest.raises(PermissionError):
         download_files(
-            filter_=Filter.name_in(EXPERIMENT_NAME),
-            attributes=AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
+            filter_=FilterInternal.name_in(EXPERIMENT_NAME),
+            attributes=AttributeFilterInternal(name_eq=[f"{PATH}/files/file-value.txt"]),
             destination=temp_dir,
             context=None,
             container_type=ContainerType.EXPERIMENT,
@@ -67,8 +67,8 @@ def test_download_files_no_permission(client, project, experiment_identifier, te
 def test_download_files_single(client, project, experiment_identifier, temp_dir):
     # when
     result_df = download_files(
-        filter_=Filter.name_in(EXPERIMENT_NAME),
-        attributes=AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
+        filter_=FilterInternal.name_in(EXPERIMENT_NAME),
+        attributes=AttributeFilterInternal(name_eq=[f"{PATH}/files/file-value.txt"]),
         destination=temp_dir,
         context=None,
         container_type=ContainerType.EXPERIMENT,
@@ -96,8 +96,8 @@ def test_download_files_single(client, project, experiment_identifier, temp_dir)
 def test_download_files_multiple(client, project, experiment_identifier, temp_dir):
     # when
     result_df = download_files(
-        filter_=Filter.name_in(EXPERIMENT_NAME),
-        attributes=AttributeFilter(name_eq=[f"{PATH}/files/file-value", f"{PATH}/files/file-value.txt"]),
+        filter_=FilterInternal.name_in(EXPERIMENT_NAME),
+        attributes=AttributeFilterInternal(name_eq=[f"{PATH}/files/file-value", f"{PATH}/files/file-value.txt"]),
         destination=temp_dir,
         context=None,
         container_type=ContainerType.EXPERIMENT,
@@ -135,8 +135,8 @@ def test_download_files_destination_a_file(client, project, experiment_identifie
 
     with pytest.raises(NotADirectoryError):
         download_files(
-            filter_=Filter.name_in(EXPERIMENT_NAME),
-            attributes=AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
+            filter_=FilterInternal.name_in(EXPERIMENT_NAME),
+            attributes=AttributeFilterInternal(name_eq=[f"{PATH}/files/file-value.txt"]),
             destination=destination,
             context=None,
             container_type=ContainerType.EXPERIMENT,

--- a/tests/e2e/internal/composition/test_type_inference.py
+++ b/tests/e2e/internal/composition/test_type_inference.py
@@ -12,8 +12,8 @@ from neptune_fetcher.internal.composition.type_inference import (
     infer_attribute_types_in_sort_by,
 )
 from neptune_fetcher.internal.filters import (
-    Attribute,
-    Filter,
+    AttributeInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.retrieval.search import fetch_experiment_sys_attrs
 
@@ -41,7 +41,7 @@ def run_with_attributes(client, project):
         fetch_experiment_sys_attrs(
             client,
             identifiers.ProjectIdentifier(project_identifier),
-            Filter.name_in(EXPERIMENT_NAME),
+            FilterInternal.name_in(EXPERIMENT_NAME),
         )
     )
     if existing.items:
@@ -89,7 +89,7 @@ def run_with_attributes_b(client, project):
         fetch_experiment_sys_attrs(
             client,
             identifiers.ProjectIdentifier(project_identifier),
-            Filter.name_in(EXPERIMENT_NAME_B),
+            FilterInternal.name_in(EXPERIMENT_NAME_B),
         )
     )
     if existing.items:
@@ -134,28 +134,28 @@ def test_infer_attribute_types_in_filter_no_filter(client, executor, project, ru
     "filter_before, filter_after",
     [
         (
-            Filter.eq(f"{PATH}/int-value", 10),
-            Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 10),
+                FilterInternal.eq(f"{PATH}/int-value", 10),
+                FilterInternal.eq(AttributeInternal(f"{PATH}/int-value", type="int"), 10),
         ),
         (
-            Filter.eq(f"{PATH}/float-value", 0.5),
-            Filter.eq(Attribute(f"{PATH}/float-value", type="float"), 0.5),
+                FilterInternal.eq(f"{PATH}/float-value", 0.5),
+                FilterInternal.eq(AttributeInternal(f"{PATH}/float-value", type="float"), 0.5),
         ),
         (
-            Filter.eq(f"{PATH}/str-value", "hello"),
-            Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello"),
+                FilterInternal.eq(f"{PATH}/str-value", "hello"),
+                FilterInternal.eq(AttributeInternal(f"{PATH}/str-value", type="string"), "hello"),
         ),
         (
-            Filter.eq(f"{PATH}/bool-value", True),
-            Filter.eq(Attribute(f"{PATH}/bool-value", type="bool"), True),
+                FilterInternal.eq(f"{PATH}/bool-value", True),
+                FilterInternal.eq(AttributeInternal(f"{PATH}/bool-value", type="bool"), True),
         ),
         (
-            Filter.eq(f"{PATH}/datetime-value", DATETIME_VALUE),
-            Filter.eq(Attribute(f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE),
+                FilterInternal.eq(f"{PATH}/datetime-value", DATETIME_VALUE),
+                FilterInternal.eq(AttributeInternal(f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE),
         ),
         (
-            Filter.eq(f"{PATH}/float-series-value", FLOAT_SERIES_VALUES[-1]),
-            Filter.eq(Attribute(f"{PATH}/float-series-value", type="float_series"), FLOAT_SERIES_VALUES[-1]),
+                FilterInternal.eq(f"{PATH}/float-series-value", FLOAT_SERIES_VALUES[-1]),
+                FilterInternal.eq(AttributeInternal(f"{PATH}/float-series-value", type="float_series"), FLOAT_SERIES_VALUES[-1]),
         ),
     ],
 )
@@ -181,12 +181,12 @@ def test_infer_attribute_types_in_filter_single(
 @pytest.mark.parametrize(
     "attribute_before, attribute_after",
     [
-        (Attribute(f"{PATH}/int-value"), Attribute(f"{PATH}/int-value", type="int")),
-        (Attribute(f"{PATH}/float-value"), Attribute(f"{PATH}/float-value", type="float")),
-        (Attribute(f"{PATH}/str-value"), Attribute(f"{PATH}/str-value", type="string")),
-        (Attribute(f"{PATH}/bool-value"), Attribute(f"{PATH}/bool-value", type="bool")),
-        (Attribute(f"{PATH}/datetime-value"), Attribute(f"{PATH}/datetime-value", type="datetime")),
-        (Attribute(f"{PATH}/float-series-value"), Attribute(f"{PATH}/float-series-value", type="float_series")),
+        (AttributeInternal(f"{PATH}/int-value"), AttributeInternal(f"{PATH}/int-value", type="int")),
+        (AttributeInternal(f"{PATH}/float-value"), AttributeInternal(f"{PATH}/float-value", type="float")),
+        (AttributeInternal(f"{PATH}/str-value"), AttributeInternal(f"{PATH}/str-value", type="string")),
+        (AttributeInternal(f"{PATH}/bool-value"), AttributeInternal(f"{PATH}/bool-value", type="bool")),
+        (AttributeInternal(f"{PATH}/datetime-value"), AttributeInternal(f"{PATH}/datetime-value", type="datetime")),
+        (AttributeInternal(f"{PATH}/float-series-value"), AttributeInternal(f"{PATH}/float-series-value", type="float_series")),
     ],
 )
 def infer_attribute_types_in_sort_by_single(
@@ -212,7 +212,7 @@ def infer_attribute_types_in_sort_by_single(
 @pytest.mark.parametrize(
     "filter_before",
     [
-        Filter.eq(f"{PATH}/does-not-exist", 10),
+        FilterInternal.eq(f"{PATH}/does-not-exist", 10),
     ],
 )
 def test_infer_attribute_types_in_filter_missing(client, executor, project, filter_before):
@@ -233,9 +233,9 @@ def test_infer_attribute_types_in_filter_missing(client, executor, project, filt
 @pytest.mark.parametrize(
     "attribute,experiment_filter",
     [
-        (Attribute(f"{PATH}/does-not-exist"), None),
-        (Attribute(f"{PATH}/does-not-exist"), Filter.name_in(EXPERIMENT_NAME)),
-        (Attribute(f"{PATH}/int-value"), Filter.name_in(EXPERIMENT_NAME + "does-not-exist")),
+        (AttributeInternal(f"{PATH}/does-not-exist"), None),
+        (AttributeInternal(f"{PATH}/does-not-exist"), FilterInternal.name_in(EXPERIMENT_NAME)),
+        (AttributeInternal(f"{PATH}/int-value"), FilterInternal.name_in(EXPERIMENT_NAME + "does-not-exist")),
     ],
 )
 def test_infer_attribute_types_in_sort_by_missing(client, executor, project, attribute, experiment_filter):
@@ -257,7 +257,7 @@ def test_infer_attribute_types_in_sort_by_missing(client, executor, project, att
 @pytest.mark.parametrize(
     "filter_before",
     [
-        Filter.eq(f"{PATH}/conflicting-type-int-str-value", 10),
+        FilterInternal.eq(f"{PATH}/conflicting-type-int-str-value", 10),
     ],
 )
 def test_infer_attribute_types_in_filter_conflicting_types(
@@ -283,7 +283,7 @@ def test_infer_attribute_types_in_filter_conflicting_types(
 @pytest.mark.parametrize(
     "filter_before",
     [
-        Filter.eq(f"{PATH}/conflicting-type-int-float-value", 0.5),
+        FilterInternal.eq(f"{PATH}/conflicting-type-int-float-value", 0.5),
     ],
 )
 def test_infer_attribute_types_in_filter_conflicting_types_todo(
@@ -306,10 +306,10 @@ def test_infer_attribute_types_in_filter_conflicting_types_todo(
 @pytest.mark.parametrize(
     "attribute_before,experiment_filter",
     [
-        (Attribute(f"{PATH}/conflicting-type-int-str-value"), None),
+        (AttributeInternal(f"{PATH}/conflicting-type-int-str-value"), None),
         (
-            Attribute(f"{PATH}/conflicting-type-int-str-value"),
-            Filter.name_in(EXPERIMENT_NAME, EXPERIMENT_NAME_B),
+                AttributeInternal(f"{PATH}/conflicting-type-int-str-value"),
+                FilterInternal.name_in(EXPERIMENT_NAME, EXPERIMENT_NAME_B),
         ),
     ],
 )
@@ -337,10 +337,10 @@ def test_infer_attribute_types_in_sort_by_conflicting_types(
 @pytest.mark.parametrize(
     "attribute_before,experiment_filter",
     [
-        (Attribute(f"{PATH}/conflicting-type-int-float-value"), None),
+        (AttributeInternal(f"{PATH}/conflicting-type-int-float-value"), None),
         (
-            Attribute(f"{PATH}/conflicting-type-int-float-value"),
-            Filter.name_in(EXPERIMENT_NAME, EXPERIMENT_NAME_B),
+                AttributeInternal(f"{PATH}/conflicting-type-int-float-value"),
+                FilterInternal.name_in(EXPERIMENT_NAME, EXPERIMENT_NAME_B),
         ),
     ],
 )
@@ -366,24 +366,24 @@ def test_infer_attribute_types_in_sort_by_conflicting_types_todo(
     "attribute_before,experiment_filter,attribute_after",
     [
         (
-            Attribute(f"{PATH}/conflicting-type-int-str-value"),
-            Filter.name_in(EXPERIMENT_NAME),
-            Attribute(f"{PATH}/conflicting-type-int-str-value", type="int"),
+                AttributeInternal(f"{PATH}/conflicting-type-int-str-value"),
+                FilterInternal.name_in(EXPERIMENT_NAME),
+                AttributeInternal(f"{PATH}/conflicting-type-int-str-value", type="int"),
         ),
         (
-            Attribute(f"{PATH}/conflicting-type-int-str-value"),
-            Filter.name_in(EXPERIMENT_NAME_B),
-            Attribute(f"{PATH}/conflicting-type-int-str-value", type="string"),
+                AttributeInternal(f"{PATH}/conflicting-type-int-str-value"),
+                FilterInternal.name_in(EXPERIMENT_NAME_B),
+                AttributeInternal(f"{PATH}/conflicting-type-int-str-value", type="string"),
         ),
         (
-            Attribute(f"{PATH}/conflicting-type-int-float-value"),
-            Filter.name_in(EXPERIMENT_NAME),
-            Attribute(f"{PATH}/conflicting-type-int-float-value", type="int"),
+                AttributeInternal(f"{PATH}/conflicting-type-int-float-value"),
+                FilterInternal.name_in(EXPERIMENT_NAME),
+                AttributeInternal(f"{PATH}/conflicting-type-int-float-value", type="int"),
         ),
         (
-            Attribute(f"{PATH}/conflicting-type-int-float-value"),
-            Filter.name_in(EXPERIMENT_NAME_B),
-            Attribute(f"{PATH}/conflicting-type-int-float-value", type="float"),
+                AttributeInternal(f"{PATH}/conflicting-type-int-float-value"),
+                FilterInternal.name_in(EXPERIMENT_NAME_B),
+                AttributeInternal(f"{PATH}/conflicting-type-int-float-value", type="float"),
         ),
     ],
 )

--- a/tests/e2e/internal/conftest.py
+++ b/tests/e2e/internal/conftest.py
@@ -14,12 +14,12 @@ def context(project):
 
 @pytest.fixture(scope="module")
 def experiment_identifier(client, project, run_with_attributes) -> RunIdentifier:
-    from neptune_fetcher.internal.filters import Filter
+    from neptune_fetcher.internal.filters import FilterInternal
     from neptune_fetcher.internal.retrieval.search import fetch_experiment_sys_attrs
 
     project_identifier = project.project_identifier
 
-    experiment_filter = Filter.name_in(TEST_DATA.experiment_names[0])
+    experiment_filter = FilterInternal.name_in(TEST_DATA.experiment_names[0])
     experiment_attrs = extract_pages(
         fetch_experiment_sys_attrs(client, project_identifier=project_identifier, filter_=experiment_filter)
     )

--- a/tests/e2e/internal/retrieval/test_attributes.py
+++ b/tests/e2e/internal/retrieval/test_attributes.py
@@ -10,7 +10,7 @@ from datetime import (
 import pytest
 
 from neptune_fetcher.exceptions import NeptuneProjectInaccessible
-from neptune_fetcher.internal.filters import AttributeFilter
+from neptune_fetcher.internal.filters import AttributeFilterInternal
 from neptune_fetcher.internal.identifiers import (
     ProjectIdentifier,
     RunIdentifier,
@@ -43,7 +43,7 @@ def test_fetch_attribute_definitions_project_does_not_exist(client, project):
     workspace, project = project.project_identifier.split("/")
     project_identifier = ProjectIdentifier(f"{workspace}/does-not-exist")
 
-    attribute_filter = AttributeFilter(name_eq="sys/name", type_in=["string"])
+    attribute_filter = AttributeFilterInternal(name_eq="sys/name", type_in=["string"])
     with pytest.raises(NeptuneProjectInaccessible):
         _extract_pages(
             fetch_attribute_definitions_single_filter(
@@ -58,7 +58,7 @@ def test_fetch_attribute_definitions_project_does_not_exist(client, project):
 def test_fetch_attribute_definitions_workspace_does_not_exist(client, project):
     project_identifier = ProjectIdentifier("this-workspace/does-not-exist")
 
-    attribute_filter = AttributeFilter(name_eq="sys/name", type_in=["string"])
+    attribute_filter = AttributeFilterInternal(name_eq="sys/name", type_in=["string"])
     with pytest.raises(NeptuneProjectInaccessible):
         _extract_pages(
             fetch_attribute_definitions_single_filter(
@@ -75,7 +75,7 @@ def test_fetch_attribute_definitions_single_string(client, project, experiment_i
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = AttributeFilter(name_eq="sys/name", type_in=["string"])
+    attribute_filter = AttributeFilterInternal(name_eq="sys/name", type_in=["string"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client, [project_identifier], [experiment_identifier], attribute_filter=attribute_filter
@@ -91,7 +91,7 @@ def test_fetch_attribute_definitions_does_not_exist(client, project, experiment_
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = AttributeFilter(name_eq="does-not-exist", type_in=["string"])
+    attribute_filter = AttributeFilterInternal(name_eq="does-not-exist", type_in=["string"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -110,7 +110,7 @@ def test_fetch_attribute_definitions_two_strings(client, project, experiment_ide
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = AttributeFilter(name_eq=["sys/name", "sys/owner"], type_in=["string"])
+    attribute_filter = AttributeFilterInternal(name_eq=["sys/name", "sys/owner"], type_in=["string"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -136,7 +136,7 @@ def test_fetch_attribute_definitions_single_float_series(client, project, experi
     path = FLOAT_SERIES_PATHS[0]
 
     #  when
-    attribute_filter = AttributeFilter(name_eq=path, type_in=["float_series"])
+    attribute_filter = AttributeFilterInternal(name_eq=path, type_in=["float_series"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -156,7 +156,7 @@ def test_fetch_attribute_definitions_single_string_series(client, project, exper
     path = STRING_SERIES_PATHS[0]
 
     #  when
-    attribute_filter = AttributeFilter(name_eq=path, type_in=["string_series"])
+    attribute_filter = AttributeFilterInternal(name_eq=path, type_in=["string_series"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -186,7 +186,7 @@ def test_fetch_attribute_definitions_all_types(client, project, experiment_ident
     ]
 
     #  when
-    attribute_filter = AttributeFilter(name_eq=[name for name, _ in all_attrs])
+    attribute_filter = AttributeFilterInternal(name_eq=[name for name, _ in all_attrs])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -206,7 +206,7 @@ def test_fetch_attribute_definitions_no_type_in(client, project, experiment_iden
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = AttributeFilter(name_eq="sys/name")
+    attribute_filter = AttributeFilterInternal(name_eq="sys/name")
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -225,7 +225,7 @@ def test_fetch_attribute_definitions_regex_matches_all(client, project, experime
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+    attribute_filter = AttributeFilterInternal(name_matches_all="sys/.*_time", type_in=["datetime"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -251,7 +251,7 @@ def test_fetch_attribute_definitions_regex_matches_none(client, project, experim
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = AttributeFilter(
+    attribute_filter = AttributeFilterInternal(
         name_matches_all="sys/.*_time", name_matches_none="modification", type_in=["datetime"]
     )
     attributes = _extract_pages(
@@ -279,7 +279,7 @@ def test_fetch_attribute_definitions_multiple_projects(client, project, experime
     project_identifier_2 = f"{project_identifier}-does-not-exist"
 
     #  when
-    attribute_filter = AttributeFilter(name_eq="sys/name", type_in=["string"])
+    attribute_filter = AttributeFilterInternal(name_eq="sys/name", type_in=["string"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -298,7 +298,7 @@ def test_fetch_attribute_definitions_paging(client, project, experiment_identifi
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+    attribute_filter = AttributeFilterInternal(name_matches_all="sys/.*_time", type_in=["datetime"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -325,7 +325,7 @@ def test_fetch_attribute_definitions_experiment_identifier_none(client, project,
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = AttributeFilter(name_eq="sys/name", type_in=["string"])
+    attribute_filter = AttributeFilterInternal(name_eq="sys/name", type_in=["string"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -344,7 +344,7 @@ def test_fetch_attribute_definitions_experiment_identifier_empty(client, project
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = AttributeFilter(name_eq="sys/name", type_in=["string"])
+    attribute_filter = AttributeFilterInternal(name_eq="sys/name", type_in=["string"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -567,7 +567,7 @@ def test_fetch_attribute_definitions_experiment_large_number_experiment_identifi
     experiment_identifiers = [experiment_identifier] + _generate_experiment_identifiers(project_identifier, 240 * 1024)
 
     #  when
-    attribute_filter = AttributeFilter(name_eq="sys/name", type_in=["string"])
+    attribute_filter = AttributeFilterInternal(name_eq="sys/name", type_in=["string"])
     attributes = _extract_pages(
         fetch_attribute_definitions_single_filter(
             client,

--- a/tests/e2e/internal/retrieval/test_search.py
+++ b/tests/e2e/internal/retrieval/test_search.py
@@ -11,8 +11,8 @@ import pytz
 
 from neptune_fetcher.exceptions import NeptuneProjectInaccessible
 from neptune_fetcher.internal.filters import (
-    Attribute,
-    Filter,
+    AttributeInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.identifiers import ProjectIdentifier
 from neptune_fetcher.internal.retrieval import util
@@ -78,14 +78,14 @@ def test_find_experiments_by_name(client, project, run_with_attributes):
     project_identifier = project.project_identifier
 
     #  when
-    experiment_filter = Filter.name_eq(EXPERIMENT_NAME)
+    experiment_filter = FilterInternal.name_eq(EXPERIMENT_NAME)
     experiment_names = _extract_names(fetch_experiment_sys_attrs(client, project_identifier, experiment_filter))
 
     # then
     assert experiment_names == [EXPERIMENT_NAME]
 
     #  when
-    experiment_filter = Filter.name_in(EXPERIMENT_NAME, "experiment_not_found")
+    experiment_filter = FilterInternal.name_in(EXPERIMENT_NAME, "experiment_not_found")
     experiment_names = _extract_names(fetch_experiment_sys_attrs(client, project_identifier, experiment_filter))
 
     # then
@@ -97,7 +97,7 @@ def test_find_experiments_by_name_not_found(client, project):
     project_identifier = project.project_identifier
 
     #  when
-    experiment_filter = Filter.name_eq("name_not_found")
+    experiment_filter = FilterInternal.name_eq("name_not_found")
     experiment_names = _extract_names(fetch_experiment_sys_attrs(client, project_identifier, experiment_filter))
 
     # then
@@ -107,99 +107,99 @@ def test_find_experiments_by_name_not_found(client, project):
 @pytest.mark.parametrize(
     "experiment_filter,found",
     [
-        (Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0), True),
-        (Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 1), False),
-        (Filter.ne(Attribute(name=f"{PATH}/int-value", type="int"), 0), False),
-        (Filter.ne(Attribute(name=f"{PATH}/int-value", type="int"), 1), True),
-        (Filter.ge(Attribute(name=f"{PATH}/int-value", type="int"), 0), True),
-        (Filter.gt(Attribute(name=f"{PATH}/int-value", type="int"), 0), False),
-        (Filter.le(Attribute(name=f"{PATH}/int-value", type="int"), 0), True),
-        (Filter.lt(Attribute(name=f"{PATH}/int-value", type="int"), 0), False),
-        (Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.0), True),
-        (Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.1), False),
-        (Filter.ne(Attribute(name=f"{PATH}/float-value", type="float"), 0.0), False),
-        (Filter.ne(Attribute(name=f"{PATH}/float-value", type="float"), 0.1), True),
-        (Filter.ge(Attribute(name=f"{PATH}/float-value", type="float"), 0.0), True),
-        (Filter.gt(Attribute(name=f"{PATH}/float-value", type="float"), 0.0), False),
-        (Filter.le(Attribute(name=f"{PATH}/float-value", type="float"), 0.0), True),
-        (Filter.lt(Attribute(name=f"{PATH}/float-value", type="float"), 0.0), False),
-        (Filter.eq(Attribute(name=f"{PATH}/bool-value", type="bool"), "True"), True),
-        (Filter.eq(Attribute(name=f"{PATH}/bool-value", type="bool"), "False"), False),
-        (Filter.ne(Attribute(name=f"{PATH}/bool-value", type="bool"), "True"), False),
-        (Filter.ne(Attribute(name=f"{PATH}/bool-value", type="bool"), "False"), True),
-        (Filter.eq(Attribute(name=f"{PATH}/str-value", type="string"), "hello_0"), True),
-        (Filter.eq(Attribute(name=f"{PATH}/str-value", type="string"), "hello2"), False),
-        (Filter.ne(Attribute(name=f"{PATH}/str-value", type="string"), "hello_0"), False),
-        (Filter.ne(Attribute(name=f"{PATH}/str-value", type="string"), "hello2"), True),
-        (Filter.matches_all(Attribute(name=f"{PATH}/str-value", type="string"), "^he..o_0$"), True),
-        (Filter.matches_all(Attribute(name=f"{PATH}/str-value", type="string"), ["^he", "lo_0$"]), True),
-        (Filter.matches_all(Attribute(name=f"{PATH}/str-value", type="string"), ["^he", "y"]), False),
-        (Filter.matches_none(Attribute(name=f"{PATH}/str-value", type="string"), "x"), True),
-        (Filter.matches_none(Attribute(name=f"{PATH}/str-value", type="string"), ["x", "y"]), True),
-        (Filter.matches_none(Attribute(name=f"{PATH}/str-value", type="string"), ["^he", "y"]), False),
-        (Filter.contains_all(Attribute(name=f"{PATH}/str-value", type="string"), "ll"), True),
-        (Filter.contains_all(Attribute(name=f"{PATH}/str-value", type="string"), ["e", "ll"]), True),
-        (Filter.contains_all(Attribute(name=f"{PATH}/str-value", type="string"), ["he", "y"]), False),
-        (Filter.contains_none(Attribute(name=f"{PATH}/str-value", type="string"), "x"), True),
-        (Filter.contains_none(Attribute(name=f"{PATH}/str-value", type="string"), ["x", "y"]), True),
-        (Filter.contains_none(Attribute(name=f"{PATH}/str-value", type="string"), ["he", "y"]), False),
-        (Filter.eq(Attribute(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), True),
-        (Filter.eq(Attribute(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE2), False),
-        (Filter.ne(Attribute(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), False),
-        (Filter.ne(Attribute(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE2), True),
-        (Filter.ge(Attribute(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), True),
-        (Filter.gt(Attribute(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), False),
-        (Filter.le(Attribute(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), True),
-        (Filter.lt(Attribute(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), False),
-        (Filter.exists(Attribute(name=f"{PATH}/str-value", type="string")), True),
-        (Filter.exists(Attribute(name=f"{PATH}/str-value", type="int")), False),
-        (Filter.exists(Attribute(name=f"{PATH}/does-not-exist-value", type="string")), False),
+        (FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0), True),
+        (FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 1), False),
+        (FilterInternal.ne(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0), False),
+        (FilterInternal.ne(AttributeInternal(name=f"{PATH}/int-value", type="int"), 1), True),
+        (FilterInternal.ge(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0), True),
+        (FilterInternal.gt(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0), False),
+        (FilterInternal.le(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0), True),
+        (FilterInternal.lt(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0), False),
+        (FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0), True),
+        (FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.1), False),
+        (FilterInternal.ne(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0), False),
+        (FilterInternal.ne(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.1), True),
+        (FilterInternal.ge(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0), True),
+        (FilterInternal.gt(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0), False),
+        (FilterInternal.le(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0), True),
+        (FilterInternal.lt(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0), False),
+        (FilterInternal.eq(AttributeInternal(name=f"{PATH}/bool-value", type="bool"), "True"), True),
+        (FilterInternal.eq(AttributeInternal(name=f"{PATH}/bool-value", type="bool"), "False"), False),
+        (FilterInternal.ne(AttributeInternal(name=f"{PATH}/bool-value", type="bool"), "True"), False),
+        (FilterInternal.ne(AttributeInternal(name=f"{PATH}/bool-value", type="bool"), "False"), True),
+        (FilterInternal.eq(AttributeInternal(name=f"{PATH}/str-value", type="string"), "hello_0"), True),
+        (FilterInternal.eq(AttributeInternal(name=f"{PATH}/str-value", type="string"), "hello2"), False),
+        (FilterInternal.ne(AttributeInternal(name=f"{PATH}/str-value", type="string"), "hello_0"), False),
+        (FilterInternal.ne(AttributeInternal(name=f"{PATH}/str-value", type="string"), "hello2"), True),
+        (FilterInternal.matches_all(AttributeInternal(name=f"{PATH}/str-value", type="string"), "^he..o_0$"), True),
+        (FilterInternal.matches_all(AttributeInternal(name=f"{PATH}/str-value", type="string"), ["^he", "lo_0$"]), True),
+        (FilterInternal.matches_all(AttributeInternal(name=f"{PATH}/str-value", type="string"), ["^he", "y"]), False),
+        (FilterInternal.matches_none(AttributeInternal(name=f"{PATH}/str-value", type="string"), "x"), True),
+        (FilterInternal.matches_none(AttributeInternal(name=f"{PATH}/str-value", type="string"), ["x", "y"]), True),
+        (FilterInternal.matches_none(AttributeInternal(name=f"{PATH}/str-value", type="string"), ["^he", "y"]), False),
+        (FilterInternal.contains_all(AttributeInternal(name=f"{PATH}/str-value", type="string"), "ll"), True),
+        (FilterInternal.contains_all(AttributeInternal(name=f"{PATH}/str-value", type="string"), ["e", "ll"]), True),
+        (FilterInternal.contains_all(AttributeInternal(name=f"{PATH}/str-value", type="string"), ["he", "y"]), False),
+        (FilterInternal.contains_none(AttributeInternal(name=f"{PATH}/str-value", type="string"), "x"), True),
+        (FilterInternal.contains_none(AttributeInternal(name=f"{PATH}/str-value", type="string"), ["x", "y"]), True),
+        (FilterInternal.contains_none(AttributeInternal(name=f"{PATH}/str-value", type="string"), ["he", "y"]), False),
+        (FilterInternal.eq(AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), True),
+        (FilterInternal.eq(AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE2), False),
+        (FilterInternal.ne(AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), False),
+        (FilterInternal.ne(AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE2), True),
+        (FilterInternal.ge(AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), True),
+        (FilterInternal.gt(AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), False),
+        (FilterInternal.le(AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), True),
+        (FilterInternal.lt(AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"), DATETIME_VALUE), False),
+        (FilterInternal.exists(AttributeInternal(name=f"{PATH}/str-value", type="string")), True),
+        (FilterInternal.exists(AttributeInternal(name=f"{PATH}/str-value", type="int")), False),
+        (FilterInternal.exists(AttributeInternal(name=f"{PATH}/does-not-exist-value", type="string")), False),
         # (Filter.exists(Attribute(name=f"{PATH}/files/file-value.txt", type="file")), True),
         # TODO - FILE not supported in nql
-        (Filter.exists(Attribute(name=f"{PATH}/files/file-value.txt", type="int")), False),
+        (FilterInternal.exists(AttributeInternal(name=f"{PATH}/files/file-value.txt", type="int")), False),
         # (Filter.exists(Attribute(name=f"{PATH}/files/does-not-exist-value.txt", type="file")), False),
         # TODO - FILE not supported in nql
         (
-            Filter.eq(
-                Attribute(name=f"{PATH}/datetime-value", type="datetime"),
+                FilterInternal.eq(
+                AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"),
                 DATETIME_VALUE.astimezone(pytz.timezone("CET")),
             ),
-            True,
+                True,
         ),
         (
-            Filter.eq(
-                Attribute(name=f"{PATH}/datetime-value", type="datetime"),
+                FilterInternal.eq(
+                AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"),
                 (DATETIME_VALUE + ONE_SECOND).astimezone(pytz.timezone("CET")),
             ),
-            False,
+                False,
         ),
         (
-            Filter.eq(
-                Attribute(name=f"{PATH}/datetime-value", type="datetime"),
+                FilterInternal.eq(
+                AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"),
                 DATETIME_VALUE.astimezone(pytz.timezone("EST")),
             ),
-            True,
+                True,
         ),
         (
-            Filter.eq(
-                Attribute(name=f"{PATH}/datetime-value", type="datetime"),
+                FilterInternal.eq(
+                AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"),
                 (DATETIME_VALUE + ONE_SECOND).astimezone(pytz.timezone("EST")),
             ),
-            False,
+                False,
         ),
         (
-            Filter.eq(
-                Attribute(name=f"{PATH}/datetime-value", type="datetime"),
+                FilterInternal.eq(
+                AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"),
                 DATETIME_VALUE.astimezone(SYSTEM_TZ).replace(tzinfo=None),
             ),
-            True,
+                True,
         ),
         (
-            Filter.eq(
-                Attribute(name=f"{PATH}/datetime-value", type="datetime"),
+                FilterInternal.eq(
+                AttributeInternal(name=f"{PATH}/datetime-value", type="datetime"),
                 (DATETIME_VALUE + ONE_SECOND).astimezone(SYSTEM_TZ).replace(tzinfo=None),
             ),
-            False,
+                False,
         ),
     ],
 )
@@ -221,119 +221,119 @@ def test_find_experiments_by_config_values(client, project, run_with_attributes,
     "experiment_filter,found",
     [
         (
-            Filter.eq(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="last"),
+                FilterInternal.eq(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="last"),
                 FLOAT_SERIES_VALUES[-1],
             ),
-            True,
+                True,
         ),
         (
-            Filter.eq(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="last"),
+                FilterInternal.eq(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="last"),
                 FLOAT_SERIES_VALUES[-2],
             ),
-            False,
+                False,
         ),
         (
-            Filter.ne(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="last"),
+                FilterInternal.ne(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="last"),
                 FLOAT_SERIES_VALUES[-1],
             ),
-            False,
+                False,
         ),
         (
-            Filter.eq(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="min"),
+                FilterInternal.eq(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="min"),
                 min(FLOAT_SERIES_VALUES),
             ),
-            True,
+                True,
         ),
         (
-            Filter.eq(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="min"),
+                FilterInternal.eq(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="min"),
                 min(FLOAT_SERIES_VALUES) + 1,
             ),
-            False,
+                False,
         ),
         (
-            Filter.ne(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="min"),
+                FilterInternal.ne(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="min"),
                 min(FLOAT_SERIES_VALUES),
             ),
-            False,
+                False,
         ),
         (
-            Filter.eq(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="max"),
+                FilterInternal.eq(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="max"),
                 max(FLOAT_SERIES_VALUES),
             ),
-            True,
+                True,
         ),
         (
-            Filter.eq(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="max"),
+                FilterInternal.eq(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="max"),
                 max(FLOAT_SERIES_VALUES) + 1,
             ),
-            False,
+                False,
         ),
         (
-            Filter.ne(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="max"),
+                FilterInternal.ne(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="max"),
                 max(FLOAT_SERIES_VALUES),
             ),
-            False,
+                False,
         ),
         (
-            Filter.eq(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="average"),
+                FilterInternal.eq(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="average"),
                 sum(FLOAT_SERIES_VALUES) / len(FLOAT_SERIES_VALUES),
             ),
-            True,
+                True,
         ),
         (
-            Filter.eq(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="average"),
+                FilterInternal.eq(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="average"),
                 sum(FLOAT_SERIES_VALUES) / len(FLOAT_SERIES_VALUES) + 1.0,
             ),
-            False,
+                False,
         ),
         (
-            Filter.ne(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="average"),
+                FilterInternal.ne(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="average"),
                 sum(FLOAT_SERIES_VALUES) / len(FLOAT_SERIES_VALUES),
             ),
-            False,
+                False,
         ),
         (
-            Filter.ge(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                FilterInternal.ge(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
                 _variance(FLOAT_SERIES_VALUES) - 1e-6,
             )
-            & Filter.le(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                & FilterInternal.le(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
                 _variance(FLOAT_SERIES_VALUES) + 1e-6,
             ),
-            True,
+                True,
         ),
         (
-            Filter.eq(
-                Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                FilterInternal.eq(
+                AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
                 _variance(FLOAT_SERIES_VALUES) + 1,
             ),
-            False,
+                False,
         ),
         (
-            Filter.negate(
-                Filter.ge(
-                    Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                FilterInternal.negate(
+                    FilterInternal.ge(
+                    AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
                     _variance(FLOAT_SERIES_VALUES) - 1e-6,
                 )
-                & Filter.le(
-                    Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                    & FilterInternal.le(
+                    AttributeInternal(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
                     _variance(FLOAT_SERIES_VALUES) + 1e-6,
                 )
             ),
-            False,
+                False,
         ),
     ],
 )
@@ -355,21 +355,21 @@ def test_find_experiments_by_float_series_values(client, project, run_with_attri
     "experiment_filter,found",
     [
         (
-            Filter.exists(
-                Attribute(name=STRING_SERIES_PATHS[0], type="string_series"),
+                FilterInternal.exists(
+                AttributeInternal(name=STRING_SERIES_PATHS[0], type="string_series"),
             ),
-            True,
+                True,
         ),
         (
-            Filter.eq(Attribute(name=STRING_SERIES_PATHS[0], type="string_series"), STRING_SERIES_VALUES[-1]),
-            True,
+                FilterInternal.eq(AttributeInternal(name=STRING_SERIES_PATHS[0], type="string_series"), STRING_SERIES_VALUES[-1]),
+                True,
         ),
         (
-            Filter.eq(
-                Attribute(name=STRING_SERIES_PATHS[0], type="string_series"),
+                FilterInternal.eq(
+                AttributeInternal(name=STRING_SERIES_PATHS[0], type="string_series"),
                 STRING_SERIES_VALUES[-2],
             ),
-            False,
+                False,
         ),
     ],
 )
@@ -391,139 +391,139 @@ def test_find_experiments_by_string_series_values(client, project, run_with_attr
     "experiment_filter,found",
     [
         (
-            Filter.all(
-                Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                FilterInternal.all(
+                FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0),
             ),
-            True,
+                True,
         ),
         (
-            Filter.all(
-                Filter.ne(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                FilterInternal.all(
+                FilterInternal.ne(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0),
             ),
-            False,
+                False,
         ),
         (
-            Filter.all(
-                Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                Filter.ne(Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                FilterInternal.all(
+                FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                FilterInternal.ne(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0),
             ),
-            False,
+                False,
         ),
         (
-            Filter.all(
-                Filter.ne(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                Filter.ne(Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                FilterInternal.all(
+                FilterInternal.ne(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                FilterInternal.ne(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0),
             ),
-            False,
+                False,
         ),
         (
-            Filter.any(
-                Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                FilterInternal.any(
+                FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0),
             ),
-            True,
+                True,
         ),
         (
-            Filter.any(
-                Filter.ne(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                FilterInternal.any(
+                FilterInternal.ne(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0),
             ),
-            True,
+                True,
         ),
         (
-            Filter.any(
-                Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                Filter.ne(Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                FilterInternal.any(
+                FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                FilterInternal.ne(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0),
             ),
-            True,
+                True,
         ),
         (
-            Filter.any(
-                Filter.ne(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                Filter.ne(Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                FilterInternal.any(
+                FilterInternal.ne(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                FilterInternal.ne(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0),
             ),
-            False,
+                False,
         ),
         (
-            Filter.negate(
-                Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                FilterInternal.negate(
+                FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
             ),
-            False,
+                False,
         ),
         (
-            Filter.negate(
-                Filter.ne(Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                FilterInternal.negate(
+                FilterInternal.ne(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
             ),
-            True,
+                True,
         ),
         (
-            Filter.all(
-                Filter.any(
-                    Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                    Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                FilterInternal.all(
+                FilterInternal.any(
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.1),
                 ),
-                Filter.any(
-                    Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-                ),
-            ),
-            True,
-        ),
-        (
-            Filter.all(
-                Filter.any(
-                    Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                    Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
-                Filter.any(
-                    Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                FilterInternal.any(
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 1),
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0),
                 ),
             ),
-            False,
+                True,
         ),
         (
-            Filter.any(
-                Filter.all(
-                    Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                    Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                FilterInternal.all(
+                FilterInternal.any(
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.1),
                 ),
-                Filter.all(
-                    Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                FilterInternal.any(
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 1),
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.1),
                 ),
             ),
-            True,
+                False,
         ),
         (
-            Filter.any(
-                Filter.all(
-                    Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                    Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                FilterInternal.any(
+                FilterInternal.all(
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.0),
                 ),
-                Filter.all(
-                    Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                FilterInternal.all(
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 1),
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.1),
                 ),
             ),
-            False,
+                True,
         ),
         (
-            Filter.negate(
-                Filter.any(
-                    Filter.all(
-                        Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                        Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                FilterInternal.any(
+                FilterInternal.all(
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.1),
+                ),
+                FilterInternal.all(
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 1),
+                    FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.1),
+                ),
+            ),
+                False,
+        ),
+        (
+                FilterInternal.negate(
+                FilterInternal.any(
+                    FilterInternal.all(
+                        FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 0),
+                        FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.1),
                     ),
-                    Filter.all(
-                        Filter.eq(Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                        Filter.eq(Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                    FilterInternal.all(
+                        FilterInternal.eq(AttributeInternal(name=f"{PATH}/int-value", type="int"), 1),
+                        FilterInternal.eq(AttributeInternal(name=f"{PATH}/float-value", type="float"), 0.1),
                     ),
                 )
             ),
-            True,
+                True,
         ),
     ],
 )
@@ -551,7 +551,7 @@ def test_find_experiments_sort_by_name_desc(client, project, run_with_attributes
             client,
             project_identifier,
             filter_=None,
-            sort_by=Attribute("sys/name", type="string"),
+            sort_by=AttributeInternal("sys/name", type="string"),
             sort_direction="desc",
         )
     )
@@ -571,7 +571,7 @@ def test_find_experiments_sort_by_name_asc(client, project, run_with_attributes)
             client,
             project_identifier,
             filter_=None,
-            sort_by=Attribute("sys/name", type="string"),
+            sort_by=AttributeInternal("sys/name", type="string"),
             sort_direction="asc",
         )
     )
@@ -591,7 +591,7 @@ def test_find_experiments_sort_by_aggregate(client, project, run_with_attributes
             client,
             project_identifier,
             filter_=None,
-            sort_by=Attribute(f"{PATH}/float-series-value", type="float_series"),
+            sort_by=AttributeInternal(f"{PATH}/float-series-value", type="float_series"),
         )
     )
 

--- a/tests/unit/alpha/test_filters.py
+++ b/tests/unit/alpha/test_filters.py
@@ -3,66 +3,66 @@ from datetime import datetime
 import pytest
 
 from neptune_fetcher.internal.filters import (
-    Attribute,
-    AttributeFilter,
-    Filter,
+    AttributeInternal,
+    AttributeFilterInternal,
+    FilterInternal,
 )
 from neptune_fetcher.internal.retrieval import attribute_types as types
 
 
 def test_attribute_valid_values():
     # Test valid cases - should not raise exceptions
-    Attribute(name="test")  # minimal case
-    Attribute(name="test", aggregation="last")
-    Attribute(name="test", type="float")
-    Attribute(name="test", aggregation="variance", type="float_series")
+    AttributeInternal(name="test")  # minimal case
+    AttributeInternal(name="test", aggregation="last")
+    AttributeInternal(name="test", type="float")
+    AttributeInternal(name="test", aggregation="variance", type="float_series")
 
 
 def test_attribute_invalid_aggregation():
     # Test invalid aggregation values
     with pytest.raises(ValueError) as exc_info:
-        Attribute(name="test", aggregation="invalid_agg")
+        AttributeInternal(name="test", aggregation="invalid_agg")
     assert f"aggregation must be one of: {sorted(types.ALL_AGGREGATIONS)}" in str(exc_info.value)
 
 
 def test_attribute_invalid_type():
     # Test invalid type values
     with pytest.raises(ValueError) as exc_info:
-        Attribute(name="test", type="invalid_type")
+        AttributeInternal(name="test", type="invalid_type")
     assert f"type must be one of: {sorted(types.ALL_TYPES)}" in str(exc_info.value)
 
 
 @pytest.mark.parametrize("aggregation", types.ALL_AGGREGATIONS)
 def test_attribute_all_valid_aggregations(aggregation):
     # Test all valid aggregation values
-    attr = Attribute(name="test", aggregation=aggregation)
+    attr = AttributeInternal(name="test", aggregation=aggregation)
     assert attr.aggregation == aggregation
 
 
 @pytest.mark.parametrize("type_", types.ALL_TYPES)
 def test_attribute_all_valid_types(type_):
     # Test all valid type values
-    attr = Attribute(name="test", type=type_)
+    attr = AttributeInternal(name="test", type=type_)
     assert attr.type == type_
 
 
 def test_filter_valid_values():
     # Test valid cases - should not raise exceptions
-    Filter.eq("test", "value")  # str value
-    Filter.eq("test", 42)  # int value
-    Filter.eq("test", 3.14)  # float value
-    Filter.eq("test", datetime.now())  # datetime value
+    FilterInternal.eq("test", "value")  # str value
+    FilterInternal.eq("test", 42)  # int value
+    FilterInternal.eq("test", 3.14)  # float value
+    FilterInternal.eq("test", datetime.now())  # datetime value
 
     # Test all operators with string value
-    Filter.ne("test", "value")
-    Filter.gt("test", "value")
-    Filter.ge("test", "value")
-    Filter.lt("test", "value")
-    Filter.le("test", "value")
-    Filter.matches_all("test", "value")
-    Filter.matches_none("test", "value")
-    Filter.contains_all("test", "value")
-    Filter.contains_none("test", "value")
+    FilterInternal.ne("test", "value")
+    FilterInternal.gt("test", "value")
+    FilterInternal.ge("test", "value")
+    FilterInternal.lt("test", "value")
+    FilterInternal.le("test", "value")
+    FilterInternal.matches_all("test", "value")
+    FilterInternal.matches_none("test", "value")
+    FilterInternal.contains_all("test", "value")
+    FilterInternal.contains_none("test", "value")
 
 
 def test_filter_invalid_value_type():
@@ -76,7 +76,7 @@ def test_filter_invalid_value_type():
 
     for invalid_value in invalid_values:
         with pytest.raises(TypeError) as exc_info:
-            Filter.eq("test", invalid_value)  # type: ignore
+            FilterInternal.eq("test", invalid_value)  # type: ignore
         assert "Invalid value type:" in str(exc_info.value)
         assert "Expected int, float, str, or datetime" in str(exc_info.value)
 
@@ -84,16 +84,16 @@ def test_filter_invalid_value_type():
 @pytest.mark.parametrize(
     "method,operator",
     [
-        (Filter.eq, "=="),
-        (Filter.ne, "!="),
-        (Filter.gt, ">"),
-        (Filter.ge, ">="),
-        (Filter.lt, "<"),
-        (Filter.le, "<="),
-        (Filter.matches_all, "MATCHES"),
-        (Filter.matches_none, "NOT MATCHES"),
-        (Filter.contains_all, "CONTAINS"),
-        (Filter.contains_none, "NOT CONTAINS"),
+        (FilterInternal.eq, "=="),
+        (FilterInternal.ne, "!="),
+        (FilterInternal.gt, ">"),
+        (FilterInternal.ge, ">="),
+        (FilterInternal.lt, "<"),
+        (FilterInternal.le, "<="),
+        (FilterInternal.matches_all, "MATCHES"),
+        (FilterInternal.matches_none, "NOT MATCHES"),
+        (FilterInternal.contains_all, "CONTAINS"),
+        (FilterInternal.contains_none, "NOT CONTAINS"),
     ],
 )
 def test_filter_operators(method, operator):
@@ -102,21 +102,21 @@ def test_filter_operators(method, operator):
     value = "value"
     filter_obj = method(attr, value)
     assert filter_obj.operator == operator
-    assert isinstance(filter_obj.attribute, Attribute)
+    assert isinstance(filter_obj.attribute, AttributeInternal)
     assert filter_obj.value == value
 
 
 def test_filter_with_attribute_object():
     # Test using Attribute object instead of string
-    attr = Attribute(name="test", type="string")
-    filter_obj = Filter.eq(attr, "value")
+    attr = AttributeInternal(name="test", type="string")
+    filter_obj = FilterInternal.eq(attr, "value")
     assert filter_obj.attribute == attr
     assert filter_obj.value == "value"
 
 
 def test_filter_query_string_escaping():
     # Test that special characters in values are properly escaped
-    filter_obj = Filter.eq("test", 'value with "quotes" and \\backslashes\\')
+    filter_obj = FilterInternal.eq("test", 'value with "quotes" and \\backslashes\\')
     query = filter_obj.to_query()
     assert '"value with \\"quotes\\" and \\\\backslashes\\\\"' in query
 
@@ -124,22 +124,22 @@ def test_filter_query_string_escaping():
 def test_filter_datetime_formatting():
     # Test datetime value formatting in query
     now = datetime.now()
-    filter_obj = Filter.eq("test", now)
+    filter_obj = FilterInternal.eq("test", now)
     query = filter_obj.to_query()
     assert now.astimezone().isoformat() in query
 
 
 def test_attribute_filter_valid_values():
     # Test valid cases
-    AttributeFilter()  # default values
-    AttributeFilter(name_eq="test")  # string
-    AttributeFilter(name_eq=["test1", "test2"])  # list of strings
-    AttributeFilter(type_in=["float", "int"])  # valid types
-    AttributeFilter(name_matches_all="test")  # string
-    AttributeFilter(name_matches_all=["test1", "test2"])  # list of strings
-    AttributeFilter(name_matches_none="test")  # string
-    AttributeFilter(name_matches_none=["test1", "test2"])  # list of strings
-    AttributeFilter(aggregations=["last", "min"])  # valid aggregations
+    AttributeFilterInternal()  # default values
+    AttributeFilterInternal(name_eq="test")  # string
+    AttributeFilterInternal(name_eq=["test1", "test2"])  # list of strings
+    AttributeFilterInternal(type_in=["float", "int"])  # valid types
+    AttributeFilterInternal(name_matches_all="test")  # string
+    AttributeFilterInternal(name_matches_all=["test1", "test2"])  # list of strings
+    AttributeFilterInternal(name_matches_none="test")  # string
+    AttributeFilterInternal(name_matches_none=["test1", "test2"])  # list of strings
+    AttributeFilterInternal(aggregations=["last", "min"])  # valid aggregations
 
 
 def test_name_eq_validation():
@@ -154,7 +154,7 @@ def test_name_eq_validation():
 
     for invalid_value in invalid_values:
         with pytest.raises(ValueError) as exc_info:
-            AttributeFilter(name_eq=invalid_value)  # type: ignore
+            AttributeFilterInternal(name_eq=invalid_value)  # type: ignore
         assert "name_eq must be a string or list of strings" in str(exc_info.value)
 
 
@@ -169,7 +169,7 @@ def test_type_in_validation():
 
     for invalid_value in invalid_values:
         with pytest.raises(ValueError) as exc_info:
-            AttributeFilter(type_in=invalid_value)  # type: ignore
+            AttributeFilterInternal(type_in=invalid_value)  # type: ignore
         assert f"type_in must be a list of valid values: {sorted(types.ALL_TYPES)}" in str(exc_info.value)
 
 
@@ -185,7 +185,7 @@ def test_name_matches_all_validation():
 
     for invalid_value in invalid_values:
         with pytest.raises(ValueError) as exc_info:
-            AttributeFilter(name_matches_all=invalid_value)  # type: ignore
+            AttributeFilterInternal(name_matches_all=invalid_value)  # type: ignore
         assert "name_matches_all must be a string or list of strings" in str(exc_info.value)
 
 
@@ -201,7 +201,7 @@ def test_name_matches_none_validation():
 
     for invalid_value in invalid_values:
         with pytest.raises(ValueError) as exc_info:
-            AttributeFilter(name_matches_none=invalid_value)  # type: ignore
+            AttributeFilterInternal(name_matches_none=invalid_value)  # type: ignore
         assert "name_matches_none must be a string or list of strings" in str(exc_info.value)
 
 
@@ -216,19 +216,19 @@ def test_aggregations_validation():
 
     for invalid_value in invalid_values:
         with pytest.raises(ValueError) as exc_info:
-            AttributeFilter(aggregations=invalid_value)  # type: ignore
+            AttributeFilterInternal(aggregations=invalid_value)  # type: ignore
         assert f"aggregations must be a list of valid values: {sorted(types.ALL_AGGREGATIONS)}" in str(exc_info.value)
 
 
 @pytest.mark.parametrize("valid_type", sorted(types.ALL_TYPES))
 def test_all_valid_types(valid_type):
     # Test each valid type individually
-    attr_filter = AttributeFilter(type_in=[valid_type])
+    attr_filter = AttributeFilterInternal(type_in=[valid_type])
     assert valid_type in attr_filter.type_in
 
 
 @pytest.mark.parametrize("valid_agg", sorted(types.ALL_AGGREGATIONS))
 def test_all_valid_aggregations(valid_agg):
     # Test each valid aggregation individually
-    attr_filter = AttributeFilter(aggregations=[valid_agg])
+    attr_filter = AttributeFilterInternal(aggregations=[valid_agg])
     assert valid_agg in attr_filter.aggregations


### PR DESCRIPTION
## Summary by Sourcery

Separate public alpha filter API from backend implementation by introducing distinct alpha-level and internal filter classes, updating code and tests to use the new internal filter types and laying groundwork for translation between the two layers.

Enhancements:
- Extract public filter definitions into `neptune_fetcher/alpha/filters.py` to expose an alpha-level `Filter`, `AttributeFilter`, and `Attribute` API.
- Introduce internal filter classes (`FilterInternal`, `AttributeFilterInternal`, `AttributeInternal`) in `neptune_fetcher/internal/filters.py` for backend composition and retrieval.
- Refactor code and update tests to replace direct use of alpha filter classes with internal equivalents across composition, retrieval, and test suites.
- Add placeholder translation functions in `neptune_fetcher/alpha/internal/_filter_translation.py` to convert alpha-level filters and attributes into internal representations.
- Update utility resolution logic to import and resolve alpha filters before delegating to internal filter processing.