### PR TITLE
fix: Fix download_files that raises AttributeError

### DIFF
--- a/src/neptune_fetcher/internal/retrieval/files.py
+++ b/src/neptune_fetcher/internal/retrieval/files.py
@@ -23,7 +23,7 @@ from typing import (
 import azure.core.exceptions
 from azure.storage.blob import BlobClient
 from neptune_api.client import AuthenticatedClient
-from neptune_storage_api.api import storagebridge
+from neptune_storage_api.api.storagebridge import signed_url
 from neptune_storage_api.models import (
     CreateSignedUrlsRequest,
     CreateSignedUrlsResponse,
@@ -57,7 +57,7 @@ def fetch_signed_urls(
         ]
     )
 
-    response = util.backoff_retry(storagebridge.signed_url.sync_detailed, client=client, body=body)
+    response = util.backoff_retry(signed_url.sync_detailed, client=client, body=body)
 
     data: CreateSignedUrlsResponse = response.parsed
 


### PR DESCRIPTION
Fixes `AttributeError: module 'neptune_storage_api.api.storagebridge' has no attribute 'signed_url'` when calling `download_files`

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Bug Fixes:
- Invoke signed_url.sync_detailed directly instead of via storagebridge to prevent AttributeError