### PR TITLE
Port main to v1

### DIFF
--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -85,6 +85,8 @@ def resolve_attributes_filter(
                 aggregations=attributes.aggregations,
             )
             return modified_attributes._to_internal()
+        if isinstance(attributes, filters.BaseAttributeFilter):
+            return attributes._to_internal()
         raise ValueError(
             "Invalid type for attributes filter. Expected str, list of str, or AttributeFilter object, but got "
             f"{type(attributes)}."

--- a/src/neptune_fetcher/internal/composition/attribute_components.py
+++ b/src/neptune_fetcher/internal/composition/attribute_components.py
@@ -29,7 +29,6 @@ from neptune_fetcher.internal.composition.attributes import (
     fetch_attribute_definition_aggregations,
     fetch_attribute_definitions,
 )
-from neptune_fetcher.internal.retrieval import attribute_definitions as att_defs
 from neptune_fetcher.internal.retrieval import attribute_values as att_vals
 from neptune_fetcher.internal.retrieval import (
     search,
@@ -45,7 +44,7 @@ def fetch_attribute_definitions_split(
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
     sys_ids: list[identifiers.SysId],
-    downstream: Callable[[list[identifiers.SysId], util.Page[att_defs.AttributeDefinition]], concurrency.OUT],
+    downstream: Callable[[list[identifiers.SysId], util.Page[identifiers.AttributeDefinition]], concurrency.OUT],
 ) -> concurrency.OUT:
     return concurrency.generate_concurrently(
         items=split.split_sys_ids(sys_ids),
@@ -72,7 +71,11 @@ def fetch_attribute_definition_aggregations_split(
     fetch_attribute_definitions_executor: Executor,
     sys_ids: list[identifiers.SysId],
     downstream: Callable[
-        [list[identifiers.SysId], util.Page[att_defs.AttributeDefinition], util.Page[AttributeDefinitionAggregation]],
+        [
+            list[identifiers.SysId],
+            util.Page[identifiers.AttributeDefinition],
+            util.Page[AttributeDefinitionAggregation],
+        ],
         concurrency.OUT,
     ],
 ) -> concurrency.OUT:
@@ -101,7 +104,7 @@ def fetch_attribute_definitions_complete(
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
     container_type: search.ContainerType,
-    downstream: Callable[[util.Page[att_defs.AttributeDefinition]], concurrency.OUT],
+    downstream: Callable[[util.Page[identifiers.AttributeDefinition]], concurrency.OUT],
 ) -> concurrency.OUT:
     if container_type == search.ContainerType.RUN and filter_ is None:
         return concurrency.generate_concurrently(
@@ -141,7 +144,7 @@ def fetch_attribute_values_split(
     project_identifier: identifiers.ProjectIdentifier,
     executor: Executor,
     sys_ids: list[identifiers.SysId],
-    attribute_definitions: list[att_defs.AttributeDefinition],
+    attribute_definitions: list[identifiers.AttributeDefinition],
     downstream: Callable[[util.Page[att_vals.AttributeValue]], concurrency.OUT],
 ) -> concurrency.OUT:
     return concurrency.generate_concurrently(

--- a/src/neptune_fetcher/internal/composition/attributes.py
+++ b/src/neptune_fetcher/internal/composition/attributes.py
@@ -37,7 +37,7 @@ from neptune_fetcher.internal.retrieval.attribute_types import TYPE_AGGREGATIONS
 
 @dataclass(frozen=True)
 class AttributeDefinitionAggregation:
-    attribute_definition: att_defs.AttributeDefinition
+    attribute_definition: identifiers.AttributeDefinition
     aggregation: Literal["last", "min", "max", "average", "variance"]
 
 
@@ -48,12 +48,12 @@ def fetch_attribute_definitions(
     attribute_filter: filters._BaseAttributeFilter,
     executor: Executor,
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_DEFINITIONS_BATCH_SIZE.get(),
-) -> Generator[util.Page[att_defs.AttributeDefinition], None, None]:
+) -> Generator[util.Page[identifiers.AttributeDefinition], None, None]:
     pages_filters = _fetch_attribute_definitions(
         client, project_identifiers, run_identifiers, attribute_filter, batch_size, executor
     )
 
-    seen_items: set[att_defs.AttributeDefinition] = set()
+    seen_items: set[identifiers.AttributeDefinition] = set()
     for page, filter_ in pages_filters:
         new_items = [item for item in page.items if item not in seen_items]
         seen_items.update(new_items)
@@ -67,7 +67,9 @@ def fetch_attribute_definition_aggregations(
     attribute_filter: filters._BaseAttributeFilter,
     executor: Executor,
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_DEFINITIONS_BATCH_SIZE.get(),
-) -> Generator[tuple[util.Page[att_defs.AttributeDefinition], util.Page[AttributeDefinitionAggregation]], None, None]:
+) -> Generator[
+    tuple[util.Page[identifiers.AttributeDefinition], util.Page[AttributeDefinitionAggregation]], None, None
+]:
     """
     Each attribute definition is yielded once when it's first encountered.
     If the attribute definition is of a type that supports aggregations (for now only float_series),
@@ -78,7 +80,7 @@ def fetch_attribute_definition_aggregations(
         client, project_identifiers, run_identifiers, attribute_filter, batch_size, executor
     )
 
-    seen_definitions: set[att_defs.AttributeDefinition] = set()
+    seen_definitions: set[identifiers.AttributeDefinition] = set()
     seen_definition_aggregations: set[AttributeDefinitionAggregation] = set()
 
     for page, filter_ in pages_filters:
@@ -112,10 +114,10 @@ def _fetch_attribute_definitions(
     attribute_filter: filters._BaseAttributeFilter,
     batch_size: int,
     executor: Executor,
-) -> Generator[tuple[util.Page[att_defs.AttributeDefinition], filters._AttributeFilter], None, None]:
+) -> Generator[tuple[util.Page[identifiers.AttributeDefinition], filters._AttributeFilter], None, None]:
     def go_fetch_single(
         filter_: filters._AttributeFilter,
-    ) -> Generator[util.Page[att_defs.AttributeDefinition], None, None]:
+    ) -> Generator[util.Page[identifiers.AttributeDefinition], None, None]:
         return att_defs.fetch_attribute_definitions_single_filter(
             client=client,
             project_identifiers=project_identifiers,

--- a/src/neptune_fetcher/internal/composition/download_files.py
+++ b/src/neptune_fetcher/internal/composition/download_files.py
@@ -41,7 +41,6 @@ from neptune_fetcher.internal.filters import (
     _Filter,
 )
 from neptune_fetcher.internal.retrieval import (
-    attribute_definitions,
     files,
     search,
 )
@@ -145,7 +144,7 @@ def download_files(
         )
 
         results: Generator[
-            tuple[identifiers.RunIdentifier, attribute_definitions.AttributeDefinition, Optional[pathlib.Path]],
+            tuple[identifiers.RunIdentifier, identifiers.AttributeDefinition, Optional[pathlib.Path]],
             None,
             None,
         ] = concurrency.gather_results(output)

--- a/src/neptune_fetcher/internal/composition/fetch_metrics.py
+++ b/src/neptune_fetcher/internal/composition/fetch_metrics.py
@@ -21,7 +21,6 @@ from typing import (
     Iterable,
     Literal,
     Optional,
-    Tuple,
 )
 
 import pandas as pd
@@ -43,16 +42,14 @@ from neptune_fetcher.internal.filters import (
     _AttributeFilter,
     _Filter,
 )
-from neptune_fetcher.internal.identifiers import RunIdentifier as ExpId
+from neptune_fetcher.internal.identifiers import RunIdentifier
 from neptune_fetcher.internal.output_format import create_metrics_dataframe
 from neptune_fetcher.internal.retrieval import (
     search,
     split,
     util,
 )
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
 from neptune_fetcher.internal.retrieval.metrics import (
-    AttributePathInRun,
     FloatPointValue,
     fetch_multiple_series_values,
 )
@@ -69,7 +66,7 @@ def fetch_metrics(
     filter_: _Filter,
     attributes: _AttributeFilter,
     include_time: Optional[Literal["absolute"]],
-    step_range: Tuple[Optional[float], Optional[float]],
+    step_range: tuple[Optional[float], Optional[float]],
     lineage_to_the_root: bool,
     tail_limit: Optional[int],
     type_suffix_in_column_names: bool,
@@ -97,7 +94,7 @@ def fetch_metrics(
             container_type=container_type,
         )
 
-        values_generator = _fetch_flat_dataframe_metrics(
+        metrics_data, sys_id_to_label_mapping = _fetch_metrics(
             filter_=filter_,
             attributes=attributes,
             client=client,
@@ -112,7 +109,8 @@ def fetch_metrics(
         )
 
         df = create_metrics_dataframe(
-            values_generator,
+            metrics_data=metrics_data,
+            sys_id_label_mapping=sys_id_to_label_mapping,
             index_column_name="experiment" if container_type == ContainerType.EXPERIMENT else "run",
             timestamp_column_name="absolute_time" if include_time == "absolute" else None,
             include_point_previews=include_point_previews,
@@ -122,7 +120,7 @@ def fetch_metrics(
     return df
 
 
-def _validate_step_range(step_range: Tuple[Optional[float], Optional[float]]) -> None:
+def _validate_step_range(step_range: tuple[Optional[float], Optional[float]]) -> None:
     """Validate that a step range tuple contains valid values and is properly ordered."""
     if not isinstance(step_range, tuple) or len(step_range) != 2:
         raise ValueError("step_range must be a tuple of two values")
@@ -155,25 +153,25 @@ def _validate_include_time(include_time: Optional[Literal["absolute"]]) -> None:
             raise ValueError("include_time must be 'absolute'")
 
 
-def _fetch_flat_dataframe_metrics(
+def _fetch_metrics(
     filter_: _Filter,
     attributes: _AttributeFilter,
     client: AuthenticatedClient,
     project_identifier: identifiers.ProjectIdentifier,
     executor: Executor,
     fetch_attribute_definitions_executor: Executor,
-    step_range: Tuple[Optional[float], Optional[float]],
+    step_range: tuple[Optional[float], Optional[float]],
     lineage_to_the_root: bool,
     include_point_previews: bool,
     tail_limit: Optional[int],
     container_type: ContainerType,
-) -> Iterable[FloatPointValue]:  # pd.DataFrame:
+) -> tuple[dict[identifiers.RunAttributeDefinition, list[FloatPointValue]], dict[identifiers.SysId, str]]:
     def fetch_values(
-        exp_paths: list[AttributePathInRun],
-    ) -> Tuple[list[concurrent.futures.Future], Iterable[FloatPointValue]]:
+        exp_paths: list[identifiers.RunAttributeDefinition],
+    ) -> tuple[list[concurrent.futures.Future], dict[identifiers.RunAttributeDefinition, list[FloatPointValue]]]:
         _series = fetch_multiple_series_values(
             client,
-            exp_paths=exp_paths,
+            run_attribute_definitions=exp_paths,
             include_inherited=lineage_to_the_root,
             include_preview=include_point_previews,
             step_range=step_range,
@@ -182,44 +180,41 @@ def _fetch_flat_dataframe_metrics(
         return [], _series
 
     def process_definitions(
-        _sys_id_to_labels: dict[identifiers.SysId, str],
-        _definitions: Generator[util.Page[AttributeDefinition], None, None],
-    ) -> Tuple[list[concurrent.futures.Future], Iterable[FloatPointValue]]:
+        _sys_ids: Iterable[identifiers.SysId],
+        _definitions: Generator[util.Page[identifiers.AttributeDefinition], None, None],
+    ) -> tuple[list[concurrent.futures.Future], dict[identifiers.RunAttributeDefinition, list[FloatPointValue]]]:
         definitions_page = next(_definitions, None)
         _futures = []
+
         if definitions_page:
-            _futures.append(executor.submit(process_definitions, _sys_id_to_labels, _definitions))
+            _futures.append(executor.submit(process_definitions, _sys_ids, _definitions))
 
             paths = definitions_page.items
 
-            product = it.product(_sys_id_to_labels.items(), paths)
             exp_paths = [
-                AttributePathInRun(ExpId(project_identifier, sys_id), label, _path.name)
-                for (sys_id, label), _path in product
+                identifiers.RunAttributeDefinition(RunIdentifier(project_identifier, sys_id), _path)
+                for sys_id, _path in it.product(_sys_ids, paths)
                 if _path.type == "float_series"
             ]
 
-            for batch in split_series_attributes(items=exp_paths, get_path=lambda r: r.attribute_path):
+            for batch in split_series_attributes(items=exp_paths, get_path=lambda r: r.attribute_definition.name):
                 _futures.append(executor.submit(fetch_values, batch))
 
-        return _futures, []
+        return _futures, {}
 
     def process_sys_ids(
-        sys_ids_generator: Generator[dict[identifiers.SysId, str], None, None],
-    ) -> Tuple[list[concurrent.futures.Future], Iterable[FloatPointValue]]:
-        sys_id_to_labels = next(sys_ids_generator, None)
+        sys_ids_generator: Generator[list[identifiers.SysId], None, None],
+    ) -> tuple[list[concurrent.futures.Future], dict[identifiers.RunAttributeDefinition, list[FloatPointValue]]]:
+        sys_ids = next(sys_ids_generator, None)
         _futures = []
 
-        if sys_id_to_labels:
+        if sys_ids:
             _futures.append(executor.submit(process_sys_ids, sys_ids_generator))
-
-            sys_ids = list(sys_id_to_labels.keys())
 
             for sys_ids_split in split.split_sys_ids(sys_ids):
                 run_identifiers_split = [
                     identifiers.RunIdentifier(project_identifier, sys_id) for sys_id in sys_ids_split
                 ]
-                sys_id_to_labels_split = {sys_id: sys_id_to_labels[sys_id] for sys_id in sys_ids_split}
                 definitions_generator = fetch_attribute_definitions(
                     client=client,
                     project_identifiers=[project_identifier],
@@ -227,24 +222,36 @@ def _fetch_flat_dataframe_metrics(
                     attribute_filter=attributes,
                     executor=fetch_attribute_definitions_executor,
                 )
-                _futures.append(executor.submit(process_definitions, sys_id_to_labels_split, definitions_generator))
+                _futures.append(executor.submit(process_definitions, sys_ids_split, definitions_generator))
 
-        return _futures, []
+        return _futures, {}
 
-    def fetch_sys_ids_labels() -> Generator[dict[identifiers.SysId, str], None, None]:
-        sys_attr_pages = search.fetch_sys_id_labels(container_type)(client, project_identifier, filter_)
-        return ({run.sys_id: run.label for run in page.items} for page in sys_attr_pages)
+    sys_id_label_mapping: dict[identifiers.SysId, str] = {}
 
-    def _start() -> Iterable[FloatPointValue]:
-        futures = {executor.submit(lambda: process_sys_ids(fetch_sys_ids_labels()))}
+    def go_fetch_sys_attrs() -> Generator[list[identifiers.SysId], None, None]:
+        for page in search.fetch_sys_id_labels(container_type)(
+            client=client,
+            project_identifier=project_identifier,
+            filter_=filter_,
+        ):
+            sys_ids = []
+            for item in page.items:
+                sys_id_label_mapping[item.sys_id] = item.label
+                sys_ids.append(item.sys_id)
+            yield sys_ids
 
-        while futures:
-            done, not_done = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_COMPLETED)
-            futures = not_done
-            for future in done:
-                new_futures, values = future.result()
-                futures.update(new_futures)
-                if values:
-                    yield from values
+    futures = {executor.submit(lambda: process_sys_ids(go_fetch_sys_attrs()))}
 
-    return _start()
+    metrics_data: dict[identifiers.RunAttributeDefinition, list[FloatPointValue]] = {}
+
+    while futures:
+        done, not_done = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_COMPLETED)
+        futures = not_done
+        for future in done:
+            new_futures, values = future.result()
+            futures.update(new_futures)
+            if values:
+                for run_attribute, metric_points in values.items():
+                    metrics_data.setdefault(run_attribute, []).extend(metric_points)
+
+    return metrics_data, sys_id_label_mapping

--- a/src/neptune_fetcher/internal/composition/fetch_series.py
+++ b/src/neptune_fetcher/internal/composition/fetch_series.py
@@ -114,7 +114,7 @@ def fetch_series(
                 downstream=lambda sys_ids_split, definitions_page: concurrency.generate_concurrently(
                     items=split.split_series_attributes(
                         items=(
-                            series.RunAttributeDefinition(
+                            identifiers.RunAttributeDefinition(
                                 run_identifier=identifiers.RunIdentifier(project_identifier, sys_id),
                                 attribute_definition=definition,
                             )
@@ -139,10 +139,10 @@ def fetch_series(
             ),
         )
         results: Generator[
-            util.Page[tuple[series.RunAttributeDefinition, list[series.StringSeriesValue]]], None, None
+            util.Page[tuple[identifiers.RunAttributeDefinition, list[series.StringSeriesValue]]], None, None
         ] = concurrency.gather_results(output)
 
-        series_data: dict[series.RunAttributeDefinition, list[series.StringSeriesValue]] = {}
+        series_data: dict[identifiers.RunAttributeDefinition, list[series.StringSeriesValue]] = {}
         for result in results:
             for run_attribute_definition, series_values in result.items:
                 series_data.setdefault(run_attribute_definition, []).extend(series_values)

--- a/src/neptune_fetcher/internal/composition/fetch_table.py
+++ b/src/neptune_fetcher/internal/composition/fetch_table.py
@@ -40,7 +40,6 @@ from neptune_fetcher.internal.filters import (
     _Filter,
 )
 from neptune_fetcher.internal.identifiers import ProjectIdentifier
-from neptune_fetcher.internal.retrieval import attribute_definitions as att_defs
 from neptune_fetcher.internal.retrieval import attribute_values as att_vals
 from neptune_fetcher.internal.retrieval import (
     search,
@@ -94,7 +93,7 @@ def fetch_table(
 
         sys_id_label_mapping: dict[identifiers.SysId, str] = {}
         result_by_id: dict[identifiers.SysId, list[att_vals.AttributeValue]] = {}
-        selected_aggregations: dict[att_defs.AttributeDefinition, set[str]] = defaultdict(set)
+        selected_aggregations: dict[identifiers.AttributeDefinition, set[str]] = defaultdict(set)
 
         def go_fetch_sys_attrs() -> Generator[list[identifiers.SysId], None, None]:
             for page in search.fetch_sys_id_labels(container_type)(
@@ -139,7 +138,7 @@ def fetch_table(
             ),
         )
         results: Generator[
-            Union[util.Page[att_vals.AttributeValue], dict[att_defs.AttributeDefinition, set[str]]], None, None
+            Union[util.Page[att_vals.AttributeValue], dict[identifiers.AttributeDefinition, set[str]]], None, None
         ] = concurrency.gather_results(output)
 
         for result in results:

--- a/src/neptune_fetcher/internal/composition/list_attributes.py
+++ b/src/neptune_fetcher/internal/composition/list_attributes.py
@@ -37,7 +37,6 @@ from neptune_fetcher.internal.filters import (
     _AttributeFilter,
     _Filter,
 )
-from neptune_fetcher.internal.retrieval import attribute_definitions as att_defs
 from neptune_fetcher.internal.retrieval import (
     search,
     util,
@@ -79,7 +78,7 @@ def list_attributes(
             container_type=container_type,
         )
 
-        results: Generator[util.Page[att_defs.AttributeDefinition], None, None] = concurrency.gather_results(output)
+        results: Generator[util.Page[identifiers.AttributeDefinition], None, None] = concurrency.gather_results(output)
         names = set()
         for page in results:
             for item in page.items:

--- a/src/neptune_fetcher/internal/composition/type_inference.py
+++ b/src/neptune_fetcher/internal/composition/type_inference.py
@@ -30,7 +30,6 @@ from neptune_fetcher.internal import (
 )
 from neptune_fetcher.internal.composition import attribute_components as _components
 from neptune_fetcher.internal.composition import concurrency
-from neptune_fetcher.internal.retrieval import attribute_definitions as att_defs
 from neptune_fetcher.internal.retrieval import (
     search,
     util,
@@ -143,7 +142,7 @@ def _infer_attribute_types_from_api(
     )
 
     attribute_definition_pages: Generator[
-        util.Page[att_defs.AttributeDefinition], None, None
+        util.Page[identifiers.AttributeDefinition], None, None
     ] = concurrency.gather_results(output)
 
     attribute_name_to_definition: dict[str, set[str]] = defaultdict(set)

--- a/src/neptune_fetcher/internal/identifiers.py
+++ b/src/neptune_fetcher/internal/identifiers.py
@@ -28,3 +28,15 @@ class RunIdentifier:
 
     def __str__(self) -> str:
         return f"{self.project_identifier}/{self.sys_id}"
+
+
+@dataclass(frozen=True)
+class AttributeDefinition:
+    name: str
+    type: str
+
+
+@dataclass(frozen=True)
+class RunAttributeDefinition:
+    run_identifier: RunIdentifier
+    attribute_definition: AttributeDefinition

--- a/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
+++ b/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
@@ -15,7 +15,6 @@
 import functools as ft
 import itertools as it
 import re
-from dataclasses import dataclass
 from typing import (
     Any,
     Generator,
@@ -30,13 +29,6 @@ from neptune_api.models import (
     QueryAttributeDefinitionsBodyDTO,
     QueryAttributeDefinitionsResultDTO,
 )
-
-
-@dataclass(frozen=True)
-class AttributeDefinition:
-    name: str
-    type: str
-
 
 # The following imports need to go after the AttributeDefinition to avoid circular imports, thus the noqa
 import neptune_fetcher.internal.filters as filters  # noqa: E402
@@ -65,7 +57,7 @@ def fetch_attribute_definitions_single_filter(
     run_identifiers: Optional[Iterable[identifiers.RunIdentifier]],
     attribute_filter: filters._AttributeFilter,
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_DEFINITIONS_BATCH_SIZE.get(),
-) -> Generator[util.Page[AttributeDefinition], None, None]:
+) -> Generator[util.Page[identifiers.AttributeDefinition], None, None]:
     params: dict[str, Any] = {
         "projectIdentifiers": list(project_identifiers),
         "attributeNameFilter": dict(),
@@ -135,10 +127,10 @@ def _fetch_attribute_definitions_page(
 
 def _process_attribute_definitions_page(
     data: QueryAttributeDefinitionsResultDTO,
-) -> util.Page[AttributeDefinition]:
+) -> util.Page[identifiers.AttributeDefinition]:
     items = []
     for entry in data.entries:
-        item = AttributeDefinition(
+        item = identifiers.AttributeDefinition(
             name=entry.name,
             type=types.map_attribute_type_backend_to_python(str(entry.type)),
         )

--- a/src/neptune_fetcher/internal/retrieval/attribute_values.py
+++ b/src/neptune_fetcher/internal/retrieval/attribute_values.py
@@ -31,7 +31,6 @@ from neptune_fetcher.internal import (
     identifiers,
 )
 from neptune_fetcher.internal.retrieval import util
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
 from neptune_fetcher.internal.retrieval.attribute_types import (
     extract_value,
     map_attribute_type_backend_to_python,
@@ -40,7 +39,7 @@ from neptune_fetcher.internal.retrieval.attribute_types import (
 
 @dataclass(frozen=True)
 class AttributeValue:
-    attribute_definition: AttributeDefinition
+    attribute_definition: identifiers.AttributeDefinition
     value: Any
     run_identifier: identifiers.RunIdentifier
 
@@ -49,10 +48,10 @@ def fetch_attribute_values(
     client: AuthenticatedClient,
     project_identifier: identifiers.ProjectIdentifier,
     run_identifiers: Iterable[identifiers.RunIdentifier],
-    attribute_definitions: Iterable[AttributeDefinition],
+    attribute_definitions: Iterable[identifiers.AttributeDefinition],
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_VALUES_BATCH_SIZE.get(),
 ) -> Generator[util.Page[AttributeValue], None, None]:
-    attribute_definitions_set: set[AttributeDefinition] = set(attribute_definitions)
+    attribute_definitions_set: set[identifiers.AttributeDefinition] = set(attribute_definitions)
     experiments = [str(e) for e in run_identifiers]
 
     if not attribute_definitions_set or not run_identifiers:
@@ -94,7 +93,7 @@ def _fetch_attribute_values_page(
 
 def _process_attribute_values_page(
     data: ProtoQueryAttributesResultDTO,
-    attribute_definitions_set: set[AttributeDefinition],
+    attribute_definitions_set: set[identifiers.AttributeDefinition],
     project_identifier: identifiers.ProjectIdentifier,
 ) -> util.Page[AttributeValue]:
     items = []
@@ -104,7 +103,9 @@ def _process_attribute_values_page(
         )
 
         for attr in entry.attributes:
-            attr_definition = AttributeDefinition(name=attr.name, type=map_attribute_type_backend_to_python(attr.type))
+            attr_definition = identifiers.AttributeDefinition(
+                name=attr.name, type=map_attribute_type_backend_to_python(attr.type)
+            )
             if attr_definition not in attribute_definitions_set:
                 continue
 

--- a/src/neptune_fetcher/internal/retrieval/metrics.py
+++ b/src/neptune_fetcher/internal/retrieval/metrics.py
@@ -13,28 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools as ft
 import logging
-from dataclasses import dataclass
-from itertools import chain
 from typing import (
-    Iterable,
-    Literal,
+    Any,
     Optional,
-    Tuple,
     Union,
 )
 
 from neptune_api.api.retrieval import get_multiple_float_series_values_proto
 from neptune_api.client import AuthenticatedClient
-from neptune_api.models import (
-    AttributesHolderIdentifier,
-    FloatTimeSeriesValuesRequest,
-    FloatTimeSeriesValuesRequestOrder,
-    FloatTimeSeriesValuesRequestSeries,
-    OpenRangeDTO,
-    TimeSeries,
-    TimeSeriesLineage,
-)
+from neptune_api.models import FloatTimeSeriesValuesRequest
 from neptune_api.proto.neptune_pb.api.v1.model.series_values_pb2 import ProtoFloatSeriesValuesResponseDTO
 
 from neptune_fetcher.internal import identifiers
@@ -42,149 +31,105 @@ from neptune_fetcher.internal.retrieval import util
 
 logger = logging.getLogger(__name__)
 
-AttributePath = str
-RunLabel = str
-
 # Tuples are used here to enhance performance
-FloatPointValue = Tuple[RunLabel, AttributePath, float, float, float, bool, float]
+FloatPointValue = tuple[float, float, float, bool, float]
 (
-    ExperimentNameIndex,
-    AttributePathIndex,
     TimestampIndex,
     StepIndex,
     ValueIndex,
     IsPreviewIndex,
     PreviewCompletionIndex,
-) = range(7)
+) = range(5)
 
 TOTAL_POINT_LIMIT: int = 1_000_000
 
 
-@dataclass(frozen=True)
-class AttributePathInRun:
-    run_identifier: identifiers.RunIdentifier
-    run_label: RunLabel
-    attribute_path: AttributePath
-
-
-@dataclass(frozen=True)
-class _SeriesRequest:
-    path: str
-    run_identifier: identifiers.RunIdentifier
-    include_inherited: bool
-    include_preview: bool
-    after_step: Optional[float]
-
-
 def fetch_multiple_series_values(
     client: AuthenticatedClient,
-    exp_paths: list[AttributePathInRun],
+    run_attribute_definitions: list[identifiers.RunAttributeDefinition],
     include_inherited: bool,
     include_preview: bool,
-    step_range: Tuple[Union[float, None], Union[float, None]] = (None, None),
+    step_range: tuple[Union[float, None], Union[float, None]] = (None, None),
     tail_limit: Optional[int] = None,
-) -> Iterable[FloatPointValue]:
-    results = []
-    partial_results: dict[AttributePathInRun, list[FloatPointValue]] = {exp_path: [] for exp_path in exp_paths}
-    attribute_steps = {exp_path: None for exp_path in exp_paths}
+) -> dict[identifiers.RunAttributeDefinition, list[FloatPointValue]]:
+    if not run_attribute_definitions:
+        return {}
 
-    while attribute_steps:
-        per_series_point_limit = TOTAL_POINT_LIMIT // len(attribute_steps)
-        per_series_point_limit = min(per_series_point_limit, tail_limit) if tail_limit else per_series_point_limit
-
-        requests = {
-            exp_path: _SeriesRequest(
-                path=exp_path.attribute_path,
-                run_identifier=exp_path.run_identifier,
-                include_inherited=include_inherited,
-                include_preview=include_preview,
-                after_step=after_step,
-            )
-            for exp_path, after_step in attribute_steps.items()
-        }
-
-        values = _fetch_series_values(
-            client=client,
-            requests=requests,
-            step_range=step_range,
-            per_series_point_limit=per_series_point_limit,
-            order="asc" if not tail_limit else "desc",
-        )
-
-        new_attribute_steps = {}
-
-        for path, series_values in values.items():
-            sorted_list = series_values if not tail_limit else reversed(series_values)
-            partial_results[path].extend(sorted_list)
-
-            is_page_full = len(series_values) == per_series_point_limit
-            need_more_points = tail_limit is None or len(partial_results[path]) < tail_limit
-            if is_page_full and need_more_points:
-                new_attribute_steps[path] = series_values[-1][StepIndex]
-            else:
-                path_result = partial_results.pop(path)
-                if path_result:
-                    results.append(path_result)
-        attribute_steps = new_attribute_steps  # type: ignore
-
-    return chain.from_iterable(results)
-
-
-def _fetch_series_values(
-    client: AuthenticatedClient,
-    requests: dict[AttributePathInRun, _SeriesRequest],
-    per_series_point_limit: int,
-    step_range: Tuple[Union[float, None], Union[float, None]],
-    order: Literal["asc", "desc"],
-) -> dict[AttributePathInRun, list[FloatPointValue]]:
-    series_requests_ids = {}
-    series_requests = []
-
-    for ix, (exp_path, request) in enumerate(requests.items()):
-        request_id = f"{ix}"
-        series_requests_ids[request_id] = exp_path
-        series_requests.append(
-            FloatTimeSeriesValuesRequestSeries(
-                request_id=request_id,
-                series=TimeSeries(
-                    attribute=exp_path.attribute_path,
-                    holder=AttributesHolderIdentifier(
-                        identifier=str(exp_path.run_identifier),
-                        type="experiment",
-                    ),
-                    lineage=TimeSeriesLineage.FULL if request.include_inherited else TimeSeriesLineage.NONE,
-                    include_preview=request.include_preview,
-                ),
-                after_step=request.after_step,
-            )
-        )
-
-    response = util.backoff_retry(
-        lambda: get_multiple_float_series_values_proto.sync_detailed(
-            client=client,
-            body=FloatTimeSeriesValuesRequest(
-                per_series_points_limit=per_series_point_limit,
-                requests=series_requests,
-                step_range=OpenRangeDTO(
-                    from_=step_range[0],
-                    to=step_range[1],
-                ),
-                order=(
-                    FloatTimeSeriesValuesRequestOrder.ASCENDING
-                    if order == "asc"
-                    else FloatTimeSeriesValuesRequestOrder.DESCENDING
-                ),
-            ),
-        )
+    assert len(run_attribute_definitions) <= TOTAL_POINT_LIMIT, (
+        f"The number of requested attributes {len(run_attribute_definitions)} exceeds the maximum limit of "
+        f"{TOTAL_POINT_LIMIT}. Please reduce the number of attributes."
     )
 
-    data = ProtoFloatSeriesValuesResponseDTO.FromString(response.content)
+    width = len(str(len(run_attribute_definitions) - 1))
+    request_id_to_attribute: dict[str, identifiers.RunAttributeDefinition] = {
+        f"{i:0{width}d}": attr for i, attr in enumerate(run_attribute_definitions)
+    }
 
-    result = {
-        series_requests_ids[series.requestId]: [
+    params: dict[str, Any] = {
+        "requests": [
+            {
+                "requestId": request_id,
+                "series": {
+                    "holder": {
+                        "identifier": str(run_attribute.run_identifier),
+                        "type": "experiment",
+                    },
+                    "attribute": run_attribute.attribute_definition.name,
+                    "lineage": "FULL" if include_inherited else "NONE",
+                    "includePreview": include_preview,
+                },
+            }
+            for request_id, run_attribute in request_id_to_attribute.items()
+        ],
+        "stepRange": {"from": step_range[0], "to": step_range[1]},
+        "order": "ascending" if not tail_limit else "descending",
+    }
+
+    results: dict[identifiers.RunAttributeDefinition, list[FloatPointValue]] = {
+        run_attribute: [] for run_attribute in run_attribute_definitions
+    }
+
+    for page_result in util.fetch_pages(
+        client=client,
+        fetch_page=_fetch_metrics_page,
+        process_page=ft.partial(_process_metrics_page, request_id_to_attribute=request_id_to_attribute),
+        make_new_page_params=ft.partial(
+            _make_new_metrics_page_params,
+            request_id_to_attribute=request_id_to_attribute,
+            tail_limit=tail_limit,
+            partial_results=results,
+        ),
+        params=params,
+    ):
+        for attribute, values in page_result.items:
+            sorted_values = values if tail_limit else reversed(values)
+            results[attribute].extend(sorted_values)
+
+    return results
+
+
+def _fetch_metrics_page(
+    client: AuthenticatedClient,
+    params: dict[str, Any],
+) -> ProtoFloatSeriesValuesResponseDTO:
+    body = FloatTimeSeriesValuesRequest.from_dict(params)
+
+    response = util.backoff_retry(
+        lambda: get_multiple_float_series_values_proto.sync_detailed(client=client, body=body)
+    )
+
+    return ProtoFloatSeriesValuesResponseDTO.FromString(response.content)
+
+
+def _process_metrics_page(
+    data: ProtoFloatSeriesValuesResponseDTO,
+    request_id_to_attribute: dict[str, identifiers.RunAttributeDefinition],
+) -> util.Page[tuple[identifiers.RunAttributeDefinition, list[FloatPointValue]]]:
+    result = {}
+    for series in data.series:
+        run_attribute = request_id_to_attribute[series.requestId]
+        result[run_attribute] = [
             (
-                series_requests_ids[series.requestId].run_label,
-                series_requests_ids[series.requestId].attribute_path,
                 point.timestamp_millis,
                 point.step,
                 point.value,
@@ -193,7 +138,58 @@ def _fetch_series_values(
             )
             for point in series.series.values
         ]
-        for series in data.series
-    }
+    return util.Page(items=list(result.items()))
 
-    return result
+
+def _make_new_metrics_page_params(
+    params: dict[str, Any],
+    data: Optional[ProtoFloatSeriesValuesResponseDTO],
+    request_id_to_attribute: dict[str, identifiers.RunAttributeDefinition],
+    tail_limit: Optional[int],
+    partial_results: dict[identifiers.RunAttributeDefinition, list[FloatPointValue]],
+) -> Optional[dict[str, Any]]:
+    if data is None:  # no past data, we are fetching the first page
+        for request in params["requests"]:
+            if "afterStep" in request:
+                del request["afterStep"]
+        per_series_points_limit = max(1, TOTAL_POINT_LIMIT // len(params["requests"]))
+        if tail_limit is not None:
+            per_series_points_limit = min(per_series_points_limit, tail_limit)
+        params["perSeriesPointsLimit"] = per_series_points_limit
+        return params
+
+    prev_per_series_points_limit = params["perSeriesPointsLimit"]
+
+    new_request_after_steps = {}
+    for series in data.series:
+        request_id = series.requestId
+        value_size = len(series.series.values)
+        is_page_full = value_size == prev_per_series_points_limit
+
+        attribute = request_id_to_attribute[request_id]
+        need_more_points = len(partial_results[attribute]) < tail_limit if tail_limit is not None else True
+
+        if is_page_full and need_more_points:
+            new_request_after_steps[request_id] = series.series.values[-1].step
+
+    if not new_request_after_steps:  # no data left to fetch, return None to stop
+        return None
+
+    new_requests = []
+    for request in params["requests"]:
+        request_id = request["requestId"]
+        if request_id in new_request_after_steps:
+            after_step = new_request_after_steps[request_id]
+            request["afterStep"] = after_step
+            new_requests.append(request)
+    params["requests"] = new_requests
+
+    per_series_points_limit = max(1, TOTAL_POINT_LIMIT // len(params["requests"]))
+    if tail_limit is not None:
+        already_fetched = next(
+            len(partial_results[request_id_to_attribute[request_id]]) for request_id in new_request_after_steps.keys()
+        )  # assumes the results for all unfinished series have the same length
+        per_series_points_limit = min(per_series_points_limit, tail_limit - already_fetched)
+    params["perSeriesPointsLimit"] = per_series_points_limit
+
+    return params

--- a/src/neptune_fetcher/internal/retrieval/series.py
+++ b/src/neptune_fetcher/internal/retrieval/series.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import functools as ft
-from dataclasses import dataclass
 from typing import (
     Any,
     Generator,
@@ -30,16 +29,8 @@ from neptune_api.models import SeriesValuesRequest
 from neptune_api.proto.neptune_pb.api.v1.model.series_values_pb2 import ProtoSeriesValuesResponseDTO
 from neptune_api.types import UNSET
 
-from neptune_fetcher.internal.identifiers import RunIdentifier
+from neptune_fetcher.internal.identifiers import RunAttributeDefinition
 from neptune_fetcher.internal.retrieval import util
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
-
-
-@dataclass(frozen=True)
-class RunAttributeDefinition:
-    run_identifier: RunIdentifier
-    attribute_definition: AttributeDefinition
-
 
 StringSeriesValue = NamedTuple("StringSeriesValue", [("step", float), ("value", str), ("timestamp_millis", float)])
 

--- a/src/neptune_fetcher/internal/retrieval/split.py
+++ b/src/neptune_fetcher/internal/retrieval/split.py
@@ -26,14 +26,13 @@ from neptune_fetcher.internal import (
     env,
     identifiers,
 )
-from neptune_fetcher.internal.retrieval import attribute_definitions as adef
 
 _UUID_SIZE = 50
 
 T = TypeVar("T")
 
 
-def _attribute_definition_size(attr: adef.AttributeDefinition) -> int:
+def _attribute_definition_size(attr: identifiers.AttributeDefinition) -> int:
     return _attribute_name_size(attr.name)
 
 
@@ -68,8 +67,8 @@ def split_sys_ids(
 
 def split_sys_ids_attributes(
     sys_ids: list[identifiers.SysId],
-    attribute_definitions: list[adef.AttributeDefinition],
-) -> Generator[tuple[list[identifiers.SysId], list[adef.AttributeDefinition]]]:
+    attribute_definitions: list[identifiers.AttributeDefinition],
+) -> Generator[tuple[list[identifiers.SysId], list[identifiers.AttributeDefinition]]]:
     """
     Splits a pair of sys ids and attribute_definitions into batches that:
     When their length is added it is of size at most `NEPTUNE_FETCHER_QUERY_SIZE_LIMIT`.
@@ -113,12 +112,13 @@ def split_sys_ids_attributes(
 
 
 def _split_attribute_definitions(
-    attribute_definitions: list[adef.AttributeDefinition],
+    attribute_definitions: list[identifiers.AttributeDefinition],
     query_size_limit: int,
     attribute_values_batch_size: int,
-) -> list[list[adef.AttributeDefinition]]:
+) -> list[list[identifiers.AttributeDefinition]]:
+
     attribute_batches = []
-    current_batch: list[adef.AttributeDefinition] = []
+    current_batch: list[identifiers.AttributeDefinition] = []
     current_batch_size = 0
     for attr in attribute_definitions:
         attr_size = _attribute_definition_size(attr)

--- a/src/neptune_fetcher/internal/retrieval/util.py
+++ b/src/neptune_fetcher/internal/retrieval/util.py
@@ -62,9 +62,8 @@ def fetch_pages(
     while page_params is not None:
         data = fetch_page(client, page_params)
         page = process_page(data)
-        page_params = make_new_page_params(page_params, data)
-
         yield page
+        page_params = make_new_page_params(page_params, data)
 
 
 def backoff_retry(

--- a/src/neptune_fetcher/v1/_internal.py
+++ b/src/neptune_fetcher/v1/_internal.py
@@ -86,6 +86,8 @@ def resolve_attributes_filter(
                 aggregations=attributes.aggregations,
             )
             return modified_attributes._to_internal()
+        if isinstance(attributes, filters.BaseAttributeFilter):
+            return attributes._to_internal()
         raise ValueError(
             "Invalid type for `attributes` filter. Expected str, list of str, or AttributeFilter object, but got "
             f"{type(attributes)}."

--- a/tests/e2e/alpha/test_fetch_metrics.py
+++ b/tests/e2e/alpha/test_fetch_metrics.py
@@ -8,6 +8,7 @@ from typing import (
     Tuple,
     Union,
 )
+from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -19,7 +20,15 @@ from neptune_fetcher.alpha.filters import (
     Filter,
 )
 from neptune_fetcher.internal.context import get_context
+from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
+    ProjectIdentifier,
+    RunAttributeDefinition,
+    RunIdentifier,
+    SysId,
+)
 from neptune_fetcher.internal.output_format import create_metrics_dataframe
+from neptune_fetcher.internal.retrieval.metrics import FloatPointValue
 from tests.e2e.data import (
     NOW,
     PATH,
@@ -31,13 +40,16 @@ NEPTUNE_PROJECT: str = os.getenv("NEPTUNE_E2E_PROJECT")
 
 
 def create_expected_data(
+    project: str,
     experiments: list[ExperimentData],
     type_suffix_in_column_names: bool,
     include_time: Union[Literal["absolute"], None],
     step_range: Tuple[Optional[int], Optional[int]],
     tail_limit: Optional[int],
 ) -> Tuple[pd.DataFrame, List[str], set[str]]:
-    rows = []
+    metrics_data: dict[RunAttributeDefinition, list[FloatPointValue]] = {}
+    sys_id_label_mapping: dict[SysId, str] = {SysId(experiment.name): experiment.name for experiment in experiments}
+
     columns = set()
     filtered_exps = set()
 
@@ -51,13 +63,11 @@ def create_expected_data(
         for path, series in chain.from_iterable([experiment.float_series.items(), experiment.unique_series.items()]):
             filtered = []
             for step in steps:
-                if step >= step_filter[0] and step <= step_filter[1]:
+                if step_filter[0] <= step <= step_filter[1]:
                     columns.add(f"{path}:float_series" if type_suffix_in_column_names else path)
                     filtered_exps.add(experiment.name)
                     filtered.append(
                         (
-                            experiment.name,
-                            path,
                             int((NOW + timedelta(seconds=int(step))).timestamp()) * 1000,
                             step,
                             series[int(step)],
@@ -66,10 +76,16 @@ def create_expected_data(
                         )
                     )
             limited = filtered[-tail_limit:] if tail_limit is not None else filtered
-            rows.extend(limited)
+
+            attribute_run = RunAttributeDefinition(
+                RunIdentifier(ProjectIdentifier(project), SysId(experiment.name)),
+                AttributeDefinition(path, "float_series"),
+            )
+            metrics_data.setdefault(attribute_run, []).extend(limited)
 
     df = create_metrics_dataframe(
-        rows,
+        metrics_data=metrics_data,
+        sys_id_label_mapping=sys_id_label_mapping,
         type_suffix_in_column_names=type_suffix_in_column_names,
         include_point_previews=False,
         timestamp_column_name="absolute_time" if include_time == "absolute" else None,
@@ -87,6 +103,7 @@ def create_expected_data(
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
 @pytest.mark.parametrize("step_range", [(0, 5), (0, None), (None, 5), (None, None), (100, 200)])
 @pytest.mark.parametrize("tail_limit", [None, 3, 5])
+@pytest.mark.parametrize("page_point_limit", [50, 1_000_000])
 @pytest.mark.parametrize(
     "attr_filter", [AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]), ".*/metrics/.*"]
 )
@@ -100,22 +117,30 @@ def create_expected_data(
 )
 @pytest.mark.parametrize("include_time", [None, "absolute"])  # "relative",
 def test__fetch_metrics_unique(
-    project, type_suffix_in_column_names, step_range, tail_limit, include_time, attr_filter, exp_filter
+    project,
+    type_suffix_in_column_names,
+    step_range,
+    tail_limit,
+    page_point_limit,
+    include_time,
+    attr_filter,
+    exp_filter,
 ):
     experiments = TEST_DATA.experiments[:3]
 
-    result = fetch_metrics(
-        experiments=exp_filter(),
-        attributes=attr_filter,
-        type_suffix_in_column_names=type_suffix_in_column_names,
-        step_range=step_range,
-        tail_limit=tail_limit,
-        include_time=include_time,
-        context=get_context().with_project(project.project_identifier),
-    )
+    with patch("neptune_fetcher.internal.retrieval.metrics.TOTAL_POINT_LIMIT", page_point_limit):
+        result = fetch_metrics(
+            experiments=exp_filter(),
+            attributes=attr_filter,
+            type_suffix_in_column_names=type_suffix_in_column_names,
+            step_range=step_range,
+            tail_limit=tail_limit,
+            include_time=include_time,
+            context=get_context().with_project(project.project_identifier),
+        )
 
     expected, columns, filtred_exps = create_expected_data(
-        experiments, type_suffix_in_column_names, include_time, step_range, tail_limit
+        project, experiments, type_suffix_in_column_names, include_time, step_range, tail_limit
     )
 
     pd.testing.assert_frame_equal(result, expected)

--- a/tests/e2e/alpha/test_fetch_metrics.py
+++ b/tests/e2e/alpha/test_fetch_metrics.py
@@ -105,7 +105,14 @@ def create_expected_data(
 @pytest.mark.parametrize("tail_limit", [None, 3, 5])
 @pytest.mark.parametrize("page_point_limit", [50, 1_000_000])
 @pytest.mark.parametrize(
-    "attr_filter", [AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]), ".*/metrics/.*"]
+    "attr_filter",
+    [
+        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]),
+        ".*/metrics/.*",
+        # Alternative should work too, see bug PY-137
+        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"])
+        | AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]),
+    ],
 )
 @pytest.mark.parametrize(
     "exp_filter",

--- a/tests/e2e/alpha/test_fetch_series.py
+++ b/tests/e2e/alpha/test_fetch_series.py
@@ -21,15 +21,13 @@ from neptune_fetcher.alpha.filters import (
 from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.context import get_context
 from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
+    RunAttributeDefinition,
     RunIdentifier,
     SysId,
 )
 from neptune_fetcher.internal.output_format import create_series_dataframe
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
-from neptune_fetcher.internal.retrieval.series import (
-    RunAttributeDefinition,
-    StringSeriesValue,
-)
+from neptune_fetcher.internal.retrieval.series import StringSeriesValue
 from tests.e2e.data import (
     NOW,
     NUMBER_OF_STEPS,

--- a/tests/e2e/internal/composition/test_attributes.py
+++ b/tests/e2e/internal/composition/test_attributes.py
@@ -10,8 +10,10 @@ import pytest
 
 from neptune_fetcher.internal.composition.attributes import fetch_attribute_definitions
 from neptune_fetcher.internal.filters import _AttributeFilter
-from neptune_fetcher.internal.identifiers import RunIdentifier
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
+from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
+    RunIdentifier,
+)
 from tests.e2e.conftest import extract_pages
 
 NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")

--- a/tests/e2e/internal/retrieval/test_attributes.py
+++ b/tests/e2e/internal/retrieval/test_attributes.py
@@ -14,14 +14,12 @@ from neptune_fetcher.internal.filters import (
     _AttributeNameFilter,
 )
 from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
     ProjectIdentifier,
     RunIdentifier,
     SysId,
 )
-from neptune_fetcher.internal.retrieval.attribute_definitions import (
-    AttributeDefinition,
-    fetch_attribute_definitions_single_filter,
-)
+from neptune_fetcher.internal.retrieval.attribute_definitions import fetch_attribute_definitions_single_filter
 from neptune_fetcher.internal.retrieval.attribute_types import (
     FloatSeriesAggregations,
     StringSeriesAggregations,

--- a/tests/e2e/internal/retrieval/test_files.py
+++ b/tests/e2e/internal/retrieval/test_files.py
@@ -11,7 +11,7 @@ from datetime import (
 import azure.core.exceptions
 import pytest
 
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
+from neptune_fetcher.internal.identifiers import AttributeDefinition
 from neptune_fetcher.internal.retrieval.attribute_values import fetch_attribute_values
 from neptune_fetcher.internal.retrieval.files import (
     SignedFile,

--- a/tests/e2e/internal/retrieval/test_series.py
+++ b/tests/e2e/internal/retrieval/test_series.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import pytest
 
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
+from neptune_fetcher.internal.identifiers import AttributeDefinition
 from neptune_fetcher.internal.retrieval.series import (
     RunAttributeDefinition,
     fetch_series_values,

--- a/tests/e2e/v1/runs/test_runs_fetch_metrics.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_metrics.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import neptune_fetcher.v1.runs as runs
+from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.output_format import create_metrics_dataframe
 from tests.e2e.v1.generator import (
     RUN_BY_ID,
@@ -214,20 +215,32 @@ def test_fetch_run_metrics(
     )
 
     expected_df = create_expected_data(
-        expected_metrics, include_time=include_time, type_suffix_in_column_names=type_suffix_in_column_names
+        new_project_context.project,
+        expected_metrics,
+        include_time=include_time,
+        type_suffix_in_column_names=type_suffix_in_column_names,
     )
 
     pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
 
 
-def create_expected_data(expected_metrics, include_time: str, type_suffix_in_column_names):
-    rows = []
+def create_expected_data(project, expected_metrics, include_time: str, type_suffix_in_column_names):
+    data = {}
     for (run, metric_name), values in expected_metrics.items():
+        attribute_run = identifiers.RunAttributeDefinition(
+            run_identifier=identifiers.RunIdentifier(project_identifier=project, sys_id=identifiers.SysId(run)),
+            attribute_definition=identifiers.AttributeDefinition(name=metric_name, type="float_series"),
+        )
+        rows = data.setdefault(attribute_run, [])
+
         for step, value in values:
-            rows.append((run, metric_name, int(timestamp_for_step(step).timestamp() * 1000), step, value, False, 1.0))
+            rows.append((int(timestamp_for_step(step).timestamp() * 1000), step, value, False, 1.0))
+
+    sys_id_label_mapping = {identifiers.SysId(run): run for run, _ in expected_metrics.keys()}
 
     return create_metrics_dataframe(
-        rows,
+        metrics_data=data,
+        sys_id_label_mapping=sys_id_label_mapping,
         type_suffix_in_column_names=type_suffix_in_column_names,
         include_point_previews=False,
         timestamp_column_name="absolute_time" if include_time == "absolute" else None,

--- a/tests/e2e/v1/runs/test_runs_fetch_metrics.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_metrics.py
@@ -215,7 +215,7 @@ def test_fetch_run_metrics(
     )
 
     expected_df = create_expected_data(
-        new_project_context.project,
+        new_project_id,
         expected_metrics,
         include_time=include_time,
         type_suffix_in_column_names=type_suffix_in_column_names,

--- a/tests/e2e/v1/test_fetch_metrics.py
+++ b/tests/e2e/v1/test_fetch_metrics.py
@@ -14,6 +14,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from neptune_fetcher.v1 import fetch_metrics
 from neptune_fetcher.v1.filters import (
     AttributeFilter,
     Filter,
@@ -103,7 +104,14 @@ def create_expected_data(
 @pytest.mark.parametrize("tail_limit", [None, 3, 5])
 @pytest.mark.parametrize("page_point_limit", [50, 1_000_000])
 @pytest.mark.parametrize(
-    "arg_attributes", [AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]), ".*/metrics/.*"]
+    "arg_attributes",
+    [
+        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]),
+        ".*/metrics/.*",
+        # Alternative should work too, see bug PY-137
+        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"])
+        | AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]),
+    ],
 )
 @pytest.mark.parametrize(
     "arg_experiments",

--- a/tests/e2e/v1/test_fetch_metrics.py
+++ b/tests/e2e/v1/test_fetch_metrics.py
@@ -14,11 +14,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from neptune_fetcher.v1 import fetch_metrics
-from neptune_fetcher.v1.filters import (
-    AttributeFilter,
-    Filter,
-)
 from neptune_fetcher.internal.identifiers import (
     AttributeDefinition,
     ProjectIdentifier,
@@ -28,6 +23,11 @@ from neptune_fetcher.internal.identifiers import (
 )
 from neptune_fetcher.internal.output_format import create_metrics_dataframe
 from neptune_fetcher.internal.retrieval.metrics import FloatPointValue
+from neptune_fetcher.v1 import fetch_metrics
+from neptune_fetcher.v1.filters import (
+    AttributeFilter,
+    Filter,
+)
 from tests.e2e.data import (
     NOW,
     PATH,

--- a/tests/e2e/v1/test_fetch_series.py
+++ b/tests/e2e/v1/test_fetch_series.py
@@ -21,12 +21,12 @@ from neptune_fetcher.internal.identifiers import (
     SysId,
 )
 from neptune_fetcher.internal.output_format import create_series_dataframe
+from neptune_fetcher.internal.retrieval.series import StringSeriesValue
 from neptune_fetcher.v1 import fetch_series
 from neptune_fetcher.v1.filters import (
     AttributeFilter,
     Filter,
 )
-from neptune_fetcher.internal.retrieval.series import StringSeriesValue
 from tests.e2e.data import (
     NOW,
     NUMBER_OF_STEPS,

--- a/tests/e2e/v1/test_fetch_series.py
+++ b/tests/e2e/v1/test_fetch_series.py
@@ -15,20 +15,18 @@ import pytest
 
 from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
+    RunAttributeDefinition,
     RunIdentifier,
     SysId,
 )
 from neptune_fetcher.internal.output_format import create_series_dataframe
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
-from neptune_fetcher.internal.retrieval.series import (
-    RunAttributeDefinition,
-    StringSeriesValue,
-)
 from neptune_fetcher.v1 import fetch_series
 from neptune_fetcher.v1.filters import (
     AttributeFilter,
     Filter,
 )
+from neptune_fetcher.internal.retrieval.series import StringSeriesValue
 from tests.e2e.data import (
     NOW,
     NUMBER_OF_STEPS,

--- a/tests/unit/internal/retrieval/test_split.py
+++ b/tests/unit/internal/retrieval/test_split.py
@@ -6,7 +6,7 @@ from neptune_fetcher.internal.env import (
     NEPTUNE_FETCHER_QUERY_SIZE_LIMIT,
     NEPTUNE_FETCHER_SERIES_BATCH_SIZE,
 )
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
+from neptune_fetcher.internal.identifiers import AttributeDefinition
 from neptune_fetcher.internal.retrieval.split import (
     split_series_attributes,
     split_sys_ids,
@@ -176,9 +176,10 @@ def test_split_series_attributes(attributes, expected):
         (3, 2 * ATTRIBUTE_DEFINITION_SIZE, 500, [2, 1]),
         (3, 3 * ATTRIBUTE_DEFINITION_SIZE, 500, [3]),
         (3, 4 * ATTRIBUTE_DEFINITION_SIZE, 500, [3]),
+        (10, 10 * ATTRIBUTE_DEFINITION_SIZE, 3, [3, 3, 3, 1]),
     ],
 )
-def split_series_attributes_custom_envs(monkeypatch, given_num, query_size_limit, batch_size, expected_nums):
+def test_split_series_attributes_custom_envs(monkeypatch, given_num, query_size_limit, batch_size, expected_nums):
     # given
     monkeypatch.setenv(NEPTUNE_FETCHER_QUERY_SIZE_LIMIT.name, str(query_size_limit))
     monkeypatch.setenv(NEPTUNE_FETCHER_SERIES_BATCH_SIZE.name, str(batch_size))

--- a/tests/unit/internal/test_output_format.py
+++ b/tests/unit/internal/test_output_format.py
@@ -5,7 +5,6 @@ from datetime import (
     timedelta,
     timezone,
 )
-from typing import Generator
 
 import numpy as np
 import pandas as pd
@@ -15,7 +14,9 @@ from pandas._testing import assert_frame_equal
 from neptune_fetcher.exceptions import ConflictingAttributeTypes
 from neptune_fetcher.internal import identifiers
 from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
     ProjectIdentifier,
+    RunAttributeDefinition,
     RunIdentifier,
     SysId,
 )
@@ -25,7 +26,6 @@ from neptune_fetcher.internal.output_format import (
     create_metrics_dataframe,
     create_series_dataframe,
 )
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
 from neptune_fetcher.internal.retrieval.attribute_types import (
     FileProperties,
     FloatSeriesAggregations,
@@ -33,10 +33,7 @@ from neptune_fetcher.internal.retrieval.attribute_types import (
 )
 from neptune_fetcher.internal.retrieval.attribute_values import AttributeValue
 from neptune_fetcher.internal.retrieval.metrics import FloatPointValue
-from neptune_fetcher.internal.retrieval.series import (
-    RunAttributeDefinition,
-    StringSeriesValue,
-)
+from neptune_fetcher.internal.retrieval.series import StringSeriesValue
 
 EXPERIMENT_IDENTIFIER = identifiers.RunIdentifier(
     identifiers.ProjectIdentifier("project/abc"), identifiers.SysId("XXX-1")
@@ -249,20 +246,29 @@ STEPS = 10
 
 def _generate_float_point_values(
     experiments: int, paths: int, steps: int, preview: bool
-) -> Generator[FloatPointValue, None, None]:
+) -> dict[RunAttributeDefinition, list[FloatPointValue]]:
+    result = {}
+
     for experiment in range(experiments):
         for path in range(paths):
+            attribute_run = RunAttributeDefinition(
+                RunIdentifier(ProjectIdentifier("foo/bar"), SysId(f"sysid{experiment}")),
+                AttributeDefinition(f"path{path}", "float_series"),
+            )
+            points = result.setdefault(attribute_run, [])
+
             for step in range(steps):
                 timestamp = datetime(2023, 1, 1, 0, 0, 0, 0, timezone.utc) + timedelta(seconds=step)
-                yield (
-                    f"exp{experiment}",
-                    f"path{path}",
-                    timestamp.timestamp(),
-                    float(step),
-                    float(step) * 100,
-                    preview,
-                    1.0 - (float(step) / 1000.0),
+                points.append(
+                    (
+                        timestamp.timestamp(),
+                        float(step),
+                        float(step) * 100,
+                        preview,
+                        1.0 - (float(step) / 1000.0),
+                    )
                 )
+    return result
 
 
 def _format_path_name(path: str, type_suffix_in_column_names: bool) -> str:
@@ -275,11 +281,13 @@ def _make_timestamp(year: int, month: int, day: int) -> float:
 
 @pytest.mark.parametrize("include_preview", [False, True])
 def test_create_metrics_dataframe_shape(include_preview):
-    float_point_values = list(_generate_float_point_values(EXPERIMENTS, PATHS, STEPS, include_preview))
+    float_point_values = _generate_float_point_values(EXPERIMENTS, PATHS, STEPS, include_preview)
+    sys_id_label_mapping = {SysId(f"sysid{experiment}"): f"exp{experiment}" for experiment in range(EXPERIMENTS)}
 
     """Test the creation of a flat DataFrame from float point values."""
     df = create_metrics_dataframe(
-        float_point_values,
+        metrics_data=float_point_values,
+        sys_id_label_mapping=sys_id_label_mapping,
         include_point_previews=include_preview,
         type_suffix_in_column_names=False,
         index_column_name="experiment",
@@ -293,7 +301,7 @@ def test_create_metrics_dataframe_shape(include_preview):
     assert df.shape[0] == num_expected_rows, f"DataFrame should have {num_expected_rows} rows"
 
     # Check the columns of the DataFrame
-    all_paths = set(fp[1] for fp in float_point_values)
+    all_paths = {key.attribute_definition.name for key in float_point_values.keys()}
     if not include_preview:
         expected_columns = all_paths
     else:
@@ -315,14 +323,31 @@ def test_create_metrics_dataframe_shape(include_preview):
 @pytest.mark.parametrize("include_preview", [True, False])
 def test_create_metrics_dataframe_with_absolute_timestamp(type_suffix_in_column_names: bool, include_preview: bool):
     # Given
-    data = [
-        ("exp1", "path1", _make_timestamp(2023, 1, 1), 1, 10.0, False, 1.0),
-        ("exp1", "path2", _make_timestamp(2023, 1, 3), 2, 20.0, False, 1.0),
-        ("exp2", "path1", _make_timestamp(2023, 1, 2), 1, 30.0, True, 0.5),
-    ]
+    data = {
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid1")), AttributeDefinition("path1", "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 1), 1, 10.0, False, 1.0),
+        ],
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid1")), AttributeDefinition("path2", "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 3), 2, 20.0, False, 1.0),
+        ],
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid2")), AttributeDefinition("path1", "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 2), 1, 30.0, True, 0.5),
+        ],
+    }
+    sys_id_label_mapping = {
+        SysId("sysid1"): "exp1",
+        SysId("sysid2"): "exp2",
+    }
 
     df = create_metrics_dataframe(
-        data,
+        metrics_data=data,
+        sys_id_label_mapping=sys_id_label_mapping,
         timestamp_column_name="absolute_time",
         type_suffix_in_column_names=type_suffix_in_column_names,
         include_point_previews=include_preview,
@@ -413,14 +438,31 @@ def test_create_series_dataframe_with_absolute_timestamp():
 @pytest.mark.parametrize("include_preview", [True, False])
 def test_create_metrics_dataframe_without_timestamp(type_suffix_in_column_names: bool, include_preview: bool):
     # Given
-    data = [
-        ("exp1", "path1", _make_timestamp(2023, 1, 1), 1, 10.0, False, 1.0),
-        ("exp1", "path2", _make_timestamp(2023, 1, 3), 2, 20.0, False, 1.0),
-        ("exp2", "path1", _make_timestamp(2023, 1, 2), 1, 30.0, True, 0.5),
-    ]
+    data = {
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid1")), AttributeDefinition("path1", "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 1), 1, 10.0, False, 1.0),
+        ],
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid1")), AttributeDefinition("path2", "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 3), 2, 20.0, False, 1.0),
+        ],
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid2")), AttributeDefinition("path1", "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 2), 1, 30.0, True, 0.5),
+        ],
+    }
+    sys_id_label_mapping = {
+        SysId("sysid1"): "exp1",
+        SysId("sysid2"): "exp2",
+    }
 
     df = create_metrics_dataframe(
-        data,
+        metrics_data=data,
+        sys_id_label_mapping=sys_id_label_mapping,
         type_suffix_in_column_names=type_suffix_in_column_names,
         include_point_previews=include_preview,
         index_column_name="experiment",
@@ -452,6 +494,46 @@ def test_create_metrics_dataframe_without_timestamp(type_suffix_in_column_names:
     pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
 
 
+def test_create_metrics_dataframe_random_order():
+    # Given
+    data = {
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid1")), AttributeDefinition("path1", "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 1), 3, 30.0, False, 1.0),
+            (_make_timestamp(2023, 1, 1), 2, 20.0, False, 1.0),
+            (_make_timestamp(2023, 1, 1), 1, 10.0, False, 1.0),
+            (_make_timestamp(2023, 1, 1), 5, 50.0, False, 1.0),
+            (_make_timestamp(2023, 1, 1), 4, 40.0, False, 1.0),
+        ],
+    }
+    sys_id_label_mapping = {
+        SysId("sysid1"): "exp1",
+    }
+
+    df = create_metrics_dataframe(
+        metrics_data=data,
+        sys_id_label_mapping=sys_id_label_mapping,
+        type_suffix_in_column_names=False,
+        include_point_previews=False,
+        index_column_name="experiment",
+    )
+
+    # Then
+    expected = {
+        "path1": [10.0, 20.0, 30.0, 40.0, 50.0],
+    }
+
+    expected_df = pd.DataFrame(
+        dict(sorted(expected.items())),
+        index=pd.MultiIndex.from_tuples(
+            [("exp1", 1.0), ("exp1", 2.0), ("exp1", 3.0), ("exp1", 4.0), ("exp1", 5.0)], names=["experiment", "step"]
+        ),
+    )
+
+    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+
+
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
 @pytest.mark.parametrize("include_preview", [True, False])
 @pytest.mark.parametrize("timestamp_column_name", [None, "absolute"])
