### PR TITLE
PY-122 Improve API of Filter

### DIFF
--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -115,7 +115,7 @@ def resolve_sort_by(sort_by: Union[str, filters.Attribute]) -> _filters._Attribu
         return _filters._Attribute(sort_by)
     if isinstance(sort_by, filters.Attribute):
         return sort_by._to_internal()
-    raise ValueError(f"Invalid type for sort_by. Expected str or Attribute object, but got {type(sort_by)}.")
+    raise ValueError(f"Invalid type for `sort_by`. Expected str or Attribute object, but got {type(sort_by)}.")
 
 
 def resolve_destination_path(destination: Optional[str]) -> pathlib.Path:

--- a/src/neptune_fetcher/v1/_internal.py
+++ b/src/neptune_fetcher/v1/_internal.py
@@ -36,14 +36,21 @@ def resolve_experiments_filter(
 ) -> Optional[_filters._Filter]:
     if isinstance(experiments, str):
         return filters.Filter.name(experiments)._to_internal()
+    if experiments == []:
+        raise ValueError(
+            "Invalid type for `experiments` filter. Expected str, non-empty list of str, or Filter object, but got "
+            "an empty list"
+        )
     if isinstance(experiments, list):
-        return filters.Filter.name_in(*experiments)._to_internal()
+        return _filters._Filter.any(
+            [_filters._Filter.eq(_filters._Attribute("sys/name", type="string"), exp) for exp in experiments]
+        )
     if isinstance(experiments, filters.Filter):
         return experiments._to_internal()
     if experiments is None:
         return None
     raise ValueError(
-        "Invalid type for experiments filter. Expected str, list of str, or Filter object, but got "
+        "Invalid type for `experiments` filter. Expected str, non-empty list of str, or Filter object, but got "
         f"{type(experiments)}."
     )
 
@@ -63,16 +70,17 @@ def resolve_attributes_filter(
                 attributes, type_in=list(types.ALL_TYPES)  # type: ignore
             )
         if attributes == []:
-            # In v1, passing attributes=[] gives us un-filtered results
-            # In v1, we're going to return no results or raise an error
-            return _filters._AttributeFilter()
+            raise ValueError(
+                "Invalid type for `attributes` filter. Expected str, non-empty list of str, or AttributeFilter object, "
+                "but got empty list."
+            )
         if isinstance(attributes, list):
             return filters.AttributeFilter(name_eq=attributes)._to_internal()
         if isinstance(attributes, filters.BaseAttributeFilter):
             return attributes._to_internal()
         raise ValueError(
-            "Invalid type for `attributes` filter. Expected str, list of str, or AttributeFilter object, but got "
-            f"{type(attributes)}."
+            "Invalid type for `attributes` filter. Expected str, non-empty list of str, or AttributeFilter object, "
+            f"but got {type(attributes)}."
         )
     else:
         if attributes is None:
