### PR TITLE
Prepare for v1: Require passing the project_identifier to the internal functions and require passing all parameters as named

### DIFF
--- a/src/neptune_fetcher/alpha/__init__.py
+++ b/src/neptune_fetcher/alpha/__init__.py
@@ -39,6 +39,7 @@ import pandas as _pandas
 
 from neptune_fetcher.alpha import filters
 from neptune_fetcher.alpha._internal import (
+    get_default_project_identifier,
     resolve_attributes_filter,
     resolve_destination_path,
     resolve_experiments_filter,
@@ -75,7 +76,12 @@ def list_experiments(
     """
     _experiments = resolve_experiments_filter(experiments)
 
-    return _list_containers.list_containers(_experiments, context, _search.ContainerType.EXPERIMENT)
+    return _list_containers.list_containers(
+        project_identifier=get_default_project_identifier(context),
+        filter_=_experiments,
+        context=context,
+        container_type=_search.ContainerType.EXPERIMENT,
+    )
 
 
 def list_attributes(
@@ -103,9 +109,14 @@ def list_attributes(
 
     _experiments = resolve_experiments_filter(experiments)
     _attributes = resolve_attributes_filter(attributes)
+    project_identifier = get_default_project_identifier(context)
 
     return _list_attributes.list_attributes(
-        _experiments, _attributes, context, container_type=_search.ContainerType.EXPERIMENT
+        project_identifier=project_identifier,
+        filter_=_experiments,
+        attributes=_attributes,
+        context=context,
+        container_type=_search.ContainerType.EXPERIMENT,
     )
 
 
@@ -150,8 +161,10 @@ def fetch_metrics(
     _experiments = resolve_experiments_filter(experiments)
     assert _experiments is not None
     _attributes = resolve_attributes_filter(attributes, forced_type=["float_series"])
+    project_identifier = get_default_project_identifier(context)
 
     return _fetch_metrics.fetch_metrics(
+        project_identifier=project_identifier,
         filter_=_experiments,
         attributes=_attributes,
         include_time=include_time,
@@ -199,8 +212,10 @@ def fetch_experiments_table(
     _experiments = resolve_experiments_filter(experiments)
     _attributes = resolve_attributes_filter(attributes)
     _sort_by = resolve_sort_by(sort_by)
+    project_identifier = get_default_project_identifier(context)
 
     return _fetch_table.fetch_table(
+        project_identifier=project_identifier,
         filter_=_experiments,
         attributes=_attributes,
         sort_by=_sort_by,
@@ -248,8 +263,10 @@ def fetch_series(
     _experiments = resolve_experiments_filter(experiments)
     assert _experiments is not None
     _attributes = resolve_attributes_filter(attributes, forced_type=["string_series"])
+    project_identifier = get_default_project_identifier(context)
 
     return _fetch_series.fetch_series(
+        project_identifier=project_identifier,
         filter_=_experiments,
         attributes=_attributes,
         include_time=include_time,
@@ -289,8 +306,10 @@ def download_files(
     _experiments = resolve_experiments_filter(experiments)
     _attributes = resolve_attributes_filter(attributes, forced_type=["file"])
     destination_path = resolve_destination_path(destination)
+    project_identifier = get_default_project_identifier(context)
 
     return _download_files.download_files(
+        project_identifier=project_identifier,
         filter_=_experiments,
         attributes=_attributes,
         destination=destination_path,

--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -25,6 +25,12 @@ from typing import (
 
 from neptune_fetcher.alpha import filters
 from neptune_fetcher.internal import filters as _filters
+from neptune_fetcher.internal.context import (
+    Context,
+    get_context,
+    validate_context,
+)
+from neptune_fetcher.internal.identifiers import ProjectIdentifier
 
 
 def resolve_experiments_filter(
@@ -113,3 +119,15 @@ def resolve_runs_filter(runs: Optional[Union[str, list[str], filters.Filter]]) -
     raise ValueError(
         f"Invalid type for `runs` filter. Expected str, list[str], or Filter object, but got {type(runs)}."
     )
+
+
+def get_default_project_identifier(context: Optional[Context] = None) -> ProjectIdentifier:
+    """
+    Returns the default project name from the current context.
+    If no context is set, it returns 'default'.
+    """
+    valid_context = validate_context(context or get_context())
+    project = valid_context.project
+    if not project:
+        raise ValueError("No project is set in the context. Please set a project before calling this function.")
+    return ProjectIdentifier(project)

--- a/src/neptune_fetcher/alpha/runs.py
+++ b/src/neptune_fetcher/alpha/runs.py
@@ -33,6 +33,7 @@ import pandas as _pandas
 
 from neptune_fetcher.alpha import filters
 from neptune_fetcher.alpha._internal import (
+    get_default_project_identifier,
     resolve_attributes_filter,
     resolve_destination_path,
     resolve_runs_filter,
@@ -62,8 +63,14 @@ def list_runs(
     `context` - a Context object to be used; primarily useful for switching projects
     """
     _runs = resolve_runs_filter(runs)
+    project_identifier = get_default_project_identifier(context)
 
-    return _list_containers.list_containers(_runs, context, _search.ContainerType.RUN)
+    return _list_containers.list_containers(
+        project_identifier=project_identifier,
+        filter_=_runs,
+        context=context,
+        container_type=_search.ContainerType.RUN,
+    )
 
 
 def list_attributes(
@@ -90,8 +97,15 @@ def list_attributes(
     """
     _runs = resolve_runs_filter(runs)
     _attributes = resolve_attributes_filter(attributes)
+    project_identifier = get_default_project_identifier(context)
 
-    return _list_attributes.list_attributes(_runs, _attributes, context, container_type=_search.ContainerType.RUN)
+    return _list_attributes.list_attributes(
+        project_identifier=project_identifier,
+        filter_=_runs,
+        attributes=_attributes,
+        context=context,
+        container_type=_search.ContainerType.RUN,
+    )
 
 
 def fetch_metrics(
@@ -135,8 +149,10 @@ def fetch_metrics(
     _runs = resolve_runs_filter(runs)
     assert _runs is not None
     _attributes = resolve_attributes_filter(attributes, forced_type=["float_series"])
+    project_identifier = get_default_project_identifier(context)
 
     return _fetch_metrics.fetch_metrics(
+        project_identifier=project_identifier,
         filter_=_runs,
         attributes=_attributes,
         include_time=include_time,
@@ -184,8 +200,10 @@ def fetch_runs_table(
     _runs = resolve_runs_filter(runs)
     _attributes = resolve_attributes_filter(attributes)
     _sort_by = resolve_sort_by(sort_by)
+    project_identifier = get_default_project_identifier(context)
 
     return _fetch_table.fetch_table(
+        project_identifier=project_identifier,
         filter_=_runs,
         attributes=_attributes,
         sort_by=_sort_by,
@@ -233,8 +251,10 @@ def fetch_series(
     _runs = resolve_runs_filter(runs)
     assert _runs is not None
     _attributes = resolve_attributes_filter(attributes, forced_type=["string_series"])
+    project_identifier = get_default_project_identifier(context)
 
     return _fetch_series.fetch_series(
+        project_identifier=project_identifier,
         filter_=_runs,
         attributes=_attributes,
         include_time=include_time,
@@ -274,8 +294,10 @@ def download_files(
     _runs = resolve_runs_filter(runs)
     _attributes = resolve_attributes_filter(attributes, forced_type=["file"])
     destination_path = resolve_destination_path(destination)
+    project_identifier = get_default_project_identifier(context)
 
     return _download_files.download_files(
+        project_identifier=project_identifier,
         filter_=_runs,
         attributes=_attributes,
         destination=destination_path,

--- a/src/neptune_fetcher/internal/composition/fetch_series.py
+++ b/src/neptune_fetcher/internal/composition/fetch_series.py
@@ -37,6 +37,7 @@ from neptune_fetcher.internal.filters import (
     _AttributeFilter,
     _Filter,
 )
+from neptune_fetcher.internal.identifiers import ProjectIdentifier
 from neptune_fetcher.internal.output_format import create_series_dataframe
 from neptune_fetcher.internal.retrieval import (
     search,
@@ -50,13 +51,15 @@ __all__ = ("fetch_series",)
 
 
 def fetch_series(
+    *,
+    project_identifier: ProjectIdentifier,
     filter_: _Filter,
     attributes: _AttributeFilter,
     include_time: Optional[Literal["absolute"]],
     step_range: Tuple[Optional[float], Optional[float]],
     lineage_to_the_root: bool,
     tail_limit: Optional[int],
-    context: Optional[Context],
+    context: Optional[Context] = None,
     container_type: ContainerType,
 ) -> pd.DataFrame:
     _validate_step_range(step_range)
@@ -65,7 +68,6 @@ def fetch_series(
 
     valid_context = validate_context(context or get_context())
     client = get_client(context=valid_context)
-    project_identifier = identifiers.ProjectIdentifier(valid_context.project)  # type: ignore
 
     with (
         concurrency.create_thread_pool_executor() as executor,

--- a/src/neptune_fetcher/internal/composition/list_attributes.py
+++ b/src/neptune_fetcher/internal/composition/list_attributes.py
@@ -45,14 +45,15 @@ from neptune_fetcher.internal.retrieval import (
 
 
 def list_attributes(
+    *,
+    project_identifier: identifiers.ProjectIdentifier,
     filter_: Optional[_Filter],
     attributes: _AttributeFilter,
-    context: Optional[Context],
+    context: Optional[Context] = None,
     container_type: search.ContainerType,
 ) -> list[str]:
     valid_context = validate_context(context or get_context())
     client = _client.get_client(context=valid_context)
-    project_identifier = identifiers.ProjectIdentifier(valid_context.project)  # type: ignore
 
     with (
         concurrency.create_thread_pool_executor() as executor,

--- a/src/neptune_fetcher/internal/composition/list_containers.py
+++ b/src/neptune_fetcher/internal/composition/list_containers.py
@@ -16,25 +16,27 @@ from typing import Optional
 
 from neptune_fetcher.internal import client as _client
 from neptune_fetcher.internal import context as _context
-from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.composition import (
     concurrency,
     type_inference,
 )
 from neptune_fetcher.internal.filters import _Filter
+from neptune_fetcher.internal.identifiers import ProjectIdentifier
 from neptune_fetcher.internal.retrieval import search
 
 __all__ = ("list_containers",)
 
 
 def list_containers(
+    *,
+    project_identifier: ProjectIdentifier,
     filter_: Optional[_Filter],
-    context: Optional[_context.Context],
+    context: Optional[_context.Context] = None,
     container_type: search.ContainerType,
 ) -> list[str]:
     validated_context = _context.validate_context(context or _context.get_context())
     client = _client.get_client(context=validated_context)
-    project_identifier = identifiers.ProjectIdentifier(validated_context.project)  # type: ignore
+    client = _client.get_client(validated_context)
 
     with (
         concurrency.create_thread_pool_executor() as executor,

--- a/tests/e2e/internal/composition/test_download_files.py
+++ b/tests/e2e/internal/composition/test_download_files.py
@@ -29,6 +29,7 @@ def temp_dir():
 def test_download_files_missing(client, project, experiment_identifier, temp_dir):
     # when
     result_df = download_files(
+        project_identifier=project.project_identifier,
         filter_=_Filter.name_in(EXPERIMENT_NAME),
         attributes=_AttributeFilter(name_eq=[f"{PATH}/files/object-does-not-exist"]),
         destination=temp_dir,
@@ -54,6 +55,7 @@ def test_download_files_no_permission(client, project, experiment_identifier, te
 
     with pytest.raises(PermissionError):
         download_files(
+            project_identifier=project.project_identifier,
             filter_=_Filter.name_in(EXPERIMENT_NAME),
             attributes=_AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
             destination=temp_dir,
@@ -67,6 +69,7 @@ def test_download_files_no_permission(client, project, experiment_identifier, te
 def test_download_files_single(client, project, experiment_identifier, temp_dir):
     # when
     result_df = download_files(
+        project_identifier=project.project_identifier,
         filter_=_Filter.name_in(EXPERIMENT_NAME),
         attributes=_AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
         destination=temp_dir,
@@ -96,6 +99,7 @@ def test_download_files_single(client, project, experiment_identifier, temp_dir)
 def test_download_files_multiple(client, project, experiment_identifier, temp_dir):
     # when
     result_df = download_files(
+        project_identifier=project.project_identifier,
         filter_=_Filter.name_in(EXPERIMENT_NAME),
         attributes=_AttributeFilter(name_eq=[f"{PATH}/files/file-value", f"{PATH}/files/file-value.txt"]),
         destination=temp_dir,
@@ -135,6 +139,7 @@ def test_download_files_destination_a_file(client, project, experiment_identifie
 
     with pytest.raises(NotADirectoryError):
         download_files(
+            project_identifier=project.project_identifier,
             filter_=_Filter.name_in(EXPERIMENT_NAME),
             attributes=_AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
             destination=destination,


### PR DESCRIPTION
* **Internal functions** no longer grab project from context.
* Require passing all parameters to the **internal functions** by name.

## Summary by Sourcery

Refactor all fetch/list pipelines to explicitly accept and propagate project identifiers, decouple project resolution from internal modules, and update alpha wrappers and tests accordingly

Enhancements:
- Add explicit project_identifier parameter to composition functions and internal pipelines
- Introduce get_default_project_identifier helper in alpha layer to derive project names
- Update alpha module calls to pass project_identifier instead of deriving from context

CI:
- Enable pytest parallel distribution with --dist=loadfile

Tests:
- Modify download_files tests to supply project_identifier argument
- Wrap E2E project creation in a file lock to prevent 409 conflicts

## Summary by Sourcery

Require explicit project_identifier parameter for all internal composition functions and alpha wrappers, remove implicit project resolution from context, and enforce named arguments throughout.

Enhancements:
- Add project_identifier as a required named argument to all internal fetch, list, and download pipelines.
- Introduce get_default_project_identifier helper in the alpha layer to derive project identifiers from context.
- Update alpha-level list_runs, list_attributes, fetch_metrics, fetch_table, fetch_series, and download_files to pass project_identifier explicitly instead of resolving it internally.

Tests:
- Modify download_files E2E tests to supply project_identifier for each invocation.