### PR TITLE
fix: fix all dtypes turning into objects after pivot

### DIFF
--- a/src/neptune_fetcher/internal/output_format.py
+++ b/src/neptune_fetcher/internal/output_format.py
@@ -258,6 +258,8 @@ def create_metrics_dataframe(
 
     experiment_dtype = pd.CategoricalDtype(categories=label_mapping)
     df[index_column_name] = pd.Categorical.from_codes(df[index_column_name], dtype=experiment_dtype)
+    if timestamp_column_name:
+        df[timestamp_column_name] = pd.to_datetime(df[timestamp_column_name], unit="ms", origin="unix", utc=True)
 
     df = _pivot_and_reindex_df(df, include_point_previews, index_column_name, timestamp_column_name)
     df = _restore_path_column_names(df, path_mapping, "float_series" if type_suffix_in_column_names else None)
@@ -311,6 +313,8 @@ def create_series_dataframe(
 
     experiment_dtype = pd.CategoricalDtype(categories=label_mapping)
     df[index_column_name] = pd.Categorical.from_codes(df[index_column_name], dtype=experiment_dtype)
+    if timestamp_column_name:
+        df[timestamp_column_name] = pd.to_datetime(df[timestamp_column_name], unit="ms", origin="unix", utc=True)
 
     df = _pivot_and_reindex_df(df, False, index_column_name, timestamp_column_name)
     df = _restore_path_column_names(df, path_mapping, None)
@@ -325,19 +329,17 @@ def _pivot_and_reindex_df(
     index_column_name: str,
     timestamp_column_name: Optional[str],
 ) -> pd.DataFrame:
-    values: Union[str, list[str]] = "value"
+    if df.empty and timestamp_column_name:
+        # Handle empty DataFrame case to avoid pandas dtype errors
+        df[timestamp_column_name] = pd.Series(dtype="datetime64[ns]")
 
-    # Create column multi-index if necessary, otherwise we stick to a flat "value" column
     if include_point_previews or timestamp_column_name:
-        values = ["value"]
-        if timestamp_column_name:
-            df[timestamp_column_name] = pd.to_datetime(df[timestamp_column_name], unit="ms", origin="unix", utc=True)
-            values.append(timestamp_column_name)
-        if include_point_previews:
-            values.append("is_preview")
-            values.append("preview_completion")
+        # if there are multiple value columns, don't specify them and rely on pandas to create the column multi-index
+        df = df.pivot(index=[index_column_name, "step"], columns="path")
+    else:
+        # when there's only "value", define values explicitly, to make pandas generate a flat index
+        df = df.pivot(index=[index_column_name, "step"], columns="path", values="value")
 
-    df = df.pivot(index=[index_column_name, "step"], columns="path", values=values)
     df = df.reset_index()
     df[index_column_name] = df[index_column_name].astype(str)
     df = df.sort_values(by=[index_column_name, "step"], ignore_index=True)

--- a/tests/unit/internal/test_output_format.py
+++ b/tests/unit/internal/test_output_format.py
@@ -384,7 +384,7 @@ def test_create_metrics_dataframe_with_absolute_timestamp(type_suffix_in_column_
         index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
     )
 
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 def _run_definition(run_id: str, attribute_path: str, attribute_type: str = "string_series") -> RunAttributeDefinition:
@@ -431,7 +431,7 @@ def test_create_series_dataframe_with_absolute_timestamp():
         dict(sorted(expected.items())),
         index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
     )
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
@@ -491,7 +491,7 @@ def test_create_metrics_dataframe_without_timestamp(type_suffix_in_column_names:
         index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
     )
 
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 def test_create_metrics_dataframe_random_order():
@@ -531,7 +531,7 @@ def test_create_metrics_dataframe_random_order():
         ),
     )
 
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
@@ -676,7 +676,7 @@ def test_create_metrics_dataframe_with_reserved_paths_with_multiindex(
         index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
     )
 
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 @pytest.mark.parametrize(
@@ -727,7 +727,7 @@ def test_create_metrics_dataframe_with_reserved_paths_with_flat_index(path: str,
         index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
     )
 
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 def test_create_files_dataframe_empty():


### PR DESCRIPTION
fixes PY-139

## Summary by Sourcery

Preserve datetime dtypes when pivoting dataframes and enforce dtype checks in tests.

Bug Fixes:
- Convert timestamp columns to UTC datetimes before pivot to avoid object dtype fallback.
- Initialize timestamp column on empty DataFrames to maintain correct datetime dtype.
- Adjust pivot logic to rely on pandas multi-index behavior when multiple columns are present and explicitly specify values only for flat pivots.

Enhancements:
- Refactor pivot implementation to separate multi-column and single-value cases for improved dtype handling.

Tests:
- Remove `check_dtype=False` from DataFrame assertions to enforce exact dtype matches.