### PR TITLE
PY-137 Fix for fetch_metrics() broken when using combined filters

### DIFF
--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -78,6 +78,8 @@ def resolve_attributes_filter(
                 aggregations=attributes.aggregations,
             )
             return modified_attributes._to_internal()
+        if isinstance(attributes, filters.BaseAttributeFilter):
+            return attributes._to_internal()
         raise ValueError(
             "Invalid type for attributes filter. Expected str, list of str, or AttributeFilter object, but got "
             f"{type(attributes)}."

--- a/tests/e2e/alpha/test_fetch_metrics.py
+++ b/tests/e2e/alpha/test_fetch_metrics.py
@@ -88,7 +88,14 @@ def create_expected_data(
 @pytest.mark.parametrize("step_range", [(0, 5), (0, None), (None, 5), (None, None), (100, 200)])
 @pytest.mark.parametrize("tail_limit", [None, 3, 5])
 @pytest.mark.parametrize(
-    "attr_filter", [AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]), ".*/metrics/.*"]
+    "attr_filter",
+    [
+        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]),
+        ".*/metrics/.*",
+        # Alternative should work too, see bug PY-137
+        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"])
+        | AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]),
+    ],
 )
 @pytest.mark.parametrize(
     "exp_filter",


### PR DESCRIPTION
## Summary by Sourcery

Support combined attribute filters in fetch_metrics by handling BaseAttributeFilter instances in resolve_attributes_filter and add test coverage for combined filters

Bug Fixes:
- Allow resolve_attributes_filter to accept BaseAttributeFilter instances for combined filters

Tests:
- Add combined AttributeFilter scenario to fetch_metrics tests to ensure support for OR-combined filters