### PR TITLE
change internal._Filter.all and any to accept a list

### DIFF
--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -19,7 +19,6 @@
 
 import pathlib
 from typing import (
-    Literal,
     Optional,
     Union,
 )
@@ -135,22 +134,3 @@ def get_default_project_identifier(context: Optional[Context] = None) -> Project
     if not project:
         raise NeptuneProjectNotProvided()
     return ProjectIdentifier(project)
-
-
-class _EmptyAssociativeOperator(_filters._AssociativeOperator):
-    """
-    A filter that maps to an empty string in the public API.
-    This is the result of calling `Filter.all()` and `Filter.any()`.
-    The results are surprising and these cannot be further combined with other filters.
-    This is going to go away in V1 and is only here for compatibility with the public API.
-    """
-
-    def __init__(self, operator: Literal["AND", "OR"]) -> None:
-        super().__init__(operator=operator, filters=[])
-
-    def __post_init__(self) -> None:
-        # Skip validation since this is an empty filter
-        pass
-
-    def to_query(self) -> str:
-        return ""

--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -39,6 +39,10 @@ def resolve_experiments_filter(
 ) -> Optional[_filters._Filter]:
     if isinstance(experiments, str):
         return _filters._Filter.matches_all(_filters._Attribute("sys/name", type="string"), experiments)
+    if experiments == []:
+        # In alpha, passing experiments=[] gives us un-filtered results
+        # In v1, we're going to return no results or raise an error
+        return None
     if isinstance(experiments, list):
         return _filters._Filter.name_in(*experiments)
     if isinstance(experiments, filters.Filter):
@@ -62,6 +66,10 @@ def resolve_attributes_filter(
             return _filters._AttributeFilter()
         if isinstance(attributes, str):
             return _filters._AttributeFilter(name_matches_all=attributes)
+        if attributes == []:
+            # In alpha, passing attributes=[] gives us un-filtered results
+            # In v1, we're going to return no results or raise an error
+            return _filters._AttributeFilter()
         if isinstance(attributes, list):
             return _filters._AttributeFilter(name_eq=attributes)
         if isinstance(attributes, filters.BaseAttributeFilter):
@@ -75,6 +83,10 @@ def resolve_attributes_filter(
             return _filters._AttributeFilter(type_in=forced_type)
         if isinstance(attributes, str):
             return _filters._AttributeFilter(name_matches_all=attributes, type_in=forced_type)
+        if attributes == []:
+            # In alpha, passing attributes=[] gives us un-filtered results
+            # In v1, we're going to return no results or raise an error
+            return _filters._AttributeFilter(type_in=forced_type)
         if isinstance(attributes, list):
             return _filters._AttributeFilter(name_eq=attributes, type_in=forced_type)
         if isinstance(attributes, filters.AttributeFilter):
@@ -111,6 +123,10 @@ def resolve_destination_path(destination: Optional[str]) -> pathlib.Path:
 def resolve_runs_filter(runs: Optional[Union[str, list[str], filters.Filter]]) -> Optional[_filters._Filter]:
     if isinstance(runs, str):
         return _filters._Filter.matches_all(_filters._Attribute("sys/custom_run_id", type="string"), regex=runs)
+    if runs == []:
+        # In alpha, passing runs=[] gives us un-filtered results
+        # In v1, we're going to return no results or raise an error
+        return None
     if isinstance(runs, list):
         return _filters._Filter.any(
             [_filters._Filter.eq(_filters._Attribute("sys/custom_run_id", type="string"), value=run) for run in runs]
@@ -120,7 +136,7 @@ def resolve_runs_filter(runs: Optional[Union[str, list[str], filters.Filter]]) -
     if runs is None:
         return None
     raise ValueError(
-        f"Invalid type for `runs` filter. Expected str, list[str], or Filter object, but got {type(runs)}."
+        f"Invalid type for `runs` filter. Expected str, list of str, or Filter object, but got {type(runs)}."
     )
 
 

--- a/src/neptune_fetcher/internal/filters.py
+++ b/src/neptune_fetcher/internal/filters.py
@@ -46,6 +46,7 @@ AGGREGATION_LITERAL = Literal["last", "min", "max", "average", "variance"]
 
 
 class _BaseAttributeFilter(ABC):
+    @staticmethod
     def any(filters: list["_BaseAttributeFilter"]) -> "_BaseAttributeFilter":
         return _AttributeFilterAlternative(filters=filters)
 

--- a/src/neptune_fetcher/internal/filters.py
+++ b/src/neptune_fetcher/internal/filters.py
@@ -76,6 +76,11 @@ class _AttributeFilter(_BaseAttributeFilter):
         "string_series", "file"]]):
             A list of allowed attribute types. Defaults to all available types.
             For a reference, see: https://docs.neptune.ai/attribute_types