@@ -80,9 +88,10 @@ def resolve_attributes_filter(
         if isinstance(attributes, str):
             return _pattern.build_extended_regex_attribute_filter(attributes, type_in=forced_type)
         if attributes == []:
-            # In v1, passing attributes=[] gives us un-filtered results
-            # In v1, we're going to return no results or raise an error
-            return _filters._AttributeFilter(type_in=forced_type)
+            raise ValueError(
+                "Invalid type for `attributes` filter. Expected str, non-empty list of str, or AttributeFilter object, "
+                "but got empty list."
+            )
         if isinstance(attributes, list):
             return filters.AttributeFilter(name_eq=attributes, type_in=forced_type)._to_internal()
         if isinstance(attributes, filters.AttributeFilter):
@@ -97,8 +106,8 @@ def resolve_attributes_filter(
         if isinstance(attributes, filters.BaseAttributeFilter):
             return attributes._to_internal()
         raise ValueError(
-            "Invalid type for `attributes` filter. Expected str, list of str, or AttributeFilter object, but got "
-            f"{type(attributes)}."
+            "Invalid type for `attributes` filter. Expected str, non-empty list of str, or AttributeFilter object, "
+            f"but got {type(attributes)}."
         )
 
 
@@ -107,24 +116,26 @@ def resolve_sort_by(sort_by: Union[str, filters.Attribute]) -> _filters._Attribu
         return _filters._Attribute(sort_by)
     if isinstance(sort_by, filters.Attribute):
         return sort_by._to_internal()
-    raise ValueError(f"Invalid type for sort_by. Expected str or Attribute object, but got {type(sort_by)}.")
+    raise ValueError(f"Invalid type for `sort_by`. Expected str or Attribute object, but got {type(sort_by)}.")
 
 
 def resolve_runs_filter(runs: Optional[Union[str, list[str], filters.Filter]]) -> Optional[_filters._Filter]:
     if isinstance(runs, str):
-        return filters.Filter.matches(
-            filters.Attribute("sys/custom_run_id", type="string"), pattern=runs
-        )._to_internal()
+        return filters.Filter.matches(filters.Attribute("sys/custom_run_id", type="string"), runs)._to_internal()
+    if runs == []:
+        raise ValueError(
+            "Invalid type for `runs` filter. Expected str, non-empty list of str, or Filter object, but got an empty list"
+        )
     if isinstance(runs, list):
-        return filters.Filter.any(
-            *[filters.Filter.eq(filters.Attribute("sys/custom_run_id", type="string"), value=run) for run in runs]
-        )._to_internal()
+        return _filters._Filter.any(
+            [_filters._Filter.eq(_filters._Attribute("sys/custom_run_id", type="string"), run) for run in runs]
+        )
     if isinstance(runs, filters.Filter):
         return runs._to_internal()
     if runs is None:
         return None
     raise ValueError(
-        f"Invalid type for `runs` filter. Expected str, list[str], or Filter object, but got {type(runs)}."
+        f"Invalid type for `runs` filter. Expected str, non-empty list of str, or Filter object, but got {type(runs)}."
     )
 
 

--- a/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
@@ -123,7 +123,7 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
             },
         ),
         (
-            Filter.matches_all("sys/custom_run_id", r"forked_history_root|forked_history_fork1"),
+            Filter.matches("sys/custom_run_id", r"forked_history_root|forked_history_fork1"),
             r".*-value$",
             {
                 "run": ["forked_history_root", "forked_history_fork1"],

--- a/tests/e2e/v1/runs/test_runs_list.py
+++ b/tests/e2e/v1/runs/test_runs_list.py
@@ -21,7 +21,8 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
         ".*",
         None,
         [run.custom_run_id for run in ALL_STATIC_RUNS],
-        Filter.name_in(*[run.experiment_name for run in ALL_STATIC_RUNS]),
+        Filter.name([run.experiment_name for run in ALL_STATIC_RUNS]),
+        Filter.name(" | ".join(run.experiment_name for run in ALL_STATIC_RUNS)),
     ],
 )
 def test_list_all_runs(new_project_id, arg_runs):
