### PR TITLE
Pin pandas to <2.3.0 for Python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ python = "^3.9"
 # Base neptune package
 neptune-api = ">=0.16.0,<0.17.0"
 azure-storage-blob = "^12.7.0"
-pandas = { version = ">=1.4.0" }
+pandas = [
+    { version = ">=1.4.0,<2.3.0", python = "<3.10" },
+    { version = ">=1.4.0", python = ">=3.10" }
+]
 
 # Optional for default progress update handling
 tqdm = { version = ">=4.66.0" }


### PR DESCRIPTION
## Summary by Sourcery

Pin the pandas dependency to versions <2.3.0 for Python 3.9 environments while preserving the existing >=1.4.0 constraint for Python 3.10 and above.

Build:
- Restrict pandas to <2.3.0 when running on Python versions below 3.10
- Maintain pandas >=1.4.0 without an upper bound for Python 3.10 and newer