### PR TITLE
fix: restrict pandas version to <2.3.0 for python=3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ python = "^3.9"
 # Base neptune package
 neptune-api = ">=0.16.0,<0.17.0"
 azure-storage-blob = "^12.7.0"
-pandas = { version = ">=1.4.0" }
+pandas = [
+    { version = ">=1.4.0,<2.3.0", python = "<3.10" },
+    { version = ">=1.4.0", python = ">=3.10" }
+]
 
 # Optional for default progress update handling
 tqdm = { version = ">=4.66.0" }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Constrain pandas to <2.3.0 for Python <3.10