### PR TITLE
chore: update neptune-api to 0.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ pattern = "default-unprefixed"
 python = "^3.9"
 
 # Base neptune package
-neptune-api = ">=0.17.0,<0.18.0"
+neptune-api = ">=0.17.0,<0.19.0"
 azure-storage-blob = "^12.7.0"
 pandas = [
     { version = ">=1.4.0,<2.3.0", python = "<3.10" },


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Extend neptune-api requirement from <0.18.0 to <0.19.0