@@ -38,7 +39,8 @@ def test_list_all_runs(new_project_id, arg_runs):
     [
         "linear.*",
         [run.custom_run_id for run in LINEAR_HISTORY_TREE],
-        Filter.name_in(*[run.experiment_name for run in LINEAR_HISTORY_TREE]),
+        Filter.name([run.experiment_name for run in LINEAR_HISTORY_TREE]),
+        Filter.name(" | ".join(run.experiment_name for run in LINEAR_HISTORY_TREE)),
         Filter.eq("linear-history", True),
         Filter.eq(Attribute(name="linear-history", type="bool"), True),
         Filter.eq(Attribute(name="linear-history"), True),

--- a/tests/e2e/v1/runs/test_runs_list_attributes.py
+++ b/tests/e2e/v1/runs/test_runs_list_attributes.py
@@ -21,10 +21,10 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
     [
         (".*", ALL_STATIC_RUNS),
         (None, ALL_STATIC_RUNS),
-        (Filter.name_in(*[run.experiment_name for run in ALL_STATIC_RUNS]), ALL_STATIC_RUNS),
+        (Filter.name([run.experiment_name for run in ALL_STATIC_RUNS]), ALL_STATIC_RUNS),
         ([run.custom_run_id for run in ALL_STATIC_RUNS], ALL_STATIC_RUNS),
         ("linear.*", LINEAR_HISTORY_TREE),
-        (Filter.name_in(*[run.experiment_name for run in LINEAR_HISTORY_TREE]), LINEAR_HISTORY_TREE),
+        (Filter.name([run.experiment_name for run in LINEAR_HISTORY_TREE]), LINEAR_HISTORY_TREE),
         (Filter.eq("linear-history", True), LINEAR_HISTORY_TREE),
         (Filter.eq(Attribute(name="linear-history", type="bool"), True), LINEAR_HISTORY_TREE),
     ],

--- a/tests/e2e/v1/test_attributes.py
+++ b/tests/e2e/v1/test_attributes.py
@@ -26,7 +26,7 @@ def _drop_sys_attr_names(attributes: Iterable[str]) -> list[str]:
 
 # Convenience filter to limit searches to experiments belonging to this test,
 # in case the run has some extra experiments.
-EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
+EXPERIMENTS_IN_THIS_TEST = Filter.name(TEST_DATA.experiment_names)
 
 
 @pytest.mark.parametrize(

--- a/tests/e2e/v1/test_experiments.py
+++ b/tests/e2e/v1/test_experiments.py
@@ -27,7 +27,7 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
 @pytest.mark.parametrize("sort_direction", ["asc", "desc"])
 def test__fetch_experiments_table(project, run_with_attributes, sort_direction):
     df = fetch_experiments_table(
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments]),
+        experiments=[exp.name for exp in TEST_DATA.experiments],
         sort_by=Attribute("sys/name", type="string"),
         sort_direction=sort_direction,
         project=project.project_identifier,
@@ -50,12 +50,8 @@ def test__fetch_experiments_table(project, run_with_attributes, sort_direction):
     [
         f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
         [TEST_DATA.exp_name(0), TEST_DATA.exp_name(1), TEST_DATA.exp_name(2)],
-        Filter.name_in(TEST_DATA.exp_name(0), TEST_DATA.exp_name(1), TEST_DATA.exp_name(2)),
-        (
-            Filter.name_eq(TEST_DATA.exp_name(0))
-            | Filter.name_eq(TEST_DATA.exp_name(1))
-            | Filter.name_eq(TEST_DATA.exp_name(2))
-        ),
+        Filter.name(" | ".join([TEST_DATA.exp_name(0), TEST_DATA.exp_name(1), TEST_DATA.exp_name(2)])),
+        (Filter.name(TEST_DATA.exp_name(0)) | Filter.name(TEST_DATA.exp_name(1)) | Filter.name(TEST_DATA.exp_name(2))),
     ],
 )
 @pytest.mark.parametrize(
@@ -124,7 +120,7 @@ def test__fetch_experiments_table_with_attributes_filter_for_metrics(
 ):
     df = fetch_experiments_table(
         project=project.project_identifier,
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        experiments=[exp.name for exp in TEST_DATA.experiments[:3]],
         sort_by=Attribute("sys/name", type="string"),
         sort_direction="asc",
         attributes=attr_filter,
@@ -180,7 +176,7 @@ def test__fetch_experiments_table_with_attributes_filter_for_series(
 ):
     df = fetch_experiments_table(
         project=project.project_identifier,
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:2]]),
+        experiments=[exp.name for exp in TEST_DATA.experiments[:2]],
         sort_by=Attribute("sys/name", type="string"),
         sort_direction="asc",
         attributes=attr_filter,
@@ -214,7 +210,7 @@ def test__fetch_experiments_table_with_attributes_filter_for_series_wrong_aggreg
 ):
     df = fetch_experiments_table(
         project=project.project_identifier,
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:2]]),
+        experiments=[exp.name for exp in TEST_DATA.experiments[:2]],
         sort_by=Attribute("sys/name", type="string"),
         sort_direction="asc",
         attributes=attr_filter,
