### PR TITLE
chore: refactor metrics

### DIFF
--- a/src/neptune_fetcher/internal/composition/attribute_components.py
+++ b/src/neptune_fetcher/internal/composition/attribute_components.py
@@ -29,7 +29,6 @@ from neptune_fetcher.internal.composition.attributes import (
     fetch_attribute_definition_aggregations,
     fetch_attribute_definitions,
 )
-from neptune_fetcher.internal.retrieval import attribute_definitions as att_defs
 from neptune_fetcher.internal.retrieval import attribute_values as att_vals
 from neptune_fetcher.internal.retrieval import (
     search,
@@ -45,7 +44,7 @@ def fetch_attribute_definitions_split(
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
     sys_ids: list[identifiers.SysId],
-    downstream: Callable[[list[identifiers.SysId], util.Page[att_defs.AttributeDefinition]], concurrency.OUT],
+    downstream: Callable[[list[identifiers.SysId], util.Page[identifiers.AttributeDefinition]], concurrency.OUT],
 ) -> concurrency.OUT:
     return concurrency.generate_concurrently(
         items=split.split_sys_ids(sys_ids),
@@ -72,7 +71,11 @@ def fetch_attribute_definition_aggregations_split(
     fetch_attribute_definitions_executor: Executor,
     sys_ids: list[identifiers.SysId],
     downstream: Callable[
-        [list[identifiers.SysId], util.Page[att_defs.AttributeDefinition], util.Page[AttributeDefinitionAggregation]],
+        [
+            list[identifiers.SysId],
+            util.Page[identifiers.AttributeDefinition],
+            util.Page[AttributeDefinitionAggregation],
+        ],
         concurrency.OUT,
     ],
 ) -> concurrency.OUT:
@@ -101,7 +104,7 @@ def fetch_attribute_definitions_complete(
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
     container_type: search.ContainerType,
-    downstream: Callable[[util.Page[att_defs.AttributeDefinition]], concurrency.OUT],
+    downstream: Callable[[util.Page[identifiers.AttributeDefinition]], concurrency.OUT],
 ) -> concurrency.OUT:
     if container_type == search.ContainerType.RUN and filter_ is None:
         return concurrency.generate_concurrently(
@@ -141,7 +144,7 @@ def fetch_attribute_values_split(
     project_identifier: identifiers.ProjectIdentifier,
     executor: Executor,
     sys_ids: list[identifiers.SysId],
-    attribute_definitions: list[att_defs.AttributeDefinition],
+    attribute_definitions: list[identifiers.AttributeDefinition],
     downstream: Callable[[util.Page[att_vals.AttributeValue]], concurrency.OUT],
 ) -> concurrency.OUT:
     return concurrency.generate_concurrently(

--- a/src/neptune_fetcher/internal/composition/attributes.py
+++ b/src/neptune_fetcher/internal/composition/attributes.py
@@ -37,7 +37,7 @@ from neptune_fetcher.internal.retrieval.attribute_types import TYPE_AGGREGATIONS
 
 @dataclass(frozen=True)
 class AttributeDefinitionAggregation:
-    attribute_definition: att_defs.AttributeDefinition
+    attribute_definition: identifiers.AttributeDefinition
     aggregation: Literal["last", "min", "max", "average", "variance"]
 
 
@@ -48,12 +48,12 @@ def fetch_attribute_definitions(
     attribute_filter: filters._BaseAttributeFilter,
     executor: Executor,
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_DEFINITIONS_BATCH_SIZE.get(),
-) -> Generator[util.Page[att_defs.AttributeDefinition], None, None]:
+) -> Generator[util.Page[identifiers.AttributeDefinition], None, None]:
     pages_filters = _fetch_attribute_definitions(
         client, project_identifiers, run_identifiers, attribute_filter, batch_size, executor
     )
 
-    seen_items: set[att_defs.AttributeDefinition] = set()
+    seen_items: set[identifiers.AttributeDefinition] = set()
     for page, filter_ in pages_filters:
         new_items = [item for item in page.items if item not in seen_items]
         seen_items.update(new_items)
@@ -67,7 +67,9 @@ def fetch_attribute_definition_aggregations(
     attribute_filter: filters._BaseAttributeFilter,
     executor: Executor,
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_DEFINITIONS_BATCH_SIZE.get(),
-) -> Generator[tuple[util.Page[att_defs.AttributeDefinition], util.Page[AttributeDefinitionAggregation]], None, None]:
+) -> Generator[
+    tuple[util.Page[identifiers.AttributeDefinition], util.Page[AttributeDefinitionAggregation]], None, None
+]:
     """
     Each attribute definition is yielded once when it's first encountered.
     If the attribute definition is of a type that supports aggregations (for now only float_series),
@@ -78,7 +80,7 @@ def fetch_attribute_definition_aggregations(
         client, project_identifiers, run_identifiers, attribute_filter, batch_size, executor
     )
 
-    seen_definitions: set[att_defs.AttributeDefinition] = set()
+    seen_definitions: set[identifiers.AttributeDefinition] = set()
     seen_definition_aggregations: set[AttributeDefinitionAggregation] = set()
 
     for page, filter_ in pages_filters:
@@ -112,10 +114,10 @@ def _fetch_attribute_definitions(
     attribute_filter: filters._BaseAttributeFilter,
     batch_size: int,
     executor: Executor,
-) -> Generator[tuple[util.Page[att_defs.AttributeDefinition], filters._AttributeFilter], None, None]:
+) -> Generator[tuple[util.Page[identifiers.AttributeDefinition], filters._AttributeFilter], None, None]:
     def go_fetch_single(
         filter_: filters._AttributeFilter,
-    ) -> Generator[util.Page[att_defs.AttributeDefinition], None, None]:
+    ) -> Generator[util.Page[identifiers.AttributeDefinition], None, None]:
         return att_defs.fetch_attribute_definitions_single_filter(
             client=client,
             project_identifiers=project_identifiers,

--- a/src/neptune_fetcher/internal/composition/download_files.py
+++ b/src/neptune_fetcher/internal/composition/download_files.py
@@ -41,7 +41,6 @@ from neptune_fetcher.internal.filters import (
     _Filter,
 )
 from neptune_fetcher.internal.retrieval import (
-    attribute_definitions,
     files,
     search,
 )
@@ -145,7 +144,7 @@ def download_files(
         )
 
         results: Generator[
-            tuple[identifiers.RunIdentifier, attribute_definitions.AttributeDefinition, Optional[pathlib.Path]],
+            tuple[identifiers.RunIdentifier, identifiers.AttributeDefinition, Optional[pathlib.Path]],
             None,
             None,
         ] = concurrency.gather_results(output)

--- a/src/neptune_fetcher/internal/composition/fetch_metrics.py
+++ b/src/neptune_fetcher/internal/composition/fetch_metrics.py
@@ -165,9 +165,7 @@ def _fetch_metrics(
     include_point_previews: bool,
     tail_limit: Optional[int],
     container_type: ContainerType,
-) -> tuple[
-    dict[identifiers.RunAttributeDefinition, list[FloatPointValue]], dict[identifiers.SysId, str]
-]:  # pd.DataFrame:
+) -> tuple[dict[identifiers.RunAttributeDefinition, list[FloatPointValue]], dict[identifiers.SysId, str]]:
     def fetch_values(
         exp_paths: list[identifiers.RunAttributeDefinition],
     ) -> tuple[list[concurrent.futures.Future], dict[identifiers.RunAttributeDefinition, list[FloatPointValue]]]:

--- a/src/neptune_fetcher/internal/composition/fetch_metrics.py
+++ b/src/neptune_fetcher/internal/composition/fetch_metrics.py
@@ -173,7 +173,7 @@ def _fetch_flat_dataframe_metrics(
     ) -> Tuple[list[concurrent.futures.Future], Iterable[FloatPointValue]]:
         _series = fetch_multiple_series_values(
             client,
-            exp_paths=exp_paths,
+            run_attribute_definitions=exp_paths,
             include_inherited=lineage_to_the_root,
             include_preview=include_point_previews,
             step_range=step_range,

--- a/src/neptune_fetcher/internal/composition/fetch_metrics.py
+++ b/src/neptune_fetcher/internal/composition/fetch_metrics.py
@@ -214,7 +214,9 @@ def _fetch_metrics(
             _futures.append(executor.submit(process_sys_ids, sys_ids_generator))
 
             for sys_ids_split in split.split_sys_ids(sys_ids):
-                run_identifiers_split = [identifiers.RunIdentifier(project_identifier, sys_id) for sys_id in sys_ids_split]
+                run_identifiers_split = [
+                    identifiers.RunIdentifier(project_identifier, sys_id) for sys_id in sys_ids_split
+                ]
                 definitions_generator = fetch_attribute_definitions(
                     client=client,
                     project_identifiers=[project_identifier],

--- a/src/neptune_fetcher/internal/composition/fetch_series.py
+++ b/src/neptune_fetcher/internal/composition/fetch_series.py
@@ -114,7 +114,7 @@ def fetch_series(
                 downstream=lambda sys_ids_split, definitions_page: concurrency.generate_concurrently(
                     items=split.split_series_attributes(
                         items=(
-                            series.RunAttributeDefinition(
+                            identifiers.RunAttributeDefinition(
                                 run_identifier=identifiers.RunIdentifier(project_identifier, sys_id),
                                 attribute_definition=definition,
                             )
@@ -139,10 +139,10 @@ def fetch_series(
             ),
         )
         results: Generator[
-            util.Page[tuple[series.RunAttributeDefinition, list[series.StringSeriesValue]]], None, None
+            util.Page[tuple[identifiers.RunAttributeDefinition, list[series.StringSeriesValue]]], None, None
         ] = concurrency.gather_results(output)
 
-        series_data: dict[series.RunAttributeDefinition, list[series.StringSeriesValue]] = {}
+        series_data: dict[identifiers.RunAttributeDefinition, list[series.StringSeriesValue]] = {}
         for result in results:
             for run_attribute_definition, series_values in result.items:
                 series_data.setdefault(run_attribute_definition, []).extend(series_values)

--- a/src/neptune_fetcher/internal/composition/fetch_table.py
+++ b/src/neptune_fetcher/internal/composition/fetch_table.py
@@ -40,7 +40,6 @@ from neptune_fetcher.internal.filters import (
     _Filter,
 )
 from neptune_fetcher.internal.identifiers import ProjectIdentifier
-from neptune_fetcher.internal.retrieval import attribute_definitions as att_defs
 from neptune_fetcher.internal.retrieval import attribute_values as att_vals
 from neptune_fetcher.internal.retrieval import (
     search,
@@ -94,7 +93,7 @@ def fetch_table(
 
         sys_id_label_mapping: dict[identifiers.SysId, str] = {}
         result_by_id: dict[identifiers.SysId, list[att_vals.AttributeValue]] = {}
-        selected_aggregations: dict[att_defs.AttributeDefinition, set[str]] = defaultdict(set)
+        selected_aggregations: dict[identifiers.AttributeDefinition, set[str]] = defaultdict(set)
 
         def go_fetch_sys_attrs() -> Generator[list[identifiers.SysId], None, None]:
             for page in search.fetch_sys_id_labels(container_type)(
@@ -139,7 +138,7 @@ def fetch_table(
             ),
         )
         results: Generator[
-            Union[util.Page[att_vals.AttributeValue], dict[att_defs.AttributeDefinition, set[str]]], None, None
+            Union[util.Page[att_vals.AttributeValue], dict[identifiers.AttributeDefinition, set[str]]], None, None
         ] = concurrency.gather_results(output)
 
         for result in results:

--- a/src/neptune_fetcher/internal/composition/list_attributes.py
+++ b/src/neptune_fetcher/internal/composition/list_attributes.py
@@ -37,7 +37,6 @@ from neptune_fetcher.internal.filters import (
     _AttributeFilter,
     _Filter,
 )
-from neptune_fetcher.internal.retrieval import attribute_definitions as att_defs
 from neptune_fetcher.internal.retrieval import (
     search,
     util,
@@ -79,7 +78,7 @@ def list_attributes(
             container_type=container_type,
         )
 
-        results: Generator[util.Page[att_defs.AttributeDefinition], None, None] = concurrency.gather_results(output)
+        results: Generator[util.Page[identifiers.AttributeDefinition], None, None] = concurrency.gather_results(output)
         names = set()
         for page in results:
             for item in page.items:

--- a/src/neptune_fetcher/internal/composition/type_inference.py
+++ b/src/neptune_fetcher/internal/composition/type_inference.py
@@ -30,7 +30,6 @@ from neptune_fetcher.internal import (
 )
 from neptune_fetcher.internal.composition import attribute_components as _components
 from neptune_fetcher.internal.composition import concurrency
-from neptune_fetcher.internal.retrieval import attribute_definitions as att_defs
 from neptune_fetcher.internal.retrieval import (
     search,
     util,
@@ -143,7 +142,7 @@ def _infer_attribute_types_from_api(
     )
 
     attribute_definition_pages: Generator[
-        util.Page[att_defs.AttributeDefinition], None, None
+        util.Page[identifiers.AttributeDefinition], None, None
     ] = concurrency.gather_results(output)
 
     attribute_name_to_definition: dict[str, set[str]] = defaultdict(set)

--- a/src/neptune_fetcher/internal/identifiers.py
+++ b/src/neptune_fetcher/internal/identifiers.py
@@ -28,3 +28,15 @@ class RunIdentifier:
 
     def __str__(self) -> str:
         return f"{self.project_identifier}/{self.sys_id}"
+
+
+@dataclass(frozen=True)
+class AttributeDefinition:
+    name: str
+    type: str
+
+
+@dataclass(frozen=True)
+class RunAttributeDefinition:
+    run_identifier: RunIdentifier
+    attribute_definition: AttributeDefinition

--- a/src/neptune_fetcher/internal/output_format.py
+++ b/src/neptune_fetcher/internal/output_format.py
@@ -200,12 +200,12 @@ def create_metrics_dataframe(
     """
 
     path_mapping: dict[str, int] = {}
-    experiment_mapping: dict[str, int] = {}
+    sys_id_mapping: dict[str, int] = {}
     label_mapping: list[str] = []
 
     for run_attr_definition in metrics_data:
-        if run_attr_definition.run_identifier.sys_id not in experiment_mapping:
-            experiment_mapping[run_attr_definition.run_identifier.sys_id] = len(experiment_mapping)
+        if run_attr_definition.run_identifier.sys_id not in sys_id_mapping:
+            sys_id_mapping[run_attr_definition.run_identifier.sys_id] = len(sys_id_mapping)
             label_mapping.append(sys_id_label_mapping[run_attr_definition.run_identifier.sys_id])
 
         if run_attr_definition.attribute_path not in path_mapping:
@@ -213,12 +213,12 @@ def create_metrics_dataframe(
 
     def generate_categorized_rows() -> Generator[Tuple, None, None]:
         for attribute, points in metrics_data.items():
-            exp_category = experiment_mapping[attribute.run_identifier.sys_id]
+            exp_category = sys_id_mapping[attribute.run_identifier.sys_id]
             path_category = path_mapping[attribute.attribute_path]
 
             for point in points:
-                # Only include columns that we know we need. Note that the order of must match the
-                # the `types` list below.
+                # Only include columns that we know we need. Note that the list of columns must match the
+                # the list of `types` below.
                 head = (
                     exp_category,
                     path_category,

--- a/src/neptune_fetcher/internal/output_format.py
+++ b/src/neptune_fetcher/internal/output_format.py
@@ -16,7 +16,6 @@ import pathlib
 from typing import (
     Any,
     Generator,
-    Iterable,
     Optional,
     Tuple,
     Union,
@@ -29,6 +28,7 @@ from neptune_fetcher.exceptions import ConflictingAttributeTypes
 from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.retrieval import (
     attribute_definitions,
+    metrics,
     series,
 )
 from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
@@ -41,9 +41,6 @@ from neptune_fetcher.internal.retrieval.attribute_types import (
 )
 from neptune_fetcher.internal.retrieval.attribute_values import AttributeValue
 from neptune_fetcher.internal.retrieval.metrics import (
-    AttributePathIndex,
-    ExperimentNameIndex,
-    FloatPointValue,
     IsPreviewIndex,
     PreviewCompletionIndex,
     StepIndex,
@@ -165,7 +162,8 @@ def convert_table_to_dataframe(
 
 
 def create_metrics_dataframe(
-    data_points: Iterable[FloatPointValue],
+    metrics_data: dict[metrics.AttributePathInRun, list[metrics.FloatPointValue]],
+    sys_id_label_mapping: dict[identifiers.SysId, str],
     *,
     type_suffix_in_column_names: bool,
     include_point_previews: bool,
@@ -203,50 +201,44 @@ def create_metrics_dataframe(
 
     path_mapping: dict[str, int] = {}
     experiment_mapping: dict[str, int] = {}
+    label_mapping: list[str] = []
+
+    for run_attr_definition in metrics_data:
+        if run_attr_definition.run_identifier.sys_id not in experiment_mapping:
+            experiment_mapping[run_attr_definition.run_identifier.sys_id] = len(experiment_mapping)
+            label_mapping.append(sys_id_label_mapping[run_attr_definition.run_identifier.sys_id])
+
+        if run_attr_definition.attribute_path not in path_mapping:
+            path_mapping[run_attr_definition.attribute_path] = len(path_mapping)
 
     def generate_categorized_rows() -> Generator[Tuple, None, None]:
-        last_experiment_name, last_experiment_category = None, None
-        last_path_name, last_path_category = None, None
+        for attribute, points in metrics_data.items():
+            exp_category = experiment_mapping[attribute.run_identifier.sys_id]
+            path_category = path_mapping[attribute.attribute_path]
 
-        for point in data_points:
-            exp_category = (
-                last_experiment_category
-                if last_experiment_name == point[ExperimentNameIndex]
-                else experiment_mapping.get(point[ExperimentNameIndex], None)  # type: ignore
-            )
-            path_category = (
-                last_path_category
-                if last_path_name == point[AttributePathIndex]
-                else path_mapping.get(point[AttributePathIndex], None)  # type: ignore
-            )
+            for point in points:
+                # Only include columns that we know we need. Note that the order of must match the
+                # the `types` list below.
+                head = (
+                    exp_category,
+                    path_category,
+                    point[StepIndex],
+                    point[ValueIndex],
+                )
+                if include_point_previews and timestamp_column_name:
+                    tail: Tuple[Any, ...] = (
+                        point[TimestampIndex],
+                        point[IsPreviewIndex],
+                        point[PreviewCompletionIndex],
+                    )
+                elif timestamp_column_name:
+                    tail = (point[TimestampIndex],)
+                elif include_point_previews:
+                    tail = (point[IsPreviewIndex], point[PreviewCompletionIndex])
+                else:
+                    tail = ()
 
-            if exp_category is None:
-                exp_category = len(experiment_mapping)
-                experiment_mapping[point[ExperimentNameIndex]] = exp_category  # type: ignore
-                last_experiment_name, last_experiment_category = point[ExperimentNameIndex], exp_category
-            if path_category is None:
-                path_category = len(path_mapping)
-                path_mapping[point[AttributePathIndex]] = path_category  # type: ignore
-                last_path_name, last_path_category = point[AttributePathIndex], path_category
-
-            # Only include columns that we know we need. Note that the order of must match the
-            # the `types` list below.
-            head = (
-                exp_category,
-                path_category,
-                point[StepIndex],
-                point[ValueIndex],
-            )
-            if include_point_previews and timestamp_column_name:
-                tail: Tuple[Any, ...] = (point[TimestampIndex], point[IsPreviewIndex], point[PreviewCompletionIndex])
-            elif timestamp_column_name:
-                tail = (point[TimestampIndex],)
-            elif include_point_previews:
-                tail = (point[IsPreviewIndex], point[PreviewCompletionIndex])
-            else:
-                tail = ()
-
-            yield head + tail
+                yield head + tail
 
     types = [
         (index_column_name, "uint32"),
@@ -266,7 +258,7 @@ def create_metrics_dataframe(
         np.fromiter(generate_categorized_rows(), dtype=types),
     )
 
-    experiment_dtype = pd.CategoricalDtype(categories=list(experiment_mapping.keys()))
+    experiment_dtype = pd.CategoricalDtype(categories=label_mapping)
     df[index_column_name] = pd.Categorical.from_codes(df[index_column_name], dtype=experiment_dtype)
 
     df = _pivot_and_reindex_df(df, include_point_previews, index_column_name, timestamp_column_name)

--- a/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
+++ b/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
@@ -15,7 +15,6 @@
 import functools as ft
 import itertools as it
 import re
-from dataclasses import dataclass
 from typing import (
     Any,
     Generator,
@@ -30,13 +29,6 @@ from neptune_api.models import (
     QueryAttributeDefinitionsBodyDTO,
     QueryAttributeDefinitionsResultDTO,
 )
-
-
-@dataclass(frozen=True)
-class AttributeDefinition:
-    name: str
-    type: str
-
 
 # The following imports need to go after the AttributeDefinition to avoid circular imports, thus the noqa
 import neptune_fetcher.internal.filters as filters  # noqa: E402
@@ -65,7 +57,7 @@ def fetch_attribute_definitions_single_filter(
     run_identifiers: Optional[Iterable[identifiers.RunIdentifier]],
     attribute_filter: filters._AttributeFilter,
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_DEFINITIONS_BATCH_SIZE.get(),
-) -> Generator[util.Page[AttributeDefinition], None, None]:
+) -> Generator[util.Page[identifiers.AttributeDefinition], None, None]:
     params: dict[str, Any] = {
         "projectIdentifiers": list(project_identifiers),
         "attributeNameFilter": dict(),
@@ -122,10 +114,10 @@ def _fetch_attribute_definitions_page(
 
 def _process_attribute_definitions_page(
     data: QueryAttributeDefinitionsResultDTO,
-) -> util.Page[AttributeDefinition]:
+) -> util.Page[identifiers.AttributeDefinition]:
     items = []
     for entry in data.entries:
-        item = AttributeDefinition(
+        item = identifiers.AttributeDefinition(
             name=entry.name,
             type=types.map_attribute_type_backend_to_python(str(entry.type)),
         )

--- a/src/neptune_fetcher/internal/retrieval/attribute_values.py
+++ b/src/neptune_fetcher/internal/retrieval/attribute_values.py
@@ -31,7 +31,6 @@ from neptune_fetcher.internal import (
     identifiers,
 )
 from neptune_fetcher.internal.retrieval import util
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
 from neptune_fetcher.internal.retrieval.attribute_types import (
     extract_value,
     map_attribute_type_backend_to_python,
@@ -40,7 +39,7 @@ from neptune_fetcher.internal.retrieval.attribute_types import (
 
 @dataclass(frozen=True)
 class AttributeValue:
-    attribute_definition: AttributeDefinition
+    attribute_definition: identifiers.AttributeDefinition
     value: Any
     run_identifier: identifiers.RunIdentifier
 
@@ -49,10 +48,10 @@ def fetch_attribute_values(
     client: AuthenticatedClient,
     project_identifier: identifiers.ProjectIdentifier,
     run_identifiers: Iterable[identifiers.RunIdentifier],
-    attribute_definitions: Iterable[AttributeDefinition],
+    attribute_definitions: Iterable[identifiers.AttributeDefinition],
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_VALUES_BATCH_SIZE.get(),
 ) -> Generator[util.Page[AttributeValue], None, None]:
-    attribute_definitions_set: set[AttributeDefinition] = set(attribute_definitions)
+    attribute_definitions_set: set[identifiers.AttributeDefinition] = set(attribute_definitions)
     experiments = [str(e) for e in run_identifiers]
 
     if not attribute_definitions_set or not run_identifiers:
@@ -94,7 +93,7 @@ def _fetch_attribute_values_page(
 
 def _process_attribute_values_page(
     data: ProtoQueryAttributesResultDTO,
-    attribute_definitions_set: set[AttributeDefinition],
+    attribute_definitions_set: set[identifiers.AttributeDefinition],
     project_identifier: identifiers.ProjectIdentifier,
 ) -> util.Page[AttributeValue]:
     items = []
@@ -104,7 +103,9 @@ def _process_attribute_values_page(
         )
 
         for attr in entry.attributes:
-            attr_definition = AttributeDefinition(name=attr.name, type=map_attribute_type_backend_to_python(attr.type))
+            attr_definition = identifiers.AttributeDefinition(
+                name=attr.name, type=map_attribute_type_backend_to_python(attr.type)
+            )
             if attr_definition not in attribute_definitions_set:
                 continue
 

--- a/src/neptune_fetcher/internal/retrieval/metrics.py
+++ b/src/neptune_fetcher/internal/retrieval/metrics.py
@@ -56,7 +56,7 @@ def fetch_multiple_series_values(
         return {}
 
     assert len(run_attribute_definitions) <= TOTAL_POINT_LIMIT, (
-        "The number of requested attributes exceeds the maximum limit of "
+        f"The number of requested attributes {len(run_attribute_definitions)} exceeds the maximum limit of "
         f"{TOTAL_POINT_LIMIT}. Please reduce the number of attributes."
     )
 

--- a/src/neptune_fetcher/internal/retrieval/metrics.py
+++ b/src/neptune_fetcher/internal/retrieval/metrics.py
@@ -23,15 +23,7 @@ from typing import (
 
 from neptune_api.api.retrieval import get_multiple_float_series_values_proto
 from neptune_api.client import AuthenticatedClient
-from neptune_api.models import (
-    AttributesHolderIdentifier,
-    FloatTimeSeriesValuesRequest,
-    FloatTimeSeriesValuesRequestOrder,
-    FloatTimeSeriesValuesRequestSeries,
-    OpenRangeDTO,
-    TimeSeries,
-    TimeSeriesLineage,
-)
+from neptune_api.models import FloatTimeSeriesValuesRequest
 from neptune_api.proto.neptune_pb.api.v1.model.series_values_pb2 import ProtoFloatSeriesValuesResponseDTO
 
 from neptune_fetcher.internal import identifiers

--- a/src/neptune_fetcher/internal/retrieval/series.py
+++ b/src/neptune_fetcher/internal/retrieval/series.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools as ft
-from dataclasses import dataclass
 from typing import (
     Any,
     Generator,
@@ -30,16 +29,8 @@ from neptune_api.models import SeriesValuesRequest
 from neptune_api.proto.neptune_pb.api.v1.model.series_values_pb2 import ProtoSeriesValuesResponseDTO
 from neptune_api.types import UNSET
 
-from neptune_fetcher.internal.identifiers import RunIdentifier
+from neptune_fetcher.internal.identifiers import RunAttributeDefinition
 from neptune_fetcher.internal.retrieval import util
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
-
-
-@dataclass(frozen=True)
-class RunAttributeDefinition:
-    run_identifier: RunIdentifier
-    attribute_definition: AttributeDefinition
-
 
 StringSeriesValue = NamedTuple("StringSeriesValue", [("step", float), ("value", str), ("timestamp_millis", float)])
 

--- a/src/neptune_fetcher/internal/retrieval/split.py
+++ b/src/neptune_fetcher/internal/retrieval/split.py
@@ -26,14 +26,13 @@ from neptune_fetcher.internal import (
     env,
     identifiers,
 )
-from neptune_fetcher.internal.retrieval import attribute_definitions as adef
 
 _UUID_SIZE = 50
 
 T = TypeVar("T")
 
 
-def _attribute_definition_size(attr: adef.AttributeDefinition) -> int:
+def _attribute_definition_size(attr: identifiers.AttributeDefinition) -> int:
     return _attribute_name_size(attr.name)
 
 
@@ -68,8 +67,8 @@ def split_sys_ids(
 
 def split_sys_ids_attributes(
     sys_ids: list[identifiers.SysId],
-    attribute_definitions: list[adef.AttributeDefinition],
-) -> Generator[tuple[list[identifiers.SysId], list[adef.AttributeDefinition]]]:
+    attribute_definitions: list[identifiers.AttributeDefinition],
+) -> Generator[tuple[list[identifiers.SysId], list[identifiers.AttributeDefinition]]]:
     """
     Splits a pair of sys ids and attribute_definitions into batches that:
     When their length is added it is of size at most `NEPTUNE_FETCHER_QUERY_SIZE_LIMIT`.
@@ -113,12 +112,13 @@ def split_sys_ids_attributes(
 
 
 def _split_attribute_definitions(
-    attribute_definitions: list[adef.AttributeDefinition],
+    attribute_definitions: list[identifiers.AttributeDefinition],
     query_size_limit: int,
     attribute_values_batch_size: int,
-) -> list[list[adef.AttributeDefinition]]:
+) -> list[list[identifiers.AttributeDefinition]]:
+
     attribute_batches = []
-    current_batch: list[adef.AttributeDefinition] = []
+    current_batch: list[identifiers.AttributeDefinition] = []
     current_batch_size = 0
     for attr in attribute_definitions:
         attr_size = _attribute_definition_size(attr)

--- a/src/neptune_fetcher/internal/retrieval/util.py
+++ b/src/neptune_fetcher/internal/retrieval/util.py
@@ -62,9 +62,8 @@ def fetch_pages(
     while page_params is not None:
         data = fetch_page(client, page_params)
         page = process_page(data)
-        page_params = make_new_page_params(page_params, data)
-
         yield page
+        page_params = make_new_page_params(page_params, data)
 
 
 def backoff_retry(

--- a/tests/e2e/alpha/runs/test_runs_fetch_metrics.py
+++ b/tests/e2e/alpha/runs/test_runs_fetch_metrics.py
@@ -5,7 +5,9 @@ import pytest
 
 import neptune_fetcher.alpha.runs as runs
 from neptune_fetcher.alpha import Context
+from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.output_format import create_metrics_dataframe
+from neptune_fetcher.internal.retrieval.metrics import AttributePathInRun
 from tests.e2e.alpha.generator import (
     RUN_BY_ID,
     timestamp_for_step,
@@ -215,20 +217,32 @@ def test_fetch_run_metrics(
     )
 
     expected_df = create_expected_data(
-        expected_metrics, include_time=include_time, type_suffix_in_column_names=type_suffix_in_column_names
+        new_project_context.project,
+        expected_metrics,
+        include_time=include_time,
+        type_suffix_in_column_names=type_suffix_in_column_names,
     )
 
     pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
 
 
-def create_expected_data(expected_metrics, include_time: str, type_suffix_in_column_names):
-    rows = []
+def create_expected_data(project, expected_metrics, include_time: str, type_suffix_in_column_names):
+    data = {}
     for (run, metric_name), values in expected_metrics.items():
+        attribute_run = AttributePathInRun(
+            run_identifier=identifiers.RunIdentifier(project_identifier=project, sys_id=identifiers.SysId(run)),
+            attribute_path=metric_name,
+        )
+        rows = data.setdefault(attribute_run, [])
+
         for step, value in values:
-            rows.append((run, metric_name, int(timestamp_for_step(step).timestamp() * 1000), step, value, False, 1.0))
+            rows.append((int(timestamp_for_step(step).timestamp() * 1000), step, value, False, 1.0))
+
+    sys_id_label_mapping = {identifiers.SysId(run): run for run, _ in expected_metrics.keys()}
 
     return create_metrics_dataframe(
-        rows,
+        metrics_data=data,
+        sys_id_label_mapping=sys_id_label_mapping,
         type_suffix_in_column_names=type_suffix_in_column_names,
         include_point_previews=False,
         timestamp_column_name="absolute_time" if include_time == "absolute" else None,

--- a/tests/e2e/alpha/runs/test_runs_fetch_metrics.py
+++ b/tests/e2e/alpha/runs/test_runs_fetch_metrics.py
@@ -7,7 +7,6 @@ import neptune_fetcher.alpha.runs as runs
 from neptune_fetcher.alpha import Context
 from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.output_format import create_metrics_dataframe
-from neptune_fetcher.internal.retrieval.metrics import AttributePathInRun
 from tests.e2e.alpha.generator import (
     RUN_BY_ID,
     timestamp_for_step,
@@ -229,9 +228,9 @@ def test_fetch_run_metrics(
 def create_expected_data(project, expected_metrics, include_time: str, type_suffix_in_column_names):
     data = {}
     for (run, metric_name), values in expected_metrics.items():
-        attribute_run = AttributePathInRun(
+        attribute_run = identifiers.RunAttributeDefinition(
             run_identifier=identifiers.RunIdentifier(project_identifier=project, sys_id=identifiers.SysId(run)),
-            attribute_path=metric_name,
+            attribute_definition=identifiers.AttributeDefinition(name=metric_name, type="float_series"),
         )
         rows = data.setdefault(attribute_run, [])
 

--- a/tests/e2e/alpha/test_fetch_metrics.py
+++ b/tests/e2e/alpha/test_fetch_metrics.py
@@ -20,15 +20,14 @@ from neptune_fetcher.alpha.filters import (
 )
 from neptune_fetcher.internal.context import get_context
 from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
     ProjectIdentifier,
+    RunAttributeDefinition,
     RunIdentifier,
     SysId,
 )
 from neptune_fetcher.internal.output_format import create_metrics_dataframe
-from neptune_fetcher.internal.retrieval.metrics import (
-    AttributePathInRun,
-    FloatPointValue,
-)
+from neptune_fetcher.internal.retrieval.metrics import FloatPointValue
 from tests.e2e.data import (
     NOW,
     PATH,
@@ -47,7 +46,7 @@ def create_expected_data(
     step_range: Tuple[Optional[int], Optional[int]],
     tail_limit: Optional[int],
 ) -> Tuple[pd.DataFrame, List[str], set[str]]:
-    metrics_data: dict[AttributePathInRun, list[FloatPointValue]] = {}
+    metrics_data: dict[RunAttributeDefinition, list[FloatPointValue]] = {}
     sys_id_label_mapping: dict[SysId, str] = {SysId(experiment.name): experiment.name for experiment in experiments}
 
     columns = set()
@@ -77,7 +76,10 @@ def create_expected_data(
                     )
             limited = filtered[-tail_limit:] if tail_limit is not None else filtered
 
-            attribute_run = AttributePathInRun(RunIdentifier(ProjectIdentifier(project), SysId(experiment.name)), path)
+            attribute_run = RunAttributeDefinition(
+                RunIdentifier(ProjectIdentifier(project), SysId(experiment.name)),
+                AttributeDefinition(path, "float_series"),
+            )
             metrics_data.setdefault(attribute_run, []).extend(limited)
 
     df = create_metrics_dataframe(

--- a/tests/e2e/alpha/test_fetch_metrics.py
+++ b/tests/e2e/alpha/test_fetch_metrics.py
@@ -51,7 +51,7 @@ def create_expected_data(
         for path, series in chain.from_iterable([experiment.float_series.items(), experiment.unique_series.items()]):
             filtered = []
             for step in steps:
-                if step >= step_filter[0] and step <= step_filter[1]:
+                if step_filter[0] <= step <= step_filter[1]:
                     columns.add(f"{path}:float_series" if type_suffix_in_column_names else path)
                     filtered_exps.add(experiment.name)
                     filtered.append(

--- a/tests/e2e/alpha/test_fetch_series.py
+++ b/tests/e2e/alpha/test_fetch_series.py
@@ -21,15 +21,13 @@ from neptune_fetcher.alpha.filters import (
 from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.context import get_context
 from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
+    RunAttributeDefinition,
     RunIdentifier,
     SysId,
 )
 from neptune_fetcher.internal.output_format import create_series_dataframe
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
-from neptune_fetcher.internal.retrieval.series import (
-    RunAttributeDefinition,
-    StringSeriesValue,
-)
+from neptune_fetcher.internal.retrieval.series import StringSeriesValue
 from tests.e2e.data import (
     NOW,
     NUMBER_OF_STEPS,

--- a/tests/e2e/internal/composition/test_attributes.py
+++ b/tests/e2e/internal/composition/test_attributes.py
@@ -10,8 +10,10 @@ import pytest
 
 from neptune_fetcher.internal.composition.attributes import fetch_attribute_definitions
 from neptune_fetcher.internal.filters import _AttributeFilter
-from neptune_fetcher.internal.identifiers import RunIdentifier
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
+from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
+    RunIdentifier,
+)
 from tests.e2e.conftest import extract_pages
 
 NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")

--- a/tests/e2e/internal/retrieval/test_attributes.py
+++ b/tests/e2e/internal/retrieval/test_attributes.py
@@ -11,14 +11,12 @@ import pytest
 from neptune_fetcher.exceptions import NeptuneProjectInaccessible
 from neptune_fetcher.internal.filters import _AttributeFilter
 from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
     ProjectIdentifier,
     RunIdentifier,
     SysId,
 )
-from neptune_fetcher.internal.retrieval.attribute_definitions import (
-    AttributeDefinition,
-    fetch_attribute_definitions_single_filter,
-)
+from neptune_fetcher.internal.retrieval.attribute_definitions import fetch_attribute_definitions_single_filter
 from neptune_fetcher.internal.retrieval.attribute_types import (
     FloatSeriesAggregations,
     StringSeriesAggregations,

--- a/tests/e2e/internal/retrieval/test_files.py
+++ b/tests/e2e/internal/retrieval/test_files.py
@@ -11,7 +11,7 @@ from datetime import (
 import azure.core.exceptions
 import pytest
 
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
+from neptune_fetcher.internal.identifiers import AttributeDefinition
 from neptune_fetcher.internal.retrieval.attribute_values import fetch_attribute_values
 from neptune_fetcher.internal.retrieval.files import (
     SignedFile,

--- a/tests/e2e/internal/retrieval/test_series.py
+++ b/tests/e2e/internal/retrieval/test_series.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import pytest
 
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
+from neptune_fetcher.internal.identifiers import AttributeDefinition
 from neptune_fetcher.internal.retrieval.series import (
     RunAttributeDefinition,
     fetch_series_values,

--- a/tests/unit/alpha/internal/retrieval/test_split.py
+++ b/tests/unit/alpha/internal/retrieval/test_split.py
@@ -6,7 +6,7 @@ from neptune_fetcher.internal.env import (
     NEPTUNE_FETCHER_QUERY_SIZE_LIMIT,
     NEPTUNE_FETCHER_SERIES_BATCH_SIZE,
 )
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
+from neptune_fetcher.internal.identifiers import AttributeDefinition
 from neptune_fetcher.internal.retrieval.split import (
     split_series_attributes,
     split_sys_ids,

--- a/tests/unit/alpha/internal/retrieval/test_split.py
+++ b/tests/unit/alpha/internal/retrieval/test_split.py
@@ -176,9 +176,10 @@ def test_split_series_attributes(attributes, expected):
         (3, 2 * ATTRIBUTE_DEFINITION_SIZE, 500, [2, 1]),
         (3, 3 * ATTRIBUTE_DEFINITION_SIZE, 500, [3]),
         (3, 4 * ATTRIBUTE_DEFINITION_SIZE, 500, [3]),
+        (10, 10 * ATTRIBUTE_DEFINITION_SIZE, 3, [3, 3, 3, 1]),
     ],
 )
-def split_series_attributes_custom_envs(monkeypatch, given_num, query_size_limit, batch_size, expected_nums):
+def test_split_series_attributes_custom_envs(monkeypatch, given_num, query_size_limit, batch_size, expected_nums):
     # given
     monkeypatch.setenv(NEPTUNE_FETCHER_QUERY_SIZE_LIMIT.name, str(query_size_limit))
     monkeypatch.setenv(NEPTUNE_FETCHER_SERIES_BATCH_SIZE.name, str(batch_size))


### PR DESCRIPTION
I had two goals:
- rewrite metrics retrieval to use util.paging
- rewrite metrics retrieval to use sysid internally instead of the 'label' (experiment name or run id), which it shouldn't care about - it should be the responsibility of the output module to display the proper string on the df columns

While doing this changes, it also seemed pointless to me that the metrics retrieval adds experiment_name+attribute path to each returned record so that it can return them ungrouped, and then the output module needs to group them back again to perform the categorical dimension optimization. So I changed the retrieval to just return a dict

Performance... seems mostly the same
```
main:
python example-metrics.py  36.31s user 0.93s system 80% cpu 46.426 total (50000, 100)
python example-metrics.py  36.74s user 0.96s system 79% cpu 47.715 total (50000, 100)
python example-metrics.py  37.34s user 1.51s system 78% cpu 49.309 total (50000, 100)

ms/metrics-ref:
python example-metrics.py  34.84s user 1.71s system 79% cpu 46.161 total (50000, 100)
python example-metrics.py  34.43s user 1.10s system 79% cpu 44.501 total (50000, 100)
python example-metrics.py  34.69s user 1.70s system 79% cpu 45.879 total (50000, 100)
```

## Summary by Sourcery

Refactor the metrics retrieval and DataFrame creation pipeline to use a paginated fetching approach, return structured mappings of run attributes to values and labels, simplify internal function signatures, and update tests accordingly

Enhancements:
- Consolidate metrics fetching into a paginated workflow using util.fetch_pages and new helpers (_fetch_metrics_page, _process_metrics_page, _make_new_metrics_page_params)
- Simplify fetch_multiple_series_values and rename internal functions to return a dict of AttributePathInRun to point lists
- Refactor the composition layer (_fetch_flat_dataframe_metrics → _fetch_metrics) to concurrently fetch sys IDs and attribute definitions and return both metrics_data and sys_id_label_mapping
- Overhaul create_metrics_dataframe to accept dict-based metrics_data and sys_id_label_mapping, rebuild category mappings, and simplify row generation logic
- Adjust util.fetch_pages to yield before computing the next page parameters

Tests:
- Update unit and end-to-end tests to use the new dict-based metrics_data format and sys_id_label_mapping
- Revise test helpers and data generators to align with updated fetch and formatting APIs

## Summary by Sourcery

Refactor the entire metrics pipeline to use paging, internal sys_id identifiers, and a structured mapping return format, and update downstream composition, output formatting, and tests accordingly

Enhancements:
- Refactor metrics retrieval to use util.fetch_pages with dedicated page fetchers and processors
- Streamline fetch_multiple_series_values to return dict of AttributePathInRun to value lists
- Update composition layer to concurrently fetch sys IDs and attribute definitions, returning both metrics data and sys_id-to-label mapping
- Revise create_metrics_dataframe to consume the dict-based metrics_data and sys_id_label_mapping and rebuild DataFrame with categorical mappings
- Simplify util.fetch_pages to yield before computing new page parameters

Tests:
- Adapt unit and end-to-end tests to use the new dict-based metrics_data and sys_id_label_mapping signatures