### PR TITLE
[port to v1] change internal._Filter.all and any to accept a list (#334)

### DIFF
--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -39,6 +39,10 @@ def resolve_experiments_filter(
 ) -> Optional[_filters._Filter]:
     if isinstance(experiments, str):
         return _filters._Filter.matches_all(_filters._Attribute("sys/name", type="string"), experiments)
+    if experiments == []:
+        # In alpha, passing experiments=[] gives us un-filtered results
+        # In v1, we're going to return no results or raise an error
+        return None
     if isinstance(experiments, list):
         return _filters._Filter.name_in(*experiments)
     if isinstance(experiments, filters.Filter):
@@ -62,6 +66,10 @@ def resolve_attributes_filter(
             return _filters._AttributeFilter()
         if isinstance(attributes, str):
             return _filters._AttributeFilter(name_matches_all=attributes)
+        if attributes == []:
+            # In alpha, passing attributes=[] gives us un-filtered results
+            # In v1, we're going to return no results or raise an error
+            return _filters._AttributeFilter()
         if isinstance(attributes, list):
             return _filters._AttributeFilter(name_eq=attributes)
         if isinstance(attributes, filters.BaseAttributeFilter):
@@ -75,6 +83,10 @@ def resolve_attributes_filter(
             return _filters._AttributeFilter(type_in=forced_type)
         if isinstance(attributes, str):
             return _filters._AttributeFilter(name_matches_all=attributes, type_in=forced_type)
+        if attributes == []:
+            # In alpha, passing attributes=[] gives us un-filtered results
+            # In v1, we're going to return no results or raise an error
+            return _filters._AttributeFilter(type_in=forced_type)
         if isinstance(attributes, list):
             return _filters._AttributeFilter(name_eq=attributes, type_in=forced_type)
         if isinstance(attributes, filters.AttributeFilter):
@@ -111,16 +123,20 @@ def resolve_destination_path(destination: Optional[str]) -> pathlib.Path:
 def resolve_runs_filter(runs: Optional[Union[str, list[str], filters.Filter]]) -> Optional[_filters._Filter]:
     if isinstance(runs, str):
         return _filters._Filter.matches_all(_filters._Attribute("sys/custom_run_id", type="string"), regex=runs)
+    if runs == []:
+        # In alpha, passing runs=[] gives us un-filtered results
+        # In v1, we're going to return no results or raise an error
+        return None
     if isinstance(runs, list):
         return _filters._Filter.any(
-            *[_filters._Filter.eq(_filters._Attribute("sys/custom_run_id", type="string"), value=run) for run in runs]
+            [_filters._Filter.eq(_filters._Attribute("sys/custom_run_id", type="string"), value=run) for run in runs]
         )
     if isinstance(runs, filters.Filter):
         return runs._to_internal()
     if runs is None:
         return None
     raise ValueError(
-        f"Invalid type for `runs` filter. Expected str, list[str], or Filter object, but got {type(runs)}."
+        f"Invalid type for `runs` filter. Expected str, list of str, or Filter object, but got {type(runs)}."
     )
 
 

--- a/src/neptune_fetcher/alpha/filters.py
+++ b/src/neptune_fetcher/alpha/filters.py
@@ -47,6 +47,7 @@ class BaseAttributeFilter(ABC):
     def __or__(self, other: "BaseAttributeFilter") -> "BaseAttributeFilter":
         return BaseAttributeFilter.any(self, other)
 
+    @staticmethod
     def any(*filters: "BaseAttributeFilter") -> "BaseAttributeFilter":
         return _AttributeFilterAlternative(filters=filters)
 
@@ -359,9 +360,8 @@ class Filter(ABC):
             filters = [Filter.name_eq(name) for name in names]
             return Filter.any(*filters)
 
-    @abc.abstractmethod
     def to_query(self) -> str:
-        ...
+        return self._to_internal().to_query()
 
     @abc.abstractmethod
     def _to_internal(self) -> _filters._Filter:
@@ -384,9 +384,6 @@ class _AttributeValuePredicate(Filter):
         if not isinstance(self.value, (bool, int, float, str, datetime)):
             raise TypeError(f"Invalid value type: {type(self.value).__name__}. Expected int, float, str, or datetime.")
 
-    def to_query(self) -> str:
-        return f"{self.attribute} {self.operator} {self._right_query()}"
-
     def _right_query(self) -> str:
         if isinstance(self.value, datetime):
             return f'"{self.value.astimezone().isoformat()}"'
@@ -407,9 +404,6 @@ class _AttributePredicate(Filter):
     postfix_operator: Literal["EXISTS"]
     attribute: Attribute
 
-    def to_query(self) -> str:
-        return f"{self.attribute} {self.postfix_operator}"
-
     def _to_internal(self) -> _filters._Filter:
         return _filters._AttributePredicate(
             postfix_operator=self.postfix_operator,
@@ -422,12 +416,8 @@ class _AssociativeOperator(Filter):
     operator: Literal["AND", "OR"]
     filters: Iterable[Filter]
 
-    def to_query(self) -> str:
-        filter_queries = [f"({child})" for child in self.filters]
-        return f" {self.operator} ".join(filter_queries)
-
     def _to_internal(self) -> _filters._Filter:
-        return _filters._AssociativeOperator(
+        return _AlphaInternalAssociativeOperator(
             operator=self.operator,
             filters=[f._to_internal() for f in self.filters],
         )
@@ -438,11 +428,19 @@ class _PrefixOperator(Filter):
     operator: Literal["NOT"]
     filter_: Filter
 
-    def to_query(self) -> str:
-        return f"{self.operator} ({self.filter_})"
-
     def _to_internal(self) -> _filters._Filter:
         return _filters._PrefixOperator(
             operator=self.operator,
             filter_=self.filter_._to_internal(),
         )
+
+
+class _AlphaInternalAssociativeOperator(_filters._AssociativeOperator):
+    """
+    A version of internal.filters._AssociativeOperator that skips filters validation and allows them to be an empty list
+    """
+
+    def __post_init__(self) -> None:
+        # Only validate the operator as we're allowing empty filters for _AssociativeOperator in alpha
+        allowed_operators = {"AND", "OR"}
+        _validate_allowed_value(self.operator, allowed_operators, "operator")

--- a/src/neptune_fetcher/internal/filters.py
+++ b/src/neptune_fetcher/internal/filters.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import abc
 from abc import ABC
 from dataclasses import (
@@ -45,10 +46,8 @@ AGGREGATION_LITERAL = Literal["last", "min", "max", "average", "variance"]
 
 
 class _BaseAttributeFilter(ABC):
-    def __or__(self, other: "_BaseAttributeFilter") -> "_BaseAttributeFilter":
-        return _BaseAttributeFilter.any(self, other)
-
-    def any(*filters: "_BaseAttributeFilter") -> "_BaseAttributeFilter":
+    @staticmethod
+    def any(filters: list["_BaseAttributeFilter"]) -> "_BaseAttributeFilter":
         return _AttributeFilterAlternative(filters=filters)
 
     @abc.abstractmethod
@@ -82,6 +81,16 @@ class _AttributeFilter(_BaseAttributeFilter):
         name_matches_none (Union[str, list[str], None]): A regular expression or list of expressions that the attribute
             names mustn't match. Attributes matching any of the regexes are excluded.
             If `None`, this filter is not applied.
+        must_match_any (Optional[list[_AttributeNameFilter]]):
+            If `None`, this filter is not applied. Otherwise, it's a list of `_AttributeNameFilter` instances.
+            Each instance specifies a set of regexes that the attribute name must match or not match.
+            Any one of the list items must match for the attribute to be included.
+            Each list item should be an `_AttributeNameFilter` and it can contain:
+                name_matches_all (Union[str, list[str], None]): A list of regular expressions that the attribute
+                    name must match. If `None`, this filter is not applied.
+                name_matches_none (Union[str, list[str], None]): A list of regular expressions that the attribute
+                    names mustn't match. Attributes matching any of the regexes are excluded.
+                    If `None`, this filter is not applied.
         aggregations (list[Literal["last", "min", "max", "average", "variance"]]): List of
             aggregation functions to apply when fetching metrics of type FloatSeries or StringSeries.
             Defaults to ["last"].
@@ -295,7 +304,7 @@ class _Filter(ABC):
             return _AttributeValuePredicate(operator="MATCHES", attribute=attribute, value=regex)
         else:
             filters = [_Filter.matches_all(attribute, r) for r in regex]
-            return _Filter.all(*filters)
+            return _Filter.all(filters)
 
     @staticmethod
     def matches_none(attribute: Union[str, _Attribute], regex: Union[str, list[str]]) -> "_Filter":
@@ -305,7 +314,7 @@ class _Filter(ABC):
             return _AttributeValuePredicate(operator="NOT MATCHES", attribute=attribute, value=regex)
         else:
             filters = [_Filter.matches_none(attribute, r) for r in regex]
-            return _Filter.all(*filters)
+            return _Filter.all(filters)
 
     @staticmethod
     def contains_all(attribute: Union[str, _Attribute], value: Union[str, list[str]]) -> "_Filter":
@@ -315,7 +324,7 @@ class _Filter(ABC):
             return _AttributeValuePredicate(operator="CONTAINS", attribute=attribute, value=value)
         else:
             filters = [_Filter.contains_all(attribute, v) for v in value]
-            return _Filter.all(*filters)
+            return _Filter.all(filters)
 
     @staticmethod
     def contains_none(attribute: Union[str, _Attribute], value: Union[str, list[str]]) -> "_Filter":
@@ -325,7 +334,7 @@ class _Filter(ABC):
             return _AttributeValuePredicate(operator="NOT CONTAINS", attribute=attribute, value=value)
         else:
             filters = [_Filter.contains_none(attribute, v) for v in value]
-            return _Filter.all(*filters)
+            return _Filter.all(filters)
 
     @staticmethod
     def exists(attribute: Union[str, _Attribute]) -> "_Filter":
@@ -334,25 +343,22 @@ class _Filter(ABC):
         return _AttributePredicate(postfix_operator="EXISTS", attribute=attribute)
 
     @staticmethod
-    def all(*filters: "_Filter") -> "_Filter":
+    def all(filters: list["_Filter"]) -> "_Filter":
+        """Combine multiple filters with a logical AND operator."""
+        if not filters or not isinstance(filters, list):
+            raise ValueError("At least one filter must be provided to combine with AND.")
         return _AssociativeOperator(operator="AND", filters=filters)
 
     @staticmethod
-    def any(*filters: "_Filter") -> "_Filter":
+    def any(filters: list["_Filter"]) -> "_Filter":
+        """Combine multiple filters with a logical OR operator."""
+        if not filters or not isinstance(filters, list):
+            raise ValueError("At least one filter must be provided to combine with OR.")
         return _AssociativeOperator(operator="OR", filters=filters)
 
     @staticmethod
     def negate(filter_: "_Filter") -> "_Filter":
         return _PrefixOperator(operator="NOT", filter_=filter_)
-
-    def __and__(self, other: "_Filter") -> "_Filter":
-        return self.all(self, other)
-
-    def __or__(self, other: "_Filter") -> "_Filter":
-        return self.any(self, other)
-
-    def __invert__(self) -> "_Filter":
-        return self.negate(self)
 
     @staticmethod
     def name_eq(name: str) -> "_Filter":
@@ -365,7 +371,7 @@ class _Filter(ABC):
             return _Filter.name_eq(names[0])
         else:
             filters = [_Filter.name_eq(name) for name in names]
-            return _Filter.any(*filters)
+            return _Filter.any(filters)
 
     @abc.abstractmethod
     def to_query(self) -> str:
@@ -412,6 +418,12 @@ class _AttributePredicate(_Filter):
 class _AssociativeOperator(_Filter):
     operator: Literal["AND", "OR"]
     filters: Iterable[_Filter]
+
+    def __post_init__(self) -> None:
+        allowed_operators = {"AND", "OR"}
+        _validate_allowed_value(self.operator, allowed_operators, "operator")
+        if not self.filters:
+            raise ValueError(f"At least one filter must be provided to combine with {self.operator}.")
 
     def to_query(self) -> str:
         filter_queries = [f"({child})" for child in self.filters]

--- a/src/neptune_fetcher/internal/pattern.py
+++ b/src/neptune_fetcher/internal/pattern.py
@@ -82,12 +82,10 @@ def build_extended_regex_filter(attribute: _Attribute, pattern: str) -> _Filter:
     parsed = parse_extended_regex(pattern)
 
     return _Filter.any(
-        *[
+        [
             _Filter.all(
-                *(
-                    [_Filter.matches_all(attribute, pattern) for pattern in conj.positive_patterns]
-                    + [_Filter.matches_none(attribute, pattern) for pattern in conj.negated_patterns]
-                )
+                [_Filter.matches_all(attribute, pattern) for pattern in conj.positive_patterns]
+                + [_Filter.matches_none(attribute, pattern) for pattern in conj.negated_patterns]
             )
             for conj in parsed.children
         ]

--- a/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
+++ b/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
@@ -157,7 +157,7 @@ def _make_new_attribute_definitions_page_params(
 
 
 def _escape_name_eq(names: Optional[list[str]]) -> Optional[list[str]]:
-    if not names:
+    if names is None:
         return None
 
     escaped = [f"{re.escape(name)}" for name in names]

--- a/tests/e2e/internal/composition/test_attributes.py
+++ b/tests/e2e/internal/composition/test_attributes.py
@@ -108,7 +108,7 @@ def test_fetch_attribute_definitions_filter_or(client, executor, project, experi
     attribute_filter_2 = _AttributeFilter(name_matches_all=f"^{re.escape(COMMON_PATH)}/.*_value_b$", type_in=["float"])
 
     #  when
-    attribute_filter = attribute_filter_1 | attribute_filter_2
+    attribute_filter = _AttributeFilter.any([attribute_filter_1, attribute_filter_2])
     attributes = extract_pages(
         fetch_attribute_definitions(
             client,
@@ -132,9 +132,8 @@ def test_fetch_attribute_definitions_filter_or(client, executor, project, experi
 @pytest.mark.parametrize(
     "make_attribute_filter",
     [
-        lambda a, b, c: a | b | c,
-        lambda a, b, c: _AttributeFilter.any(a, b, c),
-        lambda a, b, c: _AttributeFilter.any(a, _AttributeFilter.any(b, c)),
+        lambda a, b, c: _AttributeFilter.any([a, b, c]),
+        lambda a, b, c: _AttributeFilter.any([a, _AttributeFilter.any([b, c])]),
     ],
 )
 def test_fetch_attribute_definitions_filter_triple_or(
@@ -207,7 +206,9 @@ def test_fetch_attribute_definitions_should_deduplicate_items(client, executor, 
     attribute_filter_0 = _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
     attribute_filter = attribute_filter_0
     for i in range(10):
-        attribute_filter = attribute_filter | _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])
+        attribute_filter = _AttributeFilter.any(
+            [attribute_filter, _AttributeFilter(name_matches_all="sys/.*_time", type_in=["datetime"])]
+        )
 
     attributes = extract_pages(
         fetch_attribute_definitions(

--- a/tests/e2e/internal/composition/test_download_files.py
+++ b/tests/e2e/internal/composition/test_download_files.py
@@ -70,9 +70,18 @@ def test_download_files_no_permission(client, project, experiment_identifier, te
     "attributes",
     [
         _AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
-        _AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"])
-        | _AttributeFilter(name_eq=[f"{PATH}/file-value.txt"]),
-        _AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]) | _AttributeFilter(name_eq=[f"{PATH}/int-value"]),
+        _AttributeFilter.any(
+            [
+                _AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
+                _AttributeFilter(name_eq=[f"{PATH}/file-value.txt"]),
+            ]
+        ),
+        _AttributeFilter.any(
+            [
+                _AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
+                _AttributeFilter(name_eq=[f"{PATH}/int-value"]),
+            ]
+        ),
     ],
 )
 def test_download_files_single(client, project, experiment_identifier, temp_dir, attributes):

--- a/tests/e2e/internal/retrieval/test_search.py
+++ b/tests/e2e/internal/retrieval/test_search.py
@@ -305,13 +305,17 @@ def test_find_experiments_by_config_values(client, project, run_with_attributes,
             False,
         ),
         (
-            _Filter.ge(
-                _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
-                _variance(FLOAT_SERIES_VALUES) - 1e-6,
-            )
-            & _Filter.le(
-                _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
-                _variance(FLOAT_SERIES_VALUES) + 1e-6,
+            _Filter.all(
+                [
+                    _Filter.ge(
+                        _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                        _variance(FLOAT_SERIES_VALUES) - 1e-6,
+                    ),
+                    _Filter.le(
+                        _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                        _variance(FLOAT_SERIES_VALUES) + 1e-6,
+                    ),
+                ]
             ),
             True,
         ),
@@ -324,14 +328,18 @@ def test_find_experiments_by_config_values(client, project, run_with_attributes,
         ),
         (
             _Filter.negate(
-                _Filter.ge(
-                    _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
-                    _variance(FLOAT_SERIES_VALUES) - 1e-6,
-                )
-                & _Filter.le(
-                    _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
-                    _variance(FLOAT_SERIES_VALUES) + 1e-6,
-                )
+                _Filter.all(
+                    [
+                        _Filter.ge(
+                            _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                            _variance(FLOAT_SERIES_VALUES) - 1e-6,
+                        ),
+                        _Filter.le(
+                            _Attribute(name=FLOAT_SERIES_PATHS[0], type="float_series", aggregation="variance"),
+                            _variance(FLOAT_SERIES_VALUES) + 1e-6,
+                        ),
+                    ]
+                ),
             ),
             False,
         ),
@@ -392,135 +400,181 @@ def test_find_experiments_by_string_series_values(client, project, run_with_attr
     [
         (
             _Filter.all(
-                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            True,
-        ),
-        (
-            _Filter.all(
-                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            False,
-        ),
-        (
-            _Filter.all(
-                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            False,
-        ),
-        (
-            _Filter.all(
-                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            False,
-        ),
-        (
-            _Filter.any(
-                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            True,
-        ),
-        (
-            _Filter.any(
-                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            True,
-        ),
-        (
-            _Filter.any(
-                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            True,
-        ),
-        (
-            _Filter.any(
-                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-            ),
-            False,
-        ),
-        (
-            _Filter.negate(
-                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-            ),
-            False,
-        ),
-        (
-            _Filter.negate(
-                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-            ),
-            True,
-        ),
-        (
-            _Filter.all(
-                _Filter.any(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
-                _Filter.any(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-                ),
-            ),
-            True,
-        ),
-        (
-            _Filter.all(
-                _Filter.any(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
-                _Filter.any(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
-            ),
-            False,
-        ),
-        (
-            _Filter.any(
-                _Filter.all(
+                [
                     _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
                     _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
-                ),
-                _Filter.all(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
+                ]
+            ),
+            True,
+        ),
+        (
+            _Filter.all(
+                [
+                    _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            False,
+        ),
+        (
+            _Filter.all(
+                [
+                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            False,
+        ),
+        (
+            _Filter.all(
+                [
+                    _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            False,
+        ),
+        (
+            _Filter.any(
+                [
+                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
             ),
             True,
         ),
         (
             _Filter.any(
-                _Filter.all(
+                [
+                    _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            True,
+        ),
+        (
+            _Filter.any(
+                [
                     _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
-                _Filter.all(
-                    _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                    _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                ),
+                    _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            True,
+        ),
+        (
+            _Filter.any(
+                [
+                    _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                    _Filter.ne(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                ]
+            ),
+            False,
+        ),
+        (
+            _Filter.negate(
+                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+            ),
+            False,
+        ),
+        (
+            _Filter.negate(
+                _Filter.ne(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+            ),
+            True,
+        ),
+        (
+            _Filter.all(
+                [
+                    _Filter.any(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                    _Filter.any(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                        ]
+                    ),
+                ]
+            ),
+            True,
+        ),
+        (
+            _Filter.all(
+                [
+                    _Filter.any(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                    _Filter.any(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                ]
+            ),
+            False,
+        ),
+        (
+            _Filter.any(
+                [
+                    _Filter.all(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.0),
+                        ]
+                    ),
+                    _Filter.all(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                ]
+            ),
+            True,
+        ),
+        (
+            _Filter.any(
+                [
+                    _Filter.all(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                    _Filter.all(
+                        [
+                            _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
+                            _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                        ]
+                    ),
+                ]
             ),
             False,
         ),
         (
             _Filter.negate(
                 _Filter.any(
-                    _Filter.all(
-                        _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
-                        _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                    ),
-                    _Filter.all(
-                        _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
-                        _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
-                    ),
+                    [
+                        _Filter.all(
+                            [
+                                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 0),
+                                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                            ]
+                        ),
+                        _Filter.all(
+                            [
+                                _Filter.eq(_Attribute(name=f"{PATH}/int-value", type="int"), 1),
+                                _Filter.eq(_Attribute(name=f"{PATH}/float-value", type="float"), 0.1),
+                            ]
+                        ),
+                    ]
                 )
             ),
             True,

--- a/tests/unit/internal/test_validation.py
+++ b/tests/unit/internal/test_validation.py
@@ -116,12 +116,21 @@ def test_validate_include_time_invalid():
         (_AttributeFilter("a", type_in=["string_series", "float_series"]), "float_series"),
         (_AttributeFilter("a", type_in=["string_series", "float_series"]), "string_series"),
         (
-            _AttributeFilter("a", type_in=["string_series"]) | _AttributeFilter("b", type_in=["string_series"]),
+            _AttributeFilter.any(
+                [
+                    _AttributeFilter("a", type_in=["string_series"]),
+                    _AttributeFilter("b", type_in=["string_series"]),
+                ]
+            ),
             "string_series",
         ),
         (
-            _AttributeFilter("a", type_in=["string_series", "float_series"])
-            | _AttributeFilter("b", type_in=["float_series"]),
+            _AttributeFilter.any(
+                [
+                    _AttributeFilter("a", type_in=["string_series", "float_series"]),
+                    _AttributeFilter("b", type_in=["float_series"]),
+                ]
+            ),
             "float_series",
         ),
     ],
@@ -144,9 +153,20 @@ def test_validate_attribute_filter_type_valid(attribute_filter, type_in):
         (_AttributeFilter("a", type_in=["string_series"]), "float_series"),
         (_AttributeFilter("a", type_in=["float_series"]), "string_series"),
         (_AttributeFilter("a", type_in=["string_series", "float_series"]), "int"),
-        (_AttributeFilter("a", type_in=["float_series"]) | _AttributeFilter(type_in=["string_series"]), "int"),
-        (_AttributeFilter("a", type_in=["int"]) | _AttributeFilter(type_in=["string_series"]), "int"),
-        (_AttributeFilter("a", type_in=["float_series"]) | _AttributeFilter(type_in=["int"]), "int"),
+        (
+            _AttributeFilter.any(
+                [_AttributeFilter("a", type_in=["float_series"]), _AttributeFilter(type_in=["string_series"])]
+            ),
+            "int",
+        ),
+        (
+            _AttributeFilter.any([_AttributeFilter("a", type_in=["int"]), _AttributeFilter(type_in=["string_series"])]),
+            "int",
+        ),
+        (
+            _AttributeFilter.any([_AttributeFilter("a", type_in=["float_series"]), _AttributeFilter(type_in=["int"])]),
+            "int",
+        ),
     ],
 )
 def test_validate_attribute_filter_type_invalid(attribute_filter, type_in):


### PR DESCRIPTION
* Change _Filter.all, _Filter.any and _BaseAttributeFilter.any to accept a list and not VA_ARGS

* Fixes to #334

1. Introduce `_AlphaInternalAssociativeOperator`
2. Make `_BaseAttributeFilter.any` a static method
3. Remove redundant `to_query` methods from `alpha.filters.Filter` subclasses

* [alpha] Handle experiments=[], runs=[] and attributes=[] in the backward compatible way