@@ -240,7 +236,7 @@ def test__fetch_experiments_table_with_attributes_regex_filter_for_metrics(
 ):
     df = fetch_experiments_table(
         project=project.project_identifier,
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        experiments=[exp.name for exp in TEST_DATA.experiments[:3]],
         sort_by=Attribute("sys/name", type="string"),
         sort_direction="asc",
         attributes=attr_filter,
@@ -275,7 +271,7 @@ def test__fetch_experiments_table_with_attributes_regex_filter_for_metrics(
         (".*", TEST_DATA.experiment_names),
         ("", TEST_DATA.experiment_names),
         ("test_alpha", TEST_DATA.experiment_names),
-        (Filter.matches_all(Attribute("sys/name", type="string"), ".*"), TEST_DATA.experiment_names),
+        (Filter.matches(Attribute("sys/name", type="string"), ".*"), TEST_DATA.experiment_names),
     ],
 )
 def test_list_experiments_with_regex_and_filters_matching_all(project, arg_experiments, expected_subset):
@@ -315,15 +311,15 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
     "arg_experiments, expected",
     [
         (Filter.eq(Attribute("sys/name", type="string"), ""), []),
-        (Filter.name_in(*TEST_DATA.experiment_names), TEST_DATA.experiment_names),
+        (TEST_DATA.experiment_names, TEST_DATA.experiment_names),
         (
-            Filter.matches_all(Attribute("sys/name", type="string"), [f"alpha.*{TEST_DATA_VERSION}", "_3"]),
+            Filter.matches(Attribute("sys/name", type="string"), f"alpha.*{TEST_DATA_VERSION} & _3"),
             [f"test_alpha_3" f"_{TEST_DATA_VERSION}"],
         ),
         (TEST_DATA.experiment_names, TEST_DATA.experiment_names),
         (
-            Filter.matches_none(Attribute("sys/name", type="string"), ["alpha_3", "alpha_4", "alpha_5"])
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            Filter.matches(Attribute("sys/name", type="string"), "!alpha_3 & !alpha_4 & !alpha_5")
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [
                 f"test_alpha_0_{TEST_DATA_VERSION}",
                 f"test_alpha_1_{TEST_DATA_VERSION}",
@@ -333,7 +329,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
         (Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_123"), []),
         (
             Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_1")
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_1_{TEST_DATA_VERSION}"],
         ),
         (
@@ -341,36 +337,36 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
                 Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_1")
                 | Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_2")
             )
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_1_{TEST_DATA_VERSION}", f"test_alpha_2_{TEST_DATA_VERSION}"],
         ),
         (
             Filter.ne(Attribute(f"{PATH}/str-value", type="string"), "hello_1")
             & Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_2")
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_2_{TEST_DATA_VERSION}"],
         ),
         (Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 12345), []),
         (
             Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 2)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_2_{TEST_DATA_VERSION}"],
         ),
         (
             Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 2)
             | Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 3)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_2_{TEST_DATA_VERSION}", f"test_alpha_3_{TEST_DATA_VERSION}"],
         ),
         (Filter.eq(Attribute(f"{PATH}/float-value", type="float"), 1.2345), []),
         (
             Filter.eq(Attribute(f"{PATH}/float-value", type="float"), 3)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_3_{TEST_DATA_VERSION}"],
         ),
         (
             Filter.eq(Attribute(f"{PATH}/bool-value", type="bool"), False)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [
                 f"test_alpha_1_{TEST_DATA_VERSION}",
                 f"test_alpha_3_{TEST_DATA_VERSION}",
@@ -379,7 +375,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
         ),
         (
             Filter.eq(Attribute(f"{PATH}/bool-value", type="bool"), True)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [
                 f"test_alpha_0_{TEST_DATA_VERSION}",
                 f"test_alpha_2_{TEST_DATA_VERSION}",
@@ -393,7 +389,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
         ),
         (
             Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), ["string-1-0", "string-1-1"])
-            & Filter.matches_all(Attribute("sys/name", type="string"), TEST_DATA_VERSION),
+            & Filter.matches(Attribute("sys/name", type="string"), TEST_DATA_VERSION),
             [f"test_alpha_1_{TEST_DATA_VERSION}"],
         ),
         (
@@ -401,7 +397,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
                 Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "string-1-0")
                 | Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "string-0-0")
             )
