### PR TITLE
feat: series retrieval fetches all types of series

### DIFF
--- a/src/neptune_fetcher/alpha/filters.py
+++ b/src/neptune_fetcher/alpha/filters.py
@@ -187,7 +187,7 @@ class Attribute:
 
     def __post_init__(self) -> None:
         _validate_allowed_value(self.aggregation, types.ALL_AGGREGATIONS, "aggregation")
-        _validate_allowed_value(self.type, types.ALL_TYPES, "type")  # type: ignore
+        _validate_allowed_value(self.type, types.ALL_TYPES, "type")
 
     def to_query(self) -> str:
         query = f"`{self.name}`"

--- a/src/neptune_fetcher/alpha/filters.py
+++ b/src/neptune_fetcher/alpha/filters.py
@@ -107,8 +107,8 @@ class AttributeFilter(BaseAttributeFilter):
         _validate_string_or_string_list(self.name_matches_all, "name_matches_all")
         _validate_string_or_string_list(self.name_matches_none, "name_matches_none")
 
-        _validate_list_of_allowed_values(self.type_in, types.ALL_TYPES, "type_in")  # type: ignore
-        _validate_list_of_allowed_values(self.aggregations, types.ALL_AGGREGATIONS, "aggregations")  # type: ignore
+        _validate_list_of_allowed_values(self.type_in, types.ALL_TYPES, "type_in")
+        _validate_list_of_allowed_values(self.aggregations, types.ALL_AGGREGATIONS, "aggregations")
 
     def _to_internal(self) -> _filters._AttributeFilter:
         matches_all = [self.name_matches_all] if isinstance(self.name_matches_all, str) else self.name_matches_all

--- a/src/neptune_fetcher/internal/composition/fetch_series.py
+++ b/src/neptune_fetcher/internal/composition/fetch_series.py
@@ -135,10 +135,10 @@ def fetch_series(
             ),
         )
         results: Generator[
-            util.Page[tuple[identifiers.RunAttributeDefinition, list[series.StringSeriesValue]]], None, None
+            util.Page[tuple[identifiers.RunAttributeDefinition, list[series.SeriesValue]]], None, None
         ] = concurrency.gather_results(output)
 
-        series_data: dict[identifiers.RunAttributeDefinition, list[series.StringSeriesValue]] = {}
+        series_data: dict[identifiers.RunAttributeDefinition, list[series.SeriesValue]] = {}
         for result in results:
             for run_attribute_definition, series_values in result.items:
                 series_data.setdefault(run_attribute_definition, []).extend(series_values)

--- a/src/neptune_fetcher/internal/composition/type_inference.py
+++ b/src/neptune_fetcher/internal/composition/type_inference.py
@@ -35,7 +35,9 @@ from neptune_fetcher.internal.retrieval import (
     util,
 )
 from neptune_fetcher.internal.retrieval.attribute_types import (
+    FILE_SERIES_AGGREGATIONS,
     FLOAT_SERIES_AGGREGATIONS,
+    HISTOGRAM_SERIES_AGGREGATIONS,
     STRING_SERIES_AGGREGATIONS,
 )
 
@@ -115,6 +117,10 @@ def _infer_attribute_types_from_attribute(
             matches.append("float_series")
         if all(agg in STRING_SERIES_AGGREGATIONS for agg in attribute.aggregation or []):
             matches.append("string_series")
+        if all(agg in FILE_SERIES_AGGREGATIONS for agg in attribute.aggregation or []):
+            matches.append("file_series")
+        if all(agg in HISTOGRAM_SERIES_AGGREGATIONS for agg in attribute.aggregation or []):
+            matches.append("histogram_series")
         if len(matches) == 1:
             attribute.type = matches[0]  # type: ignore
 

--- a/src/neptune_fetcher/internal/filters.py
+++ b/src/neptune_fetcher/internal/filters.py
@@ -123,7 +123,7 @@ class _AttributeFilter(_BaseAttributeFilter):
     """
 
     name_eq: Union[str, list[str], None] = None
-    type_in: Sequence[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(types.ALL_TYPES))  # type: ignore
+    type_in: Sequence[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(types.ALL_TYPES))
     must_match_any: Optional[list[_AttributeNameFilter]] = None
     aggregations: Sequence[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
 
@@ -139,8 +139,8 @@ class _AttributeFilter(_BaseAttributeFilter):
                 _validate_string_list(item.must_match_regexes, "must_match_regexes")
                 _validate_string_list(item.must_not_match_regexes, "must_not_match_regexes")
 
-        _validate_list_of_allowed_values(self.type_in, types.ALL_TYPES, "type_in")  # type: ignore
-        _validate_list_of_allowed_values(self.aggregations, types.ALL_AGGREGATIONS, "aggregations")  # type: ignore
+        _validate_list_of_allowed_values(self.type_in, types.ALL_TYPES, "type_in")
+        _validate_list_of_allowed_values(self.aggregations, types.ALL_AGGREGATIONS, "aggregations")
 
     def transform(
         self, map_attribute_filter: Callable[["_AttributeFilter"], "_AttributeFilter"]

--- a/src/neptune_fetcher/internal/filters.py
+++ b/src/neptune_fetcher/internal/filters.py
@@ -25,6 +25,7 @@ from typing import (
     Iterable,
     Literal,
     Optional,
+    Sequence,
     Union,
 )
 
@@ -40,7 +41,17 @@ from neptune_fetcher.internal.util import (
 )
 
 ATTRIBUTE_LITERAL = Literal[
-    "float", "int", "string", "bool", "datetime", "float_series", "string_set", "string_series", "file"
+    "float",
+    "int",
+    "string",
+    "bool",
+    "datetime",
+    "float_series",
+    "string_set",
+    "string_series",
+    "file",
+    "file_series",
+    "histogram_series",
 ]
 AGGREGATION_LITERAL = Literal["last", "min", "max", "average", "variance"]
 
@@ -112,9 +123,9 @@ class _AttributeFilter(_BaseAttributeFilter):
     """
 
     name_eq: Union[str, list[str], None] = None
-    type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(types.ALL_TYPES))  # type: ignore
+    type_in: Sequence[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(types.ALL_TYPES))  # type: ignore
     must_match_any: Optional[list[_AttributeNameFilter]] = None
