### PR TITLE
[port to v1] fix: fix all dtypes turning into objects after pivot (#335)

### DIFF
--- a/tests/unit/internal/test_output_format.py
+++ b/tests/unit/internal/test_output_format.py
@@ -394,7 +394,7 @@ def test_create_metrics_dataframe_with_absolute_timestamp(type_suffix_in_column_
         index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
     )
 
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 def _run_definition(run_id: str, attribute_path: str, attribute_type: str = "string_series") -> RunAttributeDefinition:
@@ -441,7 +441,7 @@ def test_create_series_dataframe_with_absolute_timestamp():
         dict(sorted(expected.items())),
         index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
     )
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
@@ -501,7 +501,7 @@ def test_create_metrics_dataframe_without_timestamp(type_suffix_in_column_names:
         index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
     )
 
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 def test_create_metrics_dataframe_random_order():
@@ -541,7 +541,7 @@ def test_create_metrics_dataframe_random_order():
         ),
     )
 
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
@@ -686,7 +686,7 @@ def test_create_metrics_dataframe_with_reserved_paths_with_multiindex(
         index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
     )
 
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 @pytest.mark.parametrize(
@@ -737,7 +737,7 @@ def test_create_metrics_dataframe_with_reserved_paths_with_flat_index(path: str,
         index=pd.MultiIndex.from_tuples([("exp1", 1.0), ("exp1", 2.0), ("exp2", 1.0)], names=["experiment", "step"]),
     )
 
-    pd.testing.assert_frame_equal(df, expected_df, check_dtype=False)
+    pd.testing.assert_frame_equal(df, expected_df)
 
 
 def test_create_files_dataframe_empty():


### PR DESCRIPTION
## Summary by Sourcery

Fix dtype preservation for timestamp columns during DataFrame pivoting and simplify pivot logic to avoid object dtype conversion.

Bug Fixes:
- Convert timestamp columns to pandas datetime before pivot to preserve datetime64 dtype.
- Add empty datetime64 column for timestamp when pivoting an empty DataFrame to prevent dtype errors.

Enhancements:
- Refactor pivot logic to rely on pandas multi-index when multiple value columns are present and specify values explicitly for flat indexes.

Tests:
- Remove check_dtype=False in tests to enforce correct dtype comparisons.