-            & Filter.matches_all(Attribute("sys/name", type="string"), TEST_DATA_VERSION),
+            & Filter.matches(Attribute("sys/name", type="string"), TEST_DATA_VERSION),
             [f"test_alpha_0_{TEST_DATA_VERSION}", f"test_alpha_1_{TEST_DATA_VERSION}"],
         ),
         (
@@ -409,7 +405,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
                 Attribute(f"{PATH}/string_set-value", type="string_set"),
                 ["string-1-0", "string-2-0", "string-3-0"],
             )
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [
                 f"test_alpha_0_{TEST_DATA_VERSION}",
                 f"test_alpha_4_{TEST_DATA_VERSION}",
@@ -422,14 +418,14 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
                 ["string-1-0", "string-2-0", "string-3-0"],
             )
             & Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "string-0-0")
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_0_{TEST_DATA_VERSION}"],
         ),
         (
             Filter.eq(Attribute("sys/name", type="string"), f"test_alpha_0_{TEST_DATA_VERSION}"),
             [f"test_alpha_0_{TEST_DATA_VERSION}"],
         ),
-        # (     TODO - FILE nto supported in nql
+        # (     TODO - FILE not supported in nql
         #     Filter.exists(Attribute(f"{PATH}/files/file-value.txt", type="file")),
         #     [f"test_experiment_0_{TEST_DATA_VERSION}"],
         # ),
@@ -442,3 +438,13 @@ def test_list_experiments_with_filter_matching_some(project, arg_experiments, ex
     )
     assert set(names) == set(expected)
     assert len(names) == len(expected)
+
+
+def test_empty_experiment_list(project):
+    """Test the behavior of filtering by experiments=[]
+
+    In alpha, this used to return all experiments, but in v1 it will raises an error
+    """
+
+    with pytest.raises(ValueError, match="got an empty list"):
+        list_experiments(project=project, experiments=[])

--- a/tests/e2e/v1/test_fetch_metrics.py
+++ b/tests/e2e/v1/test_fetch_metrics.py
@@ -116,8 +116,9 @@ def create_expected_data(
 @pytest.mark.parametrize(
     "arg_experiments",
     [
-        Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        Filter.name([exp.name for exp in TEST_DATA.experiments[:3]]),
         f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
+        f"{TEST_DATA.exp_name(0)} | {TEST_DATA.exp_name(1)} | {TEST_DATA.exp_name(2)}",  # ERS
         [exp.name for exp in TEST_DATA.experiments[:3]],
     ],
 )

--- a/tests/e2e/v1/test_fetch_series.py
+++ b/tests/e2e/v1/test_fetch_series.py
@@ -109,8 +109,9 @@ def create_expected_data(
 @pytest.mark.parametrize(
     "arg_experiments",
     [
-        Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        Filter.name([exp.name for exp in TEST_DATA.experiments[:3]]),
         f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
+        f"{TEST_DATA.exp_name(0)} | {TEST_DATA.exp_name(1)} | {TEST_DATA.exp_name(2)}",  # ERS
         [exp.name for exp in TEST_DATA.experiments[:3]],
     ],
 )


### PR DESCRIPTION
## Summary by Sourcery

Improve the Filter API by introducing a unified name/regex interface, consolidating matching logic, enhancing logical operators, enforcing non-empty list validation, and updating downstream resolution and test cases accordingly.

New Features:
- Add Filter.name method to support filtering by single or multiple experiment names using regex or explicit lists

Bug Fixes:
- Raise ValueError when empty lists are provided to experiments, runs, or attributes filters

Enhancements:
- Unify regex matching into a single Filter.matches method and deprecate matches_all/matches_none
- Replace static logical combinators (all/any/negate) with operator overloads (&, |, ~) backed by internal filters
- Streamline resolve_* functions to enforce non-empty list arguments and use internal _filters._Filter.any/all for list inputs

Tests:
- Update tests to use new Filter.name and Filter.matches APIs and direct string lists for experiments
- Add end-to-end test for empty experiments list error