-    aggregations: list[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
+    aggregations: Sequence[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
 
     def __post_init__(self) -> None:
         _validate_string_or_string_list(self.name_eq, "name_eq")

--- a/src/neptune_fetcher/internal/output_format.py
+++ b/src/neptune_fetcher/internal/output_format.py
@@ -270,7 +270,7 @@ def create_metrics_dataframe(
 
 
 def create_series_dataframe(
-    series_data: dict[identifiers.RunAttributeDefinition, list[series.StringSeriesValue]],
+    series_data: dict[identifiers.RunAttributeDefinition, list[series.SeriesValue]],
     sys_id_label_mapping: dict[identifiers.SysId, str],
     index_column_name: str,
     timestamp_column_name: Optional[str],

--- a/src/neptune_fetcher/internal/output_format.py
+++ b/src/neptune_fetcher/internal/output_format.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pathlib
+from collections.abc import Collection
 from typing import (
     Any,
     Generator,
@@ -31,11 +32,8 @@ from neptune_fetcher.internal.retrieval import (
     series,
 )
 from neptune_fetcher.internal.retrieval.attribute_types import (
-    FLOAT_SERIES_AGGREGATIONS,
-    STRING_SERIES_AGGREGATIONS,
+    TYPE_AGGREGATIONS,
     File,
-    FloatSeriesAggregations,
-    StringSeriesAggregations,
 )
 from neptune_fetcher.internal.retrieval.attribute_values import AttributeValue
 from neptune_fetcher.internal.retrieval.metrics import (
@@ -74,16 +72,13 @@ def convert_table_to_dataframe(
             column_name = get_column_name(value)
             if column_name in row:
                 raise ConflictingAttributeTypes([value.attribute_definition.name])
-            if value.attribute_definition.type == "float_series":
-                float_series_aggregations: FloatSeriesAggregations = value.value
+            if value.attribute_definition.type in TYPE_AGGREGATIONS:
+                aggregation_value = value.value
                 selected_subset = selected_aggregations.get(value.attribute_definition, set())
-                agg_subset_values = get_float_series_aggregation_subset(float_series_aggregations, selected_subset)
-                for agg_name, agg_value in agg_subset_values.items():
-                    row[(column_name, agg_name)] = agg_value
-            elif value.attribute_definition.type == "string_series":
-                string_series_aggregations: StringSeriesAggregations = value.value
-                selected_subset = selected_aggregations.get(value.attribute_definition, set())
-                agg_subset_values = get_string_series_aggregation_subset(string_series_aggregations, selected_subset)
+                aggregations_set = TYPE_AGGREGATIONS[value.attribute_definition.type]
+
+                agg_subset_values = get_aggregation_subset(aggregation_value, selected_subset, aggregations_set)
+
                 for agg_name, agg_value in agg_subset_values.items():
                     row[(column_name, agg_name)] = agg_value
             elif flatten_file_properties and value.attribute_definition.type == "file":
@@ -98,22 +93,13 @@ def convert_table_to_dataframe(
     def get_column_name(attr: AttributeValue) -> str:
         return f"{attr.attribute_definition.name}:{attr.attribute_definition.type}"
 
-    def get_float_series_aggregation_subset(
-        float_series_aggregations: FloatSeriesAggregations, selected_subset: set[str]
+    def get_aggregation_subset(
+        aggregations_value: Any, selected_subset: set[str], aggregations_set: Collection[str]
     ) -> dict[str, Any]:
         result = {}
-        for agg_name in FLOAT_SERIES_AGGREGATIONS:
+        for agg_name in aggregations_set:
             if agg_name in selected_subset:
-                result[agg_name] = getattr(float_series_aggregations, agg_name)
-        return result
-
-    def get_string_series_aggregation_subset(
-        string_series_aggregation: StringSeriesAggregations, selected_subset: set[str]
-    ) -> dict[str, Any]:
-        result = {}
-        for agg_name in STRING_SERIES_AGGREGATIONS:
-            if agg_name in selected_subset:
-                result[agg_name] = getattr(string_series_aggregation, agg_name)
+                result[agg_name] = getattr(aggregations_value, agg_name)
         return result
 
     def transform_column_names(df: pd.DataFrame) -> pd.DataFrame:

--- a/src/neptune_fetcher/internal/retrieval/attribute_types.py
+++ b/src/neptune_fetcher/internal/retrieval/attribute_types.py
@@ -80,6 +80,13 @@ class File:
         return f"File({self.mime_type}, size={humanize_size(self.size_bytes)})"
 
 
+@dataclass(frozen=True)
+class Histogram:
+    type: str
+    edges: list[float]
+    values: list[float]
+
+
 def humanize_size(size_bytes: int) -> str:
     """Convert bytes to a human-readable format."""
     if size_bytes < 1024:

--- a/src/neptune_fetcher/internal/retrieval/attribute_types.py
+++ b/src/neptune_fetcher/internal/retrieval/attribute_types.py
@@ -30,7 +30,19 @@ from neptune_api.proto.neptune_pb.api.v1.model.leaderboard_entries_pb2 import (
 
 from neptune_fetcher.exceptions import warn_unsupported_value_type
 
-ALL_TYPES = ("float", "int", "string", "bool", "datetime", "float_series", "string_set", "string_series", "file")
+ALL_TYPES = (
+    "float",
+    "int",
+    "string",
+    "bool",
+    "datetime",
+    "float_series",
+    "string_set",
+    "string_series",
+    "file",
+    "file_series",
+    "histogram_series",
+)
 FLOAT_SERIES_AGGREGATIONS = frozenset({"last", "min", "max", "average", "variance"})
 STRING_SERIES_AGGREGATIONS = frozenset({"last"})
 FILE_SERIES_AGGREGATIONS = frozenset({"last"})

--- a/src/neptune_fetcher/internal/util.py
+++ b/src/neptune_fetcher/internal/util.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from typing import (
+    Collection,
     Optional,
     Union,
 )
@@ -35,13 +36,13 @@ def _validate_string_list(value: Optional[list[str]], field_name: str) -> None:
             raise ValueError(f"{field_name} must be a list of strings")
 
 
-def _validate_list_of_allowed_values(value: list[str], allowed_values: set[str], field_name: str) -> None:
+def _validate_list_of_allowed_values(value: list[str], allowed_values: Collection[str], field_name: str) -> None:
     """Validate that a value is a list containing only allowed values."""
     if not isinstance(value, list) or not all(isinstance(v, str) and v in allowed_values for v in value):
         raise ValueError(f"{field_name} must be a list of valid values: {sorted(allowed_values)}")
 
 
-def _validate_allowed_value(value: Optional[str], allowed_values: set[str], field_name: str) -> None:
+def _validate_allowed_value(value: Optional[str], allowed_values: Collection[str], field_name: str) -> None:
     """Validate that a value is either None or one of the allowed values."""
     if value is not None and (not isinstance(value, str) or value not in allowed_values):
         raise ValueError(f"{field_name} must be one of: {sorted(allowed_values)}")

--- a/src/neptune_fetcher/internal/util.py
+++ b/src/neptune_fetcher/internal/util.py
@@ -15,6 +15,7 @@
 from typing import (
     Collection,
     Optional,
+    Sequence,
     Union,
 )
 
@@ -36,7 +37,7 @@ def _validate_string_list(value: Optional[list[str]], field_name: str) -> None:
             raise ValueError(f"{field_name} must be a list of strings")
 
 
-def _validate_list_of_allowed_values(value: list[str], allowed_values: Collection[str], field_name: str) -> None:
+def _validate_list_of_allowed_values(value: Sequence[str], allowed_values: Collection[str], field_name: str) -> None:
     """Validate that a value is a list containing only allowed values."""
     if not isinstance(value, list) or not all(isinstance(v, str) and v in allowed_values for v in value):
         raise ValueError(f"{field_name} must be a list of valid values: {sorted(allowed_values)}")

--- a/src/neptune_fetcher/internal/util.py
+++ b/src/neptune_fetcher/internal/util.py
@@ -39,7 +39,7 @@ def _validate_string_list(value: Optional[list[str]], field_name: str) -> None:
 
 def _validate_list_of_allowed_values(value: Sequence[str], allowed_values: Collection[str], field_name: str) -> None:
     """Validate that a value is a list containing only allowed values."""
-    if not isinstance(value, list) or not all(isinstance(v, str) and v in allowed_values for v in value):
+    if not isinstance(value, Sequence) or not all(isinstance(v, str) and v in allowed_values for v in value):
         raise ValueError(f"{field_name} must be a list of valid values: {sorted(allowed_values)}")
 
 

--- a/src/neptune_fetcher/v1/filters.py
+++ b/src/neptune_fetcher/v1/filters.py
@@ -107,8 +107,8 @@ class AttributeFilter(BaseAttributeFilter):
         _validate_string_or_string_list(self.name_matches_all, "name_matches_all")
         _validate_string_or_string_list(self.name_matches_none, "name_matches_none")
 
-        _validate_list_of_allowed_values(self.type_in, types.ALL_TYPES, "type_in")  # type: ignore
-        _validate_list_of_allowed_values(self.aggregations, types.ALL_AGGREGATIONS, "aggregations")  # type: ignore
+        _validate_list_of_allowed_values(self.type_in, types.ALL_TYPES, "type_in")
+        _validate_list_of_allowed_values(self.aggregations, types.ALL_AGGREGATIONS, "aggregations")
 
     def _to_internal(self) -> _filters._AttributeFilter:
         matches_all = [self.name_matches_all] if isinstance(self.name_matches_all, str) else self.name_matches_all

--- a/tests/e2e/alpha/test_attributes.py
+++ b/tests/e2e/alpha/test_attributes.py
@@ -10,7 +10,9 @@ from neptune_fetcher.alpha.filters import (
     Filter,
 )
 from tests.e2e.data import (
+    FILE_SERIES_PATHS,
     FLOAT_SERIES_PATHS,
+    HISTOGRAM_SERIES_PATHS,
     PATH,
     STRING_SERIES_PATHS,
     TEST_DATA,
@@ -44,10 +46,14 @@ EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
     [
         (PATH, TEST_DATA.all_attribute_names),
         (f"{PATH}/int-value", {f"{PATH}/int-value"}),
-        (rf"{PATH}/metrics/.*", FLOAT_SERIES_PATHS + [f"{PATH}/metrics/step"] + STRING_SERIES_PATHS),
+        (
+            rf"{PATH}/metrics/.*",
+            FLOAT_SERIES_PATHS + [f"{PATH}/metrics/step"] + STRING_SERIES_PATHS + HISTOGRAM_SERIES_PATHS,
+        ),
         (
             rf"{PATH}/files/.*",
-            {f"{PATH}/files/file-value", f"{PATH}/files/file-value.txt", f"{PATH}/files/object-does-not-exist"},
+            {f"{PATH}/files/file-value", f"{PATH}/files/file-value.txt", f"{PATH}/files/object-does-not-exist"}
+            | set(FILE_SERIES_PATHS),
         ),
         (
             rf"{PATH}/.*-value$",

--- a/tests/e2e/alpha/test_fetch_series.py
+++ b/tests/e2e/alpha/test_fetch_series.py
@@ -27,7 +27,7 @@ from neptune_fetcher.internal.identifiers import (
     SysId,
 )
 from neptune_fetcher.internal.output_format import create_series_dataframe
-from neptune_fetcher.internal.retrieval.series import StringSeriesValue
+from neptune_fetcher.internal.retrieval.series import SeriesValue
 from tests.e2e.data import (
     NOW,
     NUMBER_OF_STEPS,
@@ -38,13 +38,13 @@ from tests.e2e.data import (
 NEPTUNE_PROJECT: str = os.getenv("NEPTUNE_E2E_PROJECT")
 
 
-def create_expected_data(
+def create_expected_data_string_series(
     experiments: list[ExperimentData],
     include_time: Union[Literal["absolute"], None],
     step_range: Tuple[Optional[int], Optional[int]],
     tail_limit: Optional[int],
 ) -> Tuple[pd.DataFrame, List[str], set[str]]:
-    series_data: dict[RunAttributeDefinition, list[StringSeriesValue]] = {}
+    series_data: dict[RunAttributeDefinition, list[SeriesValue]] = {}
     sys_id_label_mapping: dict[SysId, str] = {}
 
     columns = set()
@@ -70,7 +70,7 @@ def create_expected_data(
                     columns.add(path)
                     filtered_exps.add(experiment.name)
                     filtered.append(
-                        StringSeriesValue(
+                        SeriesValue(
                             step,
                             series[step],
                             int((NOW + timedelta(seconds=int(step))).timestamp()) * 1000,
@@ -116,7 +116,7 @@ def create_expected_data(
     ],
 )
 @pytest.mark.parametrize("include_time", [None, "absolute"])
-def test__fetch_series(
+def test__fetch_series_string(
     project, type_suffix_in_column_names, step_range, tail_limit, include_time, attr_filter, exp_filter
 ):
     experiments = TEST_DATA.experiments[:3]
@@ -131,7 +131,9 @@ def test__fetch_series(
         context=get_context().with_project(project.project_identifier),
     )
 
-    expected, columns, filtered_exps = create_expected_data(experiments, include_time, step_range, tail_limit)
+    expected, columns, filtered_exps = create_expected_data_string_series(
+        experiments, include_time, step_range, tail_limit
+    )
 
     pd.testing.assert_frame_equal(result, expected)
     assert result.columns.tolist() == columns

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -21,6 +21,7 @@ from neptune_fetcher.util import (
     get_config_and_token_urls,
 )
 from tests.e2e.data import (
+    FILE_SERIES_STEPS,
     NOW,
     PATH,
     TEST_DATA,
@@ -99,11 +100,18 @@ def run_with_attributes(project, client):
             series_data = {path: values[step] for path, values in experiment.string_series.items()}
             run.log_string_series(data=series_data, step=step, timestamp=NOW + timedelta(seconds=int(step)))
 
+            histogram_data = {path: values[step] for path, values in experiment.histogram_series.items()}
+            run.log_histograms(histograms=histogram_data, step=step, timestamp=NOW + timedelta(seconds=int(step)))
+
         run.log_configs(experiment.long_path_configs)
         run.log_string_series(data=experiment.long_path_series, step=1, timestamp=NOW)
         run.log_metrics(data=experiment.long_path_metrics, step=1, timestamp=NOW)
 
         run.assign_files(experiment.files)
+
+        for step in range(FILE_SERIES_STEPS):
+            file_data = {path: values[step] for path, values in experiment.file_series.items()}
+            run.log_files(files=file_data, step=step, timestamp=NOW + timedelta(seconds=int(step)))
 
         runs[experiment.name] = run
     for run in runs.values():

--- a/tests/e2e/data.py
+++ b/tests/e2e/data.py
@@ -11,14 +11,20 @@ from datetime import (
 )
 from typing import Any
 
-from neptune_scale.types import File
+from neptune_scale.types import (
+    File,
+    Histogram,
+)
 
-TEST_DATA_VERSION = "2025-05-08"
+TEST_DATA_VERSION = "2025-06-26"
 PATH = f"test/test-alpha-{TEST_DATA_VERSION}"
 FLOAT_SERIES_PATHS = [f"{PATH}/metrics/float-series-value_{j}" for j in range(5)]
 STRING_SERIES_PATHS = [f"{PATH}/metrics/string-series-value_{j}" for j in range(2)]
+FILE_SERIES_PATHS = [f"{PATH}/files/file-series-value_{j}" for j in range(2)]
+HISTOGRAM_SERIES_PATHS = [f"{PATH}/histogram-series-value_{j}" for j in range(3)]
 NUMBER_OF_STEPS = 10
 MAX_PATH_LENGTH = 1024
+FILE_SERIES_STEPS = 3
 
 
 @dataclass
@@ -30,6 +36,8 @@ class ExperimentData:
     unique_series: dict[str, list[float]]
     string_series: dict[str, list[str]]
     files: dict[str, bytes]
+    file_series: dict[str, list[bytes]]
+    histogram_series: dict[str, list[Histogram]]
     long_path_configs: dict[str, int]
     long_path_series: dict[str, str]
     long_path_metrics: dict[str, float]
@@ -45,6 +53,8 @@ class ExperimentData:
                 self.unique_series.keys(),
                 self.string_series.keys(),
                 self.files.keys(),
+                self.file_series.keys(),
+                self.histogram_series.keys(),
                 self.long_path_configs.keys(),
                 self.long_path_series.keys(),
                 self.long_path_metrics.keys(),
@@ -86,6 +96,17 @@ class TestData:
                     path: [f"string-{i}-{j}" for j in range(NUMBER_OF_STEPS)] for path in STRING_SERIES_PATHS
                 }
 
+                histogram_series = {
+                    path: [
+                        Histogram(
+                            bin_edges=[n + j for n in range(6)],
+                            counts=[n * j for n in range(5)],
+                        )
+                        for j in range(NUMBER_OF_STEPS)
+                    ]
+                    for path in HISTOGRAM_SERIES_PATHS
+                }
+
                 if i == 0:
                     files = {
                         f"{PATH}/files/file-value": b"Binary content",
@@ -93,6 +114,11 @@ class TestData:
                         f"{PATH}/files/object-does-not-exist": File(
                             "/tmp/object-does-not-exist", mime_type="text/plain", size=1
                         ),
+                    }
+
+                    file_series = {
+                        path: [f"file-{i}-{j}".encode("utf-8") for j in range(FILE_SERIES_STEPS)]
+                        for path in FILE_SERIES_PATHS
                     }
                 else:
                     files = {}
@@ -124,6 +150,8 @@ class TestData:
                         string_sets=string_sets,
                         float_series=float_series,
                         string_series=string_series,
+                        file_series=file_series,
+                        histogram_series=histogram_series,
                         unique_series={},
                         long_path_configs=long_path_configs,
                         long_path_series=long_path_series,

--- a/tests/e2e/data.py
+++ b/tests/e2e/data.py
@@ -16,12 +16,12 @@ from neptune_scale.types import (
     Histogram,
 )
 
-TEST_DATA_VERSION = "2025-06-26"
+TEST_DATA_VERSION = "2025-06-27"
 PATH = f"test/test-alpha-{TEST_DATA_VERSION}"
 FLOAT_SERIES_PATHS = [f"{PATH}/metrics/float-series-value_{j}" for j in range(5)]
 STRING_SERIES_PATHS = [f"{PATH}/metrics/string-series-value_{j}" for j in range(2)]
 FILE_SERIES_PATHS = [f"{PATH}/files/file-series-value_{j}" for j in range(2)]
-HISTOGRAM_SERIES_PATHS = [f"{PATH}/histogram-series-value_{j}" for j in range(3)]
+HISTOGRAM_SERIES_PATHS = [f"{PATH}/metrics/histogram-series-value_{j}" for j in range(3)]
 NUMBER_OF_STEPS = 10
 MAX_PATH_LENGTH = 1024
 FILE_SERIES_STEPS = 3

--- a/tests/e2e/internal/retrieval/test_search.py
+++ b/tests/e2e/internal/retrieval/test_search.py
@@ -21,7 +21,9 @@ from neptune_fetcher.internal.retrieval.search import (
     fetch_experiment_sys_attrs,
 )
 from tests.e2e.data import (
+    FILE_SERIES_PATHS,
     FLOAT_SERIES_PATHS,
+    HISTOGRAM_SERIES_PATHS,
     PATH,
     STRING_SERIES_PATHS,
     TEST_DATA,
@@ -154,11 +156,9 @@ def test_find_experiments_by_name_not_found(client, project):
         (_Filter.exists(_Attribute(name=f"{PATH}/str-value", type="string")), True),
         (_Filter.exists(_Attribute(name=f"{PATH}/str-value", type="int")), False),
         (_Filter.exists(_Attribute(name=f"{PATH}/does-not-exist-value", type="string")), False),
-        # (_Filter.exists(_Attribute(name=f"{PATH}/files/file-value.txt", type="file")), True),
-        # TODO - FILE not supported in nql
+        (_Filter.exists(_Attribute(name=f"{PATH}/files/file-value.txt", type="file")), True),
         (_Filter.exists(_Attribute(name=f"{PATH}/files/file-value.txt", type="int")), False),
-        # (_Filter.exists(_Attribute(name=f"{PATH}/files/does-not-exist-value.txt", type="file")), False),
-        # TODO - FILE not supported in nql
+        (_Filter.exists(_Attribute(name=f"{PATH}/files/does-not-exist-value.txt", type="file")), False),
         (
             _Filter.eq(
                 _Attribute(name=f"{PATH}/datetime-value", type="datetime"),
@@ -382,6 +382,70 @@ def test_find_experiments_by_float_series_values(client, project, run_with_attri
     ],
 )
 def test_find_experiments_by_string_series_values(client, project, run_with_attributes, experiment_filter, found):
+    # given
+    project_identifier = project.project_identifier
+
+    #  when
+    experiment_names = _extract_names(fetch_experiment_sys_attrs(client, project_identifier, experiment_filter))
+
+    # then
+    if found:
+        assert EXPERIMENT_NAME in experiment_names
+    else:
+        assert EXPERIMENT_NAME not in experiment_names
+
+
+@pytest.mark.parametrize(
+    "experiment_filter,found",
+    [
+        # TODO: histogram_series type not supported in nql yet
+        # (
+        #         _Filter.exists(
+        #             _Attribute(name=FILE_SERIES_PATHS[0], type="file_series"),
+        #         ),
+        #         True,
+        # ),
+        (
+            _Filter.exists(
+                _Attribute(name=FILE_SERIES_PATHS[0], type="string_series"),
+            ),
+            False,
+        ),
+    ],
+)
+def test_find_experiments_by_file_series_values(client, project, run_with_attributes, experiment_filter, found):
+    # given
+    project_identifier = project.project_identifier
+
+    #  when
+    experiment_names = _extract_names(fetch_experiment_sys_attrs(client, project_identifier, experiment_filter))
+
+    # then
+    if found:
+        assert EXPERIMENT_NAME in experiment_names
+    else:
+        assert EXPERIMENT_NAME not in experiment_names
+
+
+@pytest.mark.parametrize(
+    "experiment_filter,found",
+    [
+        # TODO: histogram_series type not supported in nql yet
+        # (
+        #         _Filter.exists(
+        #             _Attribute(name=HISTOGRAM_SERIES_PATHS[0], type="histogram_series"),
+        #         ),
+        #         True,
+        # ),
+        (
+            _Filter.exists(
+                _Attribute(name=HISTOGRAM_SERIES_PATHS[0], type="string_series"),
+            ),
+            False,
+        ),
+    ],
+)
+def test_find_experiments_by_histogram_series_values(client, project, run_with_attributes, experiment_filter, found):
     # given
     project_identifier = project.project_identifier
 

--- a/tests/e2e/internal/test_split.py
+++ b/tests/e2e/internal/test_split.py
@@ -20,7 +20,7 @@ from neptune_fetcher.internal.retrieval.attribute_values import (
 )
 from neptune_fetcher.internal.retrieval.metrics import fetch_multiple_series_values
 from neptune_fetcher.internal.retrieval.series import (
-    StringSeriesValue,
+    SeriesValue,
     fetch_series_values,
 )
 from tests.e2e.conftest import extract_pages
@@ -201,7 +201,7 @@ def test_fetch_string_series_values_retrieval(client, project, experiment_identi
                 RunAttributeDefinition(
                     run_identifier=exp, attribute_definition=AttributeDefinition(key, "string_series")
                 ),
-                [StringSeriesValue(1.0, value, int(NOW.timestamp() * 1000))],
+                [SeriesValue(1.0, value, int(NOW.timestamp() * 1000))],
             )
             for exp in exp_identifiers
             for key, value in attribute_data.items()

--- a/tests/e2e/v1/test_attributes.py
+++ b/tests/e2e/v1/test_attributes.py
@@ -10,7 +10,9 @@ from neptune_fetcher.v1.filters import (
     Filter,
 )
 from tests.e2e.data import (
+    FILE_SERIES_PATHS,
     FLOAT_SERIES_PATHS,
+    HISTOGRAM_SERIES_PATHS,
     PATH,
     STRING_SERIES_PATHS,
     TEST_DATA,
@@ -44,10 +46,14 @@ EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
     [
         (PATH, TEST_DATA.all_attribute_names),
         (f"{PATH}/int-value", {f"{PATH}/int-value"}),
-        (rf"{PATH}/metrics/.*", FLOAT_SERIES_PATHS + [f"{PATH}/metrics/step"] + STRING_SERIES_PATHS),
+        (
+            rf"{PATH}/metrics/.*",
+            FLOAT_SERIES_PATHS + [f"{PATH}/metrics/step"] + STRING_SERIES_PATHS + HISTOGRAM_SERIES_PATHS,
+        ),
         (
             rf"{PATH}/files/.*",
-            {f"{PATH}/files/file-value", f"{PATH}/files/file-value.txt", f"{PATH}/files/object-does-not-exist"},
+            {f"{PATH}/files/file-value", f"{PATH}/files/file-value.txt", f"{PATH}/files/object-does-not-exist"}
+            | set(FILE_SERIES_PATHS),
         ),
         (
             rf"{PATH}/.*-value$",

--- a/tests/e2e/v1/test_fetch_series.py
+++ b/tests/e2e/v1/test_fetch_series.py
@@ -21,7 +21,7 @@ from neptune_fetcher.internal.identifiers import (
     SysId,
 )
 from neptune_fetcher.internal.output_format import create_series_dataframe
-from neptune_fetcher.internal.retrieval.series import StringSeriesValue
+from neptune_fetcher.internal.retrieval.series import SeriesValue
 from neptune_fetcher.v1 import fetch_series
 from neptune_fetcher.v1.filters import (
     AttributeFilter,
@@ -43,7 +43,7 @@ def create_expected_data(
     step_range: Tuple[Optional[int], Optional[int]],
     tail_limit: Optional[int],
 ) -> Tuple[pd.DataFrame, List[str], set[str]]:
-    series_data: dict[RunAttributeDefinition, list[StringSeriesValue]] = {}
+    series_data: dict[RunAttributeDefinition, list[SeriesValue]] = {}
     sys_id_label_mapping: dict[SysId, str] = {}
 
     columns = set()
@@ -69,7 +69,7 @@ def create_expected_data(
                     columns.add(path)
                     filtered_exps.add(experiment.name)
                     filtered.append(
-                        StringSeriesValue(
+                        SeriesValue(
                             step,
                             series[step],
                             int((NOW + timedelta(seconds=int(step))).timestamp()) * 1000,

--- a/tests/unit/internal/test_output_format.py
+++ b/tests/unit/internal/test_output_format.py
@@ -33,7 +33,7 @@ from neptune_fetcher.internal.retrieval.attribute_types import (
 )
 from neptune_fetcher.internal.retrieval.attribute_values import AttributeValue
 from neptune_fetcher.internal.retrieval.metrics import FloatPointValue
-from neptune_fetcher.internal.retrieval.series import StringSeriesValue
+from neptune_fetcher.internal.retrieval.series import SeriesValue
 
 EXPERIMENT_IDENTIFIER = identifiers.RunIdentifier(
     identifiers.ProjectIdentifier("project/abc"), identifiers.SysId("XXX-1")
@@ -406,9 +406,9 @@ def _run_definition(run_id: str, attribute_path: str, attribute_type: str = "str
 def test_create_series_dataframe_with_absolute_timestamp():
     # Given
     series_data = {
-        _run_definition("expid1", "path1"): [StringSeriesValue(1, "aaa", _make_timestamp(2023, 1, 1))],
-        _run_definition("expid1", "path2"): [StringSeriesValue(2, "bbb", _make_timestamp(2023, 1, 3))],
-        _run_definition("expid2", "path1"): [StringSeriesValue(1, "ccc", _make_timestamp(2023, 1, 2))],
+        _run_definition("expid1", "path1"): [SeriesValue(1, "aaa", _make_timestamp(2023, 1, 1))],
+        _run_definition("expid1", "path2"): [SeriesValue(2, "bbb", _make_timestamp(2023, 1, 3))],
+        _run_definition("expid2", "path1"): [SeriesValue(1, "ccc", _make_timestamp(2023, 1, 2))],
     }
     sys_id_label_mapping = {
         SysId("expid1"): "exp1",

--- a/tests/unit/internal/test_output_format.py
+++ b/tests/unit/internal/test_output_format.py
@@ -28,7 +28,10 @@ from neptune_fetcher.internal.output_format import (
 )
 from neptune_fetcher.internal.retrieval.attribute_types import (
     File,
+    FileSeriesAggregations,
     FloatSeriesAggregations,
+    Histogram,
+    HistogramSeriesAggregations,
     StringSeriesAggregations,
 )
 from neptune_fetcher.internal.retrieval.attribute_values import AttributeValue
@@ -138,6 +141,62 @@ def test_convert_experiment_table_to_dataframe_single_string_series():
     # then
     assert dataframe.to_dict() == {
         ("attr1", "last"): {"exp1": "last log"},
+    }
+
+
+def test_convert_experiment_table_to_dataframe_single_histogram_series():
+    # given
+    last_histogram = Histogram(type="COUNTING", edges=list(range(6)), values=list(range(5)))
+    experiment_data = {
+        identifiers.SysName("exp1"): [
+            AttributeValue(
+                AttributeDefinition("attr1", "histogram_series"),
+                HistogramSeriesAggregations(last=last_histogram, last_step=10.0),
+                EXPERIMENT_IDENTIFIER,
+            ),
+        ],
+    }
+
+    # when
+    dataframe = convert_table_to_dataframe(
+        experiment_data,
+        selected_aggregations={
+            AttributeDefinition("attr1", "histogram_series"): {"last"},
+        },
+        type_suffix_in_column_names=False,
+    )
+
+    # then
+    assert dataframe.to_dict() == {
+        ("attr1", "last"): {"exp1": last_histogram},
+    }
+
+
+def test_convert_experiment_table_to_dataframe_single_file_series():
+    # given
+    last_file = File(path="path/to/last/file", size_bytes=1024, mime_type="text/plain")
+    experiment_data = {
+        identifiers.SysName("exp1"): [
+            AttributeValue(
+                AttributeDefinition("attr1", "file_series"),
+                FileSeriesAggregations(last=last_file, last_step=10.0),
+                EXPERIMENT_IDENTIFIER,
+            ),
+        ],
+    }
+
+    # when
+    dataframe = convert_table_to_dataframe(
+        experiment_data,
+        selected_aggregations={
+            AttributeDefinition("attr1", "file_series"): {"last"},
+        },
+        type_suffix_in_column_names=False,
+    )
+
+    # then
+    assert dataframe.to_dict() == {
+        ("attr1", "last"): {"exp1": last_file},
     }
 
 
@@ -403,7 +462,7 @@ def _run_definition(run_id: str, attribute_path: str, attribute_type: str = "str
     )
 
 
-def test_create_series_dataframe_with_absolute_timestamp():
+def test_create_string_series_dataframe_with_absolute_timestamp():
     # Given
     series_data = {
         _run_definition("expid1", "path1"): [SeriesValue(1, "aaa", _make_timestamp(2023, 1, 1))],
@@ -436,6 +495,52 @@ def test_create_series_dataframe_with_absolute_timestamp():
             np.nan,
         ],
         ("path2", "value"): [np.nan, "bbb", np.nan],
+    }
+    expected_df = pd.DataFrame(
+        dict(sorted(expected.items())),
+        index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
+    )
+    pd.testing.assert_frame_equal(df, expected_df)
+
+
+def test_create_histogram_dataframe_with_absolute_timestamp():
+    # Given
+    histograms = [
+        Histogram(type="COUNTING", edges=[1, 2, 3], values=[10, 20]),
+        Histogram(type="COUNTING", edges=[5, 6], values=[100]),
+        Histogram(type="COUNTING", edges=[1, 2, 3], values=[11, 19]),
+    ]
+    series_data = {
+        _run_definition("expid1", "path1"): [SeriesValue(1, histograms[0], _make_timestamp(2023, 1, 1))],
+        _run_definition("expid1", "path2"): [SeriesValue(2, histograms[1], _make_timestamp(2023, 1, 3))],
+        _run_definition("expid2", "path1"): [SeriesValue(1, histograms[2], _make_timestamp(2023, 1, 2))],
+    }
+    sys_id_label_mapping = {
+        SysId("expid1"): "exp1",
+        SysId("expid2"): "exp2",
+    }
+
+    df = create_series_dataframe(
+        series_data=series_data,
+        sys_id_label_mapping=sys_id_label_mapping,
+        index_column_name="experiment",
+        timestamp_column_name="absolute_time",
+    )
+
+    # Then
+    expected = {
+        ("path1", "absolute_time"): [
+            datetime(2023, 1, 1, tzinfo=timezone.utc),
+            np.nan,
+            datetime(2023, 1, 2, tzinfo=timezone.utc),
+        ],
+        ("path1", "value"): [histograms[0], np.nan, histograms[2]],
+        ("path2", "absolute_time"): [
+            np.nan,
+            datetime(2023, 1, 3, tzinfo=timezone.utc),
+            np.nan,
+        ],
+        ("path2", "value"): [np.nan, histograms[1], np.nan],
     }
     expected_df = pd.DataFrame(
         dict(sorted(expected.items())),


### PR DESCRIPTION
towards PY-143

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Unify series value handling by replacing the string‐only representation with a generic SeriesValue type and add support for parsing file and histogram value objects.

New Features:
- Support parsing file and histogram series values in addition to strings.

Enhancements:
- Replace StringSeriesValue with a generic SeriesValue NamedTuple carrying Any value payload.
- Introduce an extraction helper to convert ProtoPointValueDTO into the appropriate Python object based on its field.
- Update type hints and references across retrieval, composition, and output modules to use the new SeriesValue.

Tests:
- Update existing unit and end-to-end tests to reference SeriesValue and validate series retrieval with various value types.