### PR TITLE
Serialize alpha/runs tests

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,5 +6,6 @@ pytest
 pytest-mock
 pytest-retry
 pytest-timeout
+pytest-xdist
 icecream
 neptune-scale==0.13.0b0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,4 @@ ignore_missing_imports = "True"
 [tool.pytest.ini_options]
 retries = 3
 retry_delay = 2
+addopts = "--dist=loadfile"


### PR DESCRIPTION
Acquire a lock when creating the Neptune project for tests under `tests/e2e/alpha/runs`.

This allows to run e2e tests in parallel while keeping the run tests working as expected.

Additionally, add `--dist=loadfile` to pytest invocation (via pyproject.toml) which results in the quickest parallel test run (at least for us) clocking at under 3 minutes when using enough workers (here, using 32 as an example):

```
(ac50006...) ~/neptune-playground/neptune-fetcher $ poetry run pytest tests/e2e/ -n 32
======================================================== test session starts =========================================================
[...]
====================================== 1302 passed, 3 skipped, 3 warnings in 158.83s (0:02:38) =======================================
```

## Summary by Sourcery

Synchronize Neptune project creation in end-to-end tests with a file lock and configure pytest for loadfile distribution to speed up parallel test runs.

Tests:
- Acquire a file-based lock around project creation in the `new_project_id` fixture to prevent 409 conflicts when running tests in parallel
- Add `--dist loadfile` to pytest configuration for faster parallel e2e test execution

## Summary by Sourcery

Synchronize Neptune E2E project creation to avoid conflicts and optimize pytest for faster parallel end-to-end test execution

Tests:
- Acquire a file-based lock around project creation in the new_project_id fixture to prevent 409 conflicts when running tests in parallel
- Add "--dist=loadfile" to pytest configuration to speed up parallel E2E test runs