### PR TITLE
Use must_match_any in alpha filters

### DIFF
--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -65,7 +65,9 @@ def resolve_attributes_filter(
         if attributes is None:
             return _filters._AttributeFilter()
         if isinstance(attributes, str):
-            return _filters._AttributeFilter(name_matches_all=attributes)
+            return _filters._AttributeFilter(
+                must_match_any=[_filters._AttributeNameFilter(must_match_regexes=[attributes])]
+            )
         if attributes == []:
             # In alpha, passing attributes=[] gives us un-filtered results
             # In v1, we're going to return no results or raise an error
@@ -82,7 +84,10 @@ def resolve_attributes_filter(
         if attributes is None:
             return _filters._AttributeFilter(type_in=forced_type)
         if isinstance(attributes, str):
-            return _filters._AttributeFilter(name_matches_all=attributes, type_in=forced_type)
+            return _filters._AttributeFilter(
+                must_match_any=[_filters._AttributeNameFilter(must_match_regexes=[attributes])],
+                type_in=forced_type,
+            )
         if attributes == []:
             # In alpha, passing attributes=[] gives us un-filtered results
             # In v1, we're going to return no results or raise an error

--- a/src/neptune_fetcher/internal/filters.py
+++ b/src/neptune_fetcher/internal/filters.py
@@ -113,24 +113,18 @@ class _AttributeFilter(_BaseAttributeFilter):
 
     name_eq: Union[str, list[str], None] = None
     type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(types.ALL_TYPES))  # type: ignore
-    name_matches_all: Union[str, list[str], None] = None
-    name_matches_none: Union[str, list[str], None] = None
     must_match_any: Optional[list[_AttributeNameFilter]] = None
     aggregations: list[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
 
     def __post_init__(self) -> None:
         _validate_string_or_string_list(self.name_eq, "name_eq")
-        _validate_string_or_string_list(self.name_matches_all, "name_matches_all")
-        _validate_string_or_string_list(self.name_matches_none, "name_matches_none")
 
         if self.must_match_any is not None:
-            if self.name_matches_all is not None or self.name_matches_none is not None:
-                raise ValueError("must_match_any cannot be used together with name_matches_all or name_matches_none")
             if not isinstance(self.must_match_any, list):
-                raise ValueError("must_match_any must be a list of AttributeNameFilter instances")
+                raise ValueError("must_match_any must be a list of _AttributeNameFilter instances")
             for item in self.must_match_any:
                 if not isinstance(item, _AttributeNameFilter):
-                    raise ValueError("must_match_any must contain only AttributeNameFilter instances")
+                    raise ValueError("must_match_any must contain only _AttributeNameFilter instances")
                 _validate_string_list(item.must_match_regexes, "must_match_regexes")
                 _validate_string_list(item.must_not_match_regexes, "must_not_match_regexes")
 

--- a/src/neptune_fetcher/internal/pattern.py
+++ b/src/neptune_fetcher/internal/pattern.py
@@ -95,14 +95,6 @@ def build_extended_regex_filter(attribute: _Attribute, pattern: str) -> _Filter:
 def build_extended_regex_attribute_filter(pattern: str, type_in: list[ATTRIBUTE_LITERAL]) -> _AttributeFilter:
     parsed = parse_extended_regex(pattern)
 
-    if len(parsed.children) == 1:
-        child = parsed.children[0]
-        return _AttributeFilter(
-            type_in=type_in,
-            name_matches_all=child.positive_patterns if child.positive_patterns else None,
-            name_matches_none=child.negated_patterns if child.negated_patterns else None,
-        )
-
     return _AttributeFilter(
         type_in=type_in,
         must_match_any=[

--- a/tests/e2e/internal/composition/test_attributes.py
+++ b/tests/e2e/internal/composition/test_attributes.py
@@ -9,7 +9,10 @@ from datetime import (
 import pytest
 
 from neptune_fetcher.internal.composition.attributes import fetch_attribute_definitions
-from neptune_fetcher.internal.filters import _AttributeFilter
+from neptune_fetcher.internal.filters import (
+    _AttributeFilter,
+    _AttributeNameFilter,
+)
 from neptune_fetcher.internal.identifiers import (
     AttributeDefinition,
     RunIdentifier,
@@ -104,8 +107,14 @@ def test_fetch_attribute_definitions_filter_or(client, executor, project, experi
     # given
     project_identifier = project.project_identifier
 
-    attribute_filter_1 = _AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_a$", type_in=["int"])
-    attribute_filter_2 = _AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["float"])
+    attribute_filter_1 = _AttributeFilter(
+        must_match_any=[_AttributeNameFilter(must_match_regexes=[f"^{re.escape(COMMON_PATH)}/.*_value_a$"])],
+        type_in=["int"],
+    )
+    attribute_filter_2 = _AttributeFilter(
+        must_match_any=[_AttributeNameFilter(must_match_regexes=[f"^{re.escape(COMMON_PATH)}/.*_value_b$"])],
+        type_in=["float"],
+    )
 
     #  when
     attribute_filter = _AttributeFilter.any([attribute_filter_1, attribute_filter_2])
@@ -142,9 +151,18 @@ def test_fetch_attribute_definitions_filter_triple_or(
     # given
     project_identifier = project.project_identifier
 
-    attribute_filter_1 = _AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_a$", type_in=["int"])
-    attribute_filter_2 = _AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["float"])
-    attribute_filter_3 = _AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["int"])
+    attribute_filter_1 = _AttributeFilter(
+        must_match_any=[_AttributeNameFilter(must_match_regexes=[f"^{re.escape(COMMON_PATH)}/.*_value_a$"])],
+        type_in=["int"],
+    )
+    attribute_filter_2 = _AttributeFilter(
+        must_match_any=[_AttributeNameFilter(must_match_regexes=[f"^{re.escape(COMMON_PATH)}/.*_value_b$"])],
+        type_in=["float"],
+    )
+    attribute_filter_3 = _AttributeFilter(
+        must_match_any=[_AttributeNameFilter(must_match_regexes=[f"^{re.escape(COMMON_PATH)}/.*_value_b$"])],
+        type_in=["int"],
+    )
     attribute_filter = make_attribute_filter(attribute_filter_1, attribute_filter_2, attribute_filter_3)
 
     #  when
@@ -174,7 +192,10 @@ def test_fetch_attribute_definitions_paging_executor(client, executor, project, 
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+    attribute_filter = _AttributeFilter(
+        must_match_any=[_AttributeNameFilter(must_match_regexes=["sys/.*_time"])],
+        type_in=["datetime"],
+    )
 
     attributes = extract_pages(
         fetch_attribute_definitions(
@@ -203,11 +224,20 @@ def test_fetch_attribute_definitions_should_deduplicate_items(client, executor, 
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter_0 = _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+    attribute_filter_0 = _AttributeFilter(
+        must_match_any=[_AttributeNameFilter(must_match_regexes=["sys/.*_time"])],
+        type_in=["datetime"],
+    )
     attribute_filter = attribute_filter_0
     for i in range(10):
         attribute_filter = _AttributeFilter.any(
-            [attribute_filter, _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])]
+            [
+                attribute_filter,
+                _AttributeFilter(
+                    must_match_any=[_AttributeNameFilter(must_match_regexes=["sys/.*_time"])],
+                    type_in=["datetime"],
+                ),
+            ]
         )
 
     attributes = extract_pages(

--- a/tests/e2e/internal/retrieval/test_attributes.py
+++ b/tests/e2e/internal/retrieval/test_attributes.py
@@ -226,7 +226,10 @@ def test_fetch_attribute_definitions_regex_matches_all(client, project, experime
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+    attribute_filter = _AttributeFilter(
+        must_match_any=[_AttributeNameFilter(must_match_regexes=["sys/.*_time"])],
+        type_in=["datetime"],
+    )
     attributes = extract_pages(
         fetch_attribute_definitions_single_filter(
             client,
@@ -253,7 +256,13 @@ def test_fetch_attribute_definitions_regex_matches_none(client, project, experim
 
     #  when
     attribute_filter = _AttributeFilter(
-        name_matches_all="sys/.*_time", name_matches_none="modification", type_in=["datetime"]
+        must_match_any=[
+            _AttributeNameFilter(
+                must_match_regexes=["sys/.*_time"],
+                must_not_match_regexes=["modification"],
+            ),
+        ],
+        type_in=["datetime"],
     )
     attributes = extract_pages(
         fetch_attribute_definitions_single_filter(
@@ -389,7 +398,10 @@ def test_fetch_attribute_definitions_paging(client, project, experiment_identifi
     project_identifier = project.project_identifier
 
     #  when
-    attribute_filter = _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+    attribute_filter = _AttributeFilter(
+        must_match_any=[_AttributeNameFilter(must_match_regexes=["sys/.*_time"])],
+        type_in=["datetime"],
+    )
     attributes = extract_pages(
         fetch_attribute_definitions_single_filter(
             client,

--- a/tests/unit/internal/test_pattern.py
+++ b/tests/unit/internal/test_pattern.py
@@ -94,12 +94,45 @@ def test_build_extended_regex_filter(attribute, pattern, query):
 @pytest.mark.parametrize(
     "type_in,pattern,expected",
     [
-        (["string"], "", _AttributeFilter(type_in=["string"], name_matches_all=[""])),
-        (["string"], "a", _AttributeFilter(type_in=["string"], name_matches_all=["a"])),
-        (["int"], "a", _AttributeFilter(type_in=["int"], name_matches_all=["a"])),
-        (["string"], "!a", _AttributeFilter(type_in=["string"], name_matches_none=["a"])),
-        (["string"], " ! a", _AttributeFilter(type_in=["string"], name_matches_none=["a"])),
-        (["string"], "a & b", _AttributeFilter(type_in=["string"], name_matches_all=["a", "b"])),
+        (
+            ["string"],
+            "",
+            _AttributeFilter(type_in=["string"], must_match_any=[_AttributeNameFilter(must_match_regexes=[""])]),
+        ),
+        (
+            ["string"],
+            "a",
+            _AttributeFilter(type_in=["string"], must_match_any=[_AttributeNameFilter(must_match_regexes=["a"])]),
+        ),
+        (
+            ["int"],
+            "a",
+            _AttributeFilter(type_in=["int"], must_match_any=[_AttributeNameFilter(must_match_regexes=["a"])]),
+        ),
+        (
+            ["string"],
+            "!a",
+            _AttributeFilter(
+                type_in=["string"],
+                must_match_any=[_AttributeNameFilter(must_not_match_regexes=["a"])],
+            ),
+        ),
+        (
+            ["string"],
+            " ! a",
+            _AttributeFilter(
+                type_in=["string"],
+                must_match_any=[_AttributeNameFilter(must_not_match_regexes=["a"])],
+            ),
+        ),
+        (
+            ["string"],
+            "a & b",
+            _AttributeFilter(
+                type_in=["string"],
+                must_match_any=[_AttributeNameFilter(must_match_regexes=["a", "b"])],
+            ),
+        ),
         (
             ["string"],
             "a | b",


### PR DESCRIPTION
Since `_AttributeFilter.must_match_any` can express name_matches_all and name_matches_none, I'm simplifying the code to always use `must_match_any`.

## Summary by Sourcery

Consolidate attribute name matching by deprecating name_matches_all and name_matches_none in favor of a unified must_match_any configuration across alpha and internal filters, and update all related code and tests accordingly.

Enhancements:
- Replace name_matches_all and name_matches_none with a unified must_match_any parameter in attribute filters
- Refactor internal filter conversion to build attributeNameFilter.mustMatchAny from must_match_any and name_eq
- Update alpha filter implementation to always emit must_match_any for name matching

Tests:
- Refactor unit and e2e tests to instantiate must_match_any with _AttributeNameFilter instead of name_matches_all/none
- Adjust validation tests to expect new error messages for must_match_regexes, must_not_match_regexes, and must_match_any

Chores:
- Remove legacy single-child special case in build_extended_regex_attribute_filter