### PR TITLE
Handle `UnableToParseResponse`

### DIFF
--- a/src/neptune_fetcher/internal/retrieval/util.py
+++ b/src/neptune_fetcher/internal/retrieval/util.py
@@ -30,7 +30,10 @@ from typing import (
 
 import httpx
 from neptune_api import AuthenticatedClient
-from neptune_api.errors import ApiKeyRejectedError
+from neptune_api.errors import (
+    ApiKeyRejectedError,
+    UnableToParseResponse,
+)
 from neptune_api.types import Response
 
 from neptune_fetcher import exceptions
@@ -96,21 +99,28 @@ def backoff_retry(
 
     while True:
         tries += 1
+        response = None
         try:
             response = func(*args, **kwargs)
         except ApiKeyRejectedError as e:
             # The API token is explicitly rejected by the backend -- don't retry anymore.
-            raise NeptuneInvalidCredentialsError from e
+            raise NeptuneInvalidCredentialsError() from e
         except httpx.TimeoutException as e:
-            response = None
             last_exc = e
             logger.warning(
                 "Neptune API request timed out. Retrying...\n"
                 "Check your network connection or increase the timeout by setting the "
                 "NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS environment variable (default: 60 seconds)."
             )
+        except UnableToParseResponse as e:
+            # Allow invalid response in 5xx errors to be retried, raise otherwise
+            if e.response.status_code < 500:
+                raise exceptions.NeptuneUnexpectedResponseError(
+                    status_code=e.response.status_code,
+                    content=e.response.content,
+                ) from e
+            last_exc = e
         except Exception as e:
-            response = None
             last_exc = e
 
         if response is not None:


### PR DESCRIPTION
## Summary by Sourcery

Prevent retrying on response parsing failures by catching `UnableToParseResponse` and raising an immediate error with proper status and content, and add a unit test to confirm this behavior.

Bug Fixes:
- Catch `UnableToParseResponse` in `backoff_retry` and raise a user-facing exception without retrying.

Enhancements:
- Update `_raise_for_response` signature to indicate it never returns.

Tests:
- Add unit test to verify no retry occurs when response parsing fails.