@@ -462,7 +544,8 @@ def test_create_empty_metrics_dataframe(
 
     # When
     df = create_metrics_dataframe(
-        [],
+        metrics_data={},
+        sys_id_label_mapping={},
         type_suffix_in_column_names=type_suffix_in_column_names,
         include_point_previews=include_preview,
         timestamp_column_name=timestamp_column_name,
@@ -527,14 +610,32 @@ def test_create_metrics_dataframe_with_reserved_paths_with_multiindex(
     path: str, type_suffix_in_column_names: bool, include_preview: bool, timestamp_column_name: str
 ):
     # Given
-    data = [
-        ("exp1", path, _make_timestamp(2023, 1, 1), 1, 10.0, False, 1.0),
-        ("exp1", "other_path", _make_timestamp(2023, 1, 3), 2, 20.0, False, 1.0),
-        ("exp2", path, _make_timestamp(2023, 1, 2), 1, 30.0, True, 0.5),
-    ]
+    data = {
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid1")), AttributeDefinition(path, "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 1), 1, 10.0, False, 1.0),
+        ],
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid2")), AttributeDefinition(path, "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 2), 1, 30.0, True, 0.5),
+        ],
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid1")),
+            AttributeDefinition("other_path", "float_series"),
+        ): [
+            (_make_timestamp(2023, 1, 3), 2, 20.0, False, 1.0),
+        ],
+    }
+    sys_id_label_mapping = {
+        SysId("sysid1"): "exp1",
+        SysId("sysid2"): "exp2",
+    }
 
     df = create_metrics_dataframe(
-        data,
+        metrics_data=data,
+        sys_id_label_mapping=sys_id_label_mapping,
         timestamp_column_name=timestamp_column_name,
         type_suffix_in_column_names=type_suffix_in_column_names,
         include_point_previews=include_preview,
@@ -584,14 +685,32 @@ def test_create_metrics_dataframe_with_reserved_paths_with_multiindex(
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
 def test_create_metrics_dataframe_with_reserved_paths_with_flat_index(path: str, type_suffix_in_column_names: bool):
     # Given
-    data = [
-        ("exp1", path, _make_timestamp(2023, 1, 1), 1, 10.0, False, 1.0),
-        ("exp1", "other_path", _make_timestamp(2023, 1, 3), 2, 20.0, False, 1.0),
-        ("exp2", path, _make_timestamp(2023, 1, 2), 1, 30.0, True, 0.5),
-    ]
+    data = {
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid1")), AttributeDefinition(path, "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 1), 1, 10.0, False, 1.0),
+        ],
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid2")), AttributeDefinition(path, "float_series")
+        ): [
+            (_make_timestamp(2023, 1, 2), 1, 30.0, True, 0.5),
+        ],
+        RunAttributeDefinition(
+            RunIdentifier(ProjectIdentifier("foo/bar"), SysId("sysid1")),
+            AttributeDefinition("other_path", "float_series"),
+        ): [
+            (_make_timestamp(2023, 1, 3), 2, 20.0, False, 1.0),
+        ],
+    }
+    sys_id_label_mapping = {
+        SysId("sysid1"): "exp1",
+        SysId("sysid2"): "exp2",
+    }
 
     df = create_metrics_dataframe(
-        data,
+        metrics_data=data,
+        sys_id_label_mapping=sys_id_label_mapping,
         type_suffix_in_column_names=type_suffix_in_column_names,
         include_point_previews=False,
         index_column_name="experiment",

--- a/tests/unit/v1/test_split.py
+++ b/tests/unit/v1/test_split.py
@@ -9,16 +9,15 @@ import pytest
 
 from neptune_fetcher import v1 as npt
 from neptune_fetcher.internal.identifiers import (
+    AttributeDefinition,
     ProjectIdentifier,
+    RunAttributeDefinition,
     RunIdentifier,
     SysId,
     SysName,
 )
 from neptune_fetcher.internal.retrieval import util
-from neptune_fetcher.internal.retrieval.attribute_definitions import AttributeDefinition
-from neptune_fetcher.internal.retrieval.metrics import AttributePathInRun
 from neptune_fetcher.internal.retrieval.search import ExperimentSysAttrs
-from neptune_fetcher.internal.retrieval.series import RunAttributeDefinition
 from neptune_fetcher.v1.filters import AttributeFilter
 
 
@@ -274,11 +273,10 @@ def test_fetch_metrics_patched(sys_id_length, exp_count, attr_name_length, attr_
         for i in range(exp_count)
     ]
     attributes = [AttributeDefinition(name=f"{i:0{attr_name_length}d}", type="float_series") for i in range(attr_count)]
-    attribute_path_in_runs = [
-        AttributePathInRun(
+    exp_attributes = [
+        RunAttributeDefinition(
             run_identifier=RunIdentifier(project_identifier=project, sys_id=experiment.sys_id),
-            run_label=experiment.sys_name,
-            attribute_path=attribute.name,
+            attribute_definition=attribute,
         )
         for experiment in experiments
         for attribute in attributes
@@ -298,7 +296,7 @@ def test_fetch_metrics_patched(sys_id_length, exp_count, attr_name_length, attr_
         get_client.return_value = None
         fetch_experiment_sys_attrs.return_value = iter([util.Page(experiments)])
         fetch_attribute_definitions_single_filter.side_effect = lambda **kwargs: iter([util.Page(attributes)])
-        fetch_multiple_series_values.return_value = iter([])
+        fetch_multiple_series_values.return_value = {}
 
         npt.fetch_metrics(
             project=project,
@@ -308,7 +306,7 @@ def test_fetch_metrics_patched(sys_id_length, exp_count, attr_name_length, attr_
 
     # then
     call_sizes = Counter(
-        len(fetch_multiple_series_values.call_args_list[i].kwargs["exp_paths"])
+        len(fetch_multiple_series_values.call_args_list[i].kwargs["run_attribute_definitions"])
         for i in range(fetch_multiple_series_values.call_count)
     )
     assert call_sizes == Counter(expected_calls)
@@ -316,7 +314,7 @@ def test_fetch_metrics_patched(sys_id_length, exp_count, attr_name_length, attr_
         [
             call(
                 ANY,
-                exp_paths=attribute_path_in_runs[start:end],
+                run_attribute_definitions=exp_attributes[start:end],
                 include_inherited=ANY,
                 include_preview=ANY,
                 step_range=ANY,


### PR DESCRIPTION
Porting the following PRs to v1:

#313 Handle `UnableToParseResponse`

#325 PY-137 Fix for fetch_metrics() broken when using combined filters

#303 chore: refactor metrics

## Summary by Sourcery

Port core metrics retrieval, composition, and output formatting modules to the new v1 API surface, unifying identifier types and refactoring pagination, dataframe construction, and attribute handling accordingly.

Bug Fixes:
- Retry on UnableToParseResponse only for 5xx errors in backoff_retry and raise for non-500 codes.
- Restore correct behavior when using combined AttributeFilter in fetch_metrics (#325).

Enhancements:
- Introduce RunAttributeDefinition and identifiers.AttributeDefinition to replace legacy path-and-label tuples.
- Refactor fetch_multiple_series_values to use a paginated fetch_pages approach with dedicated page processors and param builders.
- Simplify create_metrics_dataframe and create_series_dataframe to accept structured metrics_data and sys_id_label_mapping dictionaries for dataframe construction.
- Unify attribute definition handling across composition and retrieval layers by replacing legacy types with identifiers.AttributeDefinition.
- Update split utilities and composition functions to batch identifiers.AttributeDefinition instead of legacy types.

Tests:
- Adapt unit and end-to-end tests to the new metrics_data API and RunAttributeDefinition usage.
- Add tests covering backoff_retry behavior on parse errors and random ordering in dataframe output.

Chores:
- Port main branch changes into the v1 entrypoint and remove outdated dataclasses and function signatures.