+        name_matches_all (Union[str, list[str], None]): A regular expression or list of expressions that the attribute
+            name must match. If `None`, this filter is not applied.
+        name_matches_none (Union[str, list[str], None]): A regular expression or list of expressions that the attribute
+            names mustn't match. Attributes matching any of the regexes are excluded.
+            If `None`, this filter is not applied.
         must_match_any (Optional[list[_AttributeNameFilter]]):
             If `None`, this filter is not applied. Otherwise, it's a list of `_AttributeNameFilter` instances.
             Each instance specifies a set of regexes that the attribute name must match or not match.

--- a/src/neptune_fetcher/internal/pattern.py
+++ b/src/neptune_fetcher/internal/pattern.py
@@ -82,12 +82,10 @@ def build_extended_regex_filter(attribute: _Attribute, pattern: str) -> _Filter:
     parsed = parse_extended_regex(pattern)
 
     return _Filter.any(
-        *[
+        [
             _Filter.all(
-                *(
-                    [_Filter.matches_all(attribute, pattern) for pattern in conj.positive_patterns]
-                    + [_Filter.matches_none(attribute, pattern) for pattern in conj.negated_patterns]
-                )
+                [_Filter.matches_all(attribute, pattern) for pattern in conj.positive_patterns]
+                + [_Filter.matches_none(attribute, pattern) for pattern in conj.negated_patterns]
             )
             for conj in parsed.children
         ]

--- a/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
+++ b/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
@@ -157,7 +157,7 @@ def _make_new_attribute_definitions_page_params(
 
 
 def _escape_name_eq(names: Optional[list[str]]) -> Optional[list[str]]:
-    if not names:
+    if names is None:
         return None
 
     escaped = [f"{re.escape(name)}" for name in names]

--- a/tests/e2e/alpha/test_experiments.py
+++ b/tests/e2e/alpha/test_experiments.py
@@ -15,6 +15,7 @@ from neptune_fetcher.alpha.filters import (
     AttributeFilter,
     Filter,
 )
+from neptune_fetcher.exceptions import NeptuneUnexpectedResponseError
 from neptune_fetcher.internal import env
 from tests.e2e.data import (
     FLOAT_SERIES_PATHS,
@@ -433,3 +434,44 @@ def test_list_experiments_with_filter_matching_some(project, filter_, expected):
     names = list_experiments(filter_, context=_context(project))
     assert set(names) == set(expected)
     assert len(names) == len(expected)
+
+
+def test_list_experiments_with_filter_all_any(project):
+    """Test the behavior of `Filter.any` and `Filter.all` filters in the list_experiments function.
+
+    This is specific to alpha, in v1, we're going to do something more clever
+    """
+
+    output_all = list_experiments(Filter.any(), context=_context(project))
+    assert set(output_all).issuperset(set(TEST_DATA.experiment_names))
+
+    output_any = list_experiments(Filter.any(), context=_context(project))
+    assert set(output_any).issuperset(set(TEST_DATA.experiment_names))
+
+    # These generate invalid queries:
+    with pytest.raises(NeptuneUnexpectedResponseError):
+        list_experiments(Filter.all() | Filter.any(), context=_context(project))
+
+    with pytest.raises(NeptuneUnexpectedResponseError):
+        list_experiments(Filter.any() | Filter.all(), context=_context(project))
+
+    with pytest.raises(NeptuneUnexpectedResponseError):
+        list_experiments(Filter.any() & Filter.any(), context=_context(project))
+
+    with pytest.raises(NeptuneUnexpectedResponseError):
+        list_experiments(Filter.any() & Filter.all(), context=_context(project))
+
+    with pytest.raises(NeptuneUnexpectedResponseError):
+        list_experiments(Filter.all() & Filter.all(), context=_context(project))
+
+    with pytest.raises(NeptuneUnexpectedResponseError):
+        list_experiments(Filter.all() & Filter.ne("sys/name", "xyz"), context=_context(project))
+
+    with pytest.raises(NeptuneUnexpectedResponseError):
+        list_experiments(Filter.all() | Filter.ne("sys/name", "xyz"), context=_context(project))
+
+    with pytest.raises(NeptuneUnexpectedResponseError):
+        list_experiments(Filter.ne("sys/name", "xyz") & Filter.all(), context=_context(project))
+
+    with pytest.raises(NeptuneUnexpectedResponseError):
+        list_experiments(Filter.ne("sys/name", "xyz") & Filter.any(), context=_context(project))

--- a/tests/e2e/alpha/test_experiments.py
+++ b/tests/e2e/alpha/test_experiments.py
@@ -424,7 +424,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
             Filter.eq(Attribute("sys/name", type="string"), f"test_alpha_0_{TEST_DATA_VERSION}"),
             [f"test_alpha_0_{TEST_DATA_VERSION}"],
         ),
-        # (     TODO - FILE nto supported in nql
+        # (     TODO - FILE not supported in nql
         #     Filter.exists(Attribute(f"{PATH}/files/file-value.txt", type="file")),
         #     [f"test_experiment_0_{TEST_DATA_VERSION}"],
         # ),
@@ -475,3 +475,13 @@ def test_list_experiments_with_filter_all_any(project):
 
     with pytest.raises(NeptuneUnexpectedResponseError):
         list_experiments(Filter.ne("sys/name", "xyz") & Filter.any(), context=_context(project))
+
+
+def test_empty_experiment_list(project):
+    """Test the behavior of filtering by experiments=[]
+
+    In alpha, this returns all experiments, in v1, it will either return empty, or raise an error
+    """
+
+    output_all = list_experiments(experiments=[], context=_context(project))
+    assert set(output_all).issuperset(set(TEST_DATA.experiment_names))

--- a/tests/e2e/internal/composition/test_attributes.py
+++ b/tests/e2e/internal/composition/test_attributes.py
@@ -108,7 +108,7 @@ def test_fetch_attribute_definitions_filter_or(client, executor, project, experi
     attribute_filter_2 = _AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["float"])
 
     #  when
-    attribute_filter = attribute_filter_1 | attribute_filter_2
+    attribute_filter = _AttributeFilter.any([attribute_filter_1, attribute_filter_2])
     attributes = extract_pages(
         fetch_attribute_definitions(
             client,
@@ -132,9 +132,8 @@ def test_fetch_attribute_definitions_filter_or(client, executor, project, experi
 @pytest.mark.parametrize(
     "make_attribute_filter",
     [
-        lambda a, b, c: a | b | c,
-        lambda a, b, c: _AttributeFilter.any(a, b, c),
-        lambda a, b, c: _AttributeFilter.any(a, _AttributeFilter.any(b, c)),
+        lambda a, b, c: _AttributeFilter.any([a, b, c]),
+        lambda a, b, c: _AttributeFilter.any([a, _AttributeFilter.any([b, c])]),
     ],
 )
 def test_fetch_attribute_definitions_filter_triple_or(
@@ -207,7 +206,9 @@ def test_fetch_attribute_definitions_should_deduplicate_items(client, executor, 
     attribute_filter_0 = _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
     attribute_filter = attribute_filter_0
     for i in range(10):
-        attribute_filter = attribute_filter | _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+        attribute_filter = _AttributeFilter.any(
+            [attribute_filter, _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])]
+        )
 
     attributes = extract_pages(
         fetch_attribute_definitions(

--- a/tests/e2e/internal/composition/test_download_files.py
+++ b/tests/e2e/internal/composition/test_download_files.py
@@ -70,9 +70,18 @@ def test_download_files_no_permission(client, project, experiment_identifier, te
     "attributes",
     [
         _AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
-        _AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"])
-        | _AttributeFilter(name_eq=[f"{PATH}/file-value.txt"]),
-        _AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]) | _AttributeFilter(name_eq=[f"{PATH}/int-value"]),
+        _AttributeFilter.any(
+            [
+                _AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
+                _AttributeFilter(name_eq=[f"{PATH}/file-value.txt"]),
+            ]
+        ),
+        _AttributeFilter.any(
+            [
+                _AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
+                _AttributeFilter(name_eq=[f"{PATH}/int-value"]),
+            ]
+        ),
     ],
 )
 def test_download_files_single(client, project, experiment_identifier, temp_dir, attributes):

--- a/tests/e2e/internal/retrieval/test_search.py
+++ b/tests/e2e/internal/retrieval/test_search.py
@@ -305,13 +305,17 @@ def test_find_experiments_by_config_values(client, project, run_with_attributes,
             False,
         ),
         (
-            _Filter.ge(
-                _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
-                _variance(FLOAT_SERIES_VALUES) - 1e-6,
-            )
-            & _Filter.le(
-                _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
-                _variance(FLOAT_SERIES_VALUES) + 1e-6,
+            _Filter.all(
+                [
+                    _Filter.ge(
+                        _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                        _variance(FLOAT_SERIES_VALUES) - 1e-6,
+                    ),
+                    _Filter.le(
+                        _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                        _variance(FLOAT_SERIES_VALUES) + 1e-6,
+                    ),
+                ]
             ),
             True,
         ),
@@ -324,14 +328,18 @@ def test_find_experiments_by_config_values(client, project, run_with_attributes,
         ),
         (
             _Filter.negate(
-                _Filter.ge(
-                    _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
-                    _variance(FLOAT_SERIES_VALUES) - 1e-6,
-                )
-                & _Filter.le(
-                    _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
-                    _variance(FLOAT_SERIES_VALUES) + 1e-6,
-                )
+                _Filter.all(
+                    [
+                        _Filter.ge(
+                            _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                            _variance(FLOAT_SERIES_VALUES) - 1e-6,
+                        ),
+                        _Filter.le(
+                            _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                            _variance(FLOAT_SERIES_VALUES) + 1e-6,
+                        ),
+                    ]
+                ),
             ),
             False,
         ),
@@ -392,135 +400,181 @@ def test_find_experiments_by_string_series_values(client, project, run_with_attr
     [
         (
             _Filter.all(
-                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            True,
-        ),
-        (
-            _Filter.all(
-                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            False,
-        ),
-        (
-            _Filter.all(
-                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            False,
-        ),
-        (
-            _Filter.all(
-                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            False,
-        ),
-        (
-            _Filter.any(
-                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            True,
-        ),
-        (
-            _Filter.any(
-                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            True,
-        ),
-        (
-            _Filter.any(
-                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            True,
-        ),
-        (
-            _Filter.any(
-                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            False,
-        ),
-        (
-            _Filter.negate(
-                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-            ),
-            False,
-        ),
-        (
-            _Filter.negate(
-                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-            ),
-            True,
-        ),
-        (
-            _Filter.all(
-                _Filter.any(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
-                _Filter.any(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-                ),
-            ),
-            True,
-        ),
-        (
-            _Filter.all(
-                _Filter.any(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
-                _Filter.any(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
-            ),
-            False,
-        ),
-        (
-            _Filter.any(
-                _Filter.all(
+                [
                     _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
                     _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-                ),
-                _Filter.all(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
+                ]
+            ),
+            True,
+        ),
+        (
+            _Filter.all(
+                [
+                    _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            False,
+        ),
+        (
+            _Filter.all(
+                [
+                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            False,
+        ),
+        (
+            _Filter.all(
+                [
+                    _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            False,
+        ),
+        (
+            _Filter.any(
+                [
+                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
             ),
             True,
         ),
         (
             _Filter.any(
-                _Filter.all(
+                [
+                    _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            True,
+        ),
+        (
+            _Filter.any(
+                [
                     _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
-                _Filter.all(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
+                    _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            True,
+        ),
+        (
+            _Filter.any(
+                [
+                    _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            False,
+        ),
+        (
+            _Filter.negate(
+                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+            ),
+            False,
+        ),
+        (
+            _Filter.negate(
+                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+            ),
+            True,
+        ),
+        (
+            _Filter.all(
+                [
+                    _Filter.any(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                    _Filter.any(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                        ]
+                    ),
+                ]
+            ),
+            True,
+        ),
+        (
+            _Filter.all(
+                [
+                    _Filter.any(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                    _Filter.any(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                ]
+            ),
+            False,
+        ),
+        (
+            _Filter.any(
+                [
+                    _Filter.all(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                        ]
+                    ),
+                    _Filter.all(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                ]
+            ),
+            True,
+        ),
+        (
+            _Filter.any(
+                [
+                    _Filter.all(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                    _Filter.all(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                ]
             ),
             False,
         ),
         (
             _Filter.negate(
                 _Filter.any(
-                    _Filter.all(
-                        _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                        _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                    ),
-                    _Filter.all(
-                        _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                        _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                    ),
+                    [
+                        _Filter.all(
+                            [
+                                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                            ]
+                        ),
+                        _Filter.all(
+                            [
+                                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
+                                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                            ]
+                        ),
+                    ]
                 )
             ),
             True,

--- a/tests/unit/internal/test_validation.py
+++ b/tests/unit/internal/test_validation.py
@@ -116,12 +116,21 @@ def test_validate_include_time_invalid():
         (_AttributeFilter("a", type_in=["string_series", "float_series"]), "float_series"),
         (_AttributeFilter("a", type_in=["string_series", "float_series"]), "string_series"),
         (
-            _AttributeFilter("a", type_in=["string_series"]) | _AttributeFilter("b", type_in=["string_series"]),
+            _AttributeFilter.any(
+                [
+                    _AttributeFilter("a", type_in=["string_series"]),
+                    _AttributeFilter("b", type_in=["string_series"]),
+                ]
+            ),
             "string_series",
         ),
         (
-            _AttributeFilter("a", type_in=["string_series", "float_series"])
-            | _AttributeFilter("b", type_in=["float_series"]),
+            _AttributeFilter.any(
+                [
+                    _AttributeFilter("a", type_in=["string_series", "float_series"]),
+                    _AttributeFilter("b", type_in=["float_series"]),
+                ]
+            ),
             "float_series",
         ),
     ],
@@ -144,9 +153,20 @@ def test_validate_attribute_filter_type_valid(attribute_filter, type_in):
         (_AttributeFilter("a", type_in=["string_series"]), "float_series"),
         (_AttributeFilter("a", type_in=["float_series"]), "string_series"),
         (_AttributeFilter("a", type_in=["string_series", "float_series"]), "int"),
-        (_AttributeFilter("a", type_in=["float_series"]) | _AttributeFilter(type_in=["string_series"]), "int"),
-        (_AttributeFilter("a", type_in=["int"]) | _AttributeFilter(type_in=["string_series"]), "int"),
-        (_AttributeFilter("a", type_in=["float_series"]) | _AttributeFilter(type_in=["int"]), "int"),
+        (
+            _AttributeFilter.any(
+                [_AttributeFilter("a", type_in=["float_series"]), _AttributeFilter(type_in=["string_series"])]
+            ),
+            "int",
+        ),
+        (
+            _AttributeFilter.any([_AttributeFilter("a", type_in=["int"]), _AttributeFilter(type_in=["string_series"])]),
+            "int",
+        ),
+        (
+            _AttributeFilter.any([_AttributeFilter("a", type_in=["float_series"]), _AttributeFilter(type_in=["int"])]),
+            "int",
+        ),
     ],
 )
 def test_validate_attribute_filter_type_invalid(attribute_filter, type_in):


### PR DESCRIPTION
Make _Filter.all, _Filter.any and _AssociativeOperator require non-empty list of sub-filters.
But allow alpha to work in backward-compatible way by introducing an _EmptyAssociativeOperator that generates an empty string as the generated query.

## Summary by Sourcery

Revise the internal filter API to use list-based signatures for combining filters and update all usages and related documentation accordingly.

Enhancements:
- Change `_Filter.all` and `_Filter.any` to accept a list of filters instead of variadic parameters
- Refactor `__and__`, `__or__` and `__invert__` overloads to use the new list-based combinator signatures
- Update composite predicate methods (`matches_all`, `matches_none`, `contains_all`, `contains_none`) to build filters from lists
- Replace `name_matches_all`/`name_matches_none` parameters with a `must_match_any` list of `_AttributeNameFilter` in `_AttributeFilter` docs
- Adjust `resolve_runs_filter` internal logic to construct OR filters from a list

Tests:
- Update end-to-end retrieval tests to use list inputs for `_Filter.all` and `_Filter.any`

## Summary by Sourcery

Migrate filter combinators to a strictly list-based API and enforce non-empty inputs while preserving backward compatibility for zero-argument public filters in the alpha client.

Enhancements:
- Require `_Filter.all` and `_Filter.any` to accept a non-empty list of sub-filters and raise on empty or invalid inputs
- Introduce an `_EmptyAssociativeOperator` to support legacy zero-argument `Filter.all()`/`Filter.any()` in the alpha client by producing an empty query
- Refactor attribute filter logic and documentation to replace separate `name_matches_all`/`name_matches_none` parameters with a `must_match_any` list
- Update composite predicate and `name_in` methods to use the new list-based combinator signatures
- Remove variadic overloads for filter combination and consolidate `__and__`/`__or__`/`__invert__` to internal list-based logic

Tests:
- Refactor end-to-end and unit tests to supply list inputs to `all`/`any` combinators
- Add new alpha-specific tests to validate behavior of empty `Filter.all()` and `Filter.any()` usages raising errors or yielding empty queries