### PR TITLE
PY-122 Improve API of AttributeFilter

### DIFF
--- a/src/neptune_fetcher/internal/pattern.py
+++ b/src/neptune_fetcher/internal/pattern.py
@@ -22,6 +22,7 @@ from neptune_fetcher.internal.filters import (
     _AttributeFilter,
     _AttributeNameFilter,
     _Filter,
+    AGGREGATION_LITERAL,
 )
 
 _WS_PATTERN = re.compile(r"[ \t\r\n]")
@@ -92,7 +93,11 @@ def build_extended_regex_filter(attribute: _Attribute, pattern: str) -> _Filter:
     )
 
 
-def build_extended_regex_attribute_filter(pattern: str, type_in: list[ATTRIBUTE_LITERAL]) -> _AttributeFilter:
+def build_extended_regex_attribute_filter(
+    pattern: str,
+    type_in: list[ATTRIBUTE_LITERAL] | None = None,
+    aggregations: list[AGGREGATION_LITERAL] | None = None,
+) -> _AttributeFilter:
     parsed = parse_extended_regex(pattern)
 
     return _AttributeFilter(
@@ -104,4 +109,5 @@ def build_extended_regex_attribute_filter(pattern: str, type_in: list[ATTRIBUTE_
             )
             for conj in parsed.children
         ],
+        aggregations=["last"] if aggregations is None else aggregations,
     )

--- a/src/neptune_fetcher/v1/_internal.py
+++ b/src/neptune_fetcher/v1/_internal.py
@@ -75,7 +75,7 @@ def resolve_attributes_filter(
                 "but got empty list."
             )
         if isinstance(attributes, list):
-            return filters.AttributeFilter(name_eq=attributes)._to_internal()
+            return _filters._AttributeFilter(name_eq=attributes)
         if isinstance(attributes, filters.BaseAttributeFilter):
             return attributes._to_internal()
         raise ValueError(
@@ -93,12 +93,10 @@ def resolve_attributes_filter(
                 "but got empty list."
             )
         if isinstance(attributes, list):
-            return filters.AttributeFilter(name_eq=attributes, type_in=forced_type)._to_internal()
+            return _filters._AttributeFilter(name_eq=attributes, type_in=forced_type)
         if isinstance(attributes, filters.AttributeFilter):
             modified_attributes = filters.AttributeFilter(
-                name_eq=attributes.name_eq,
-                name_matches_all=attributes.name_matches_all,
-                name_matches_none=attributes.name_matches_none,
+                name=attributes.name,
                 type_in=forced_type,
                 aggregations=attributes.aggregations,
             )
@@ -124,7 +122,8 @@ def resolve_runs_filter(runs: Optional[Union[str, list[str], filters.Filter]]) -
         return filters.Filter.matches(filters.Attribute("sys/custom_run_id", type="string"), runs)._to_internal()
     if runs == []:
         raise ValueError(
-            "Invalid type for `runs` filter. Expected str, non-empty list of str, or Filter object, but got an empty list"
+            "Invalid type for `runs` filter. Expected str, non-empty list of str, or Filter object, "
+            "but got an empty list"
         )
     if isinstance(runs, list):
         return _filters._Filter.any(

--- a/src/neptune_fetcher/v1/filters.py
+++ b/src/neptune_fetcher/v1/filters.py
@@ -28,7 +28,6 @@ from typing import (
 
 from neptune_fetcher.internal import filters as _filters
 from neptune_fetcher.internal import pattern as _pattern
-from neptune_fetcher.internal.filters import _AttributeNameFilter
 from neptune_fetcher.internal.retrieval import attribute_types as types
 from neptune_fetcher.internal.util import (
     _validate_allowed_value,
@@ -64,17 +63,13 @@ class AttributeFilter(BaseAttributeFilter):
     Use to select specific metrics or other metadata based on various criteria.
 
     Args:
-        name_eq (Union[str, list[str], None]): An attribute name or list of names to match exactly.
-            If `None`, this filter is not applied.
+        name (str|list[str], optional):
+            if str given: an extended regular expression to match attribute names.
+            if list[str] given: a list of attribute names to match exactly.
         type_in (list[Literal["float", "int", "string", "bool", "datetime", "float_series", "string_set",
         "string_series", "file"]]):
             A list of allowed attribute types. Defaults to all available types.
             For a reference, see: https://docs.neptune.ai/attribute_types
-        name_matches_all (Union[str, list[str], None]): A regular expression or list of expressions that the attribute
-            name must match. If `None`, this filter is not applied.
-        name_matches_none (Union[str, list[str], None]): A regular expression or list of expressions that the attribute
-            names mustn't match. Attributes matching any of the regexes are excluded.
-            If `None`, this filter is not applied.
         aggregations (list[Literal["last", "min", "max", "average", "variance"]]): List of
             aggregation functions to apply when fetching metrics of type FloatSeries or StringSeries.
             Defaults to ["last"].
@@ -88,7 +83,7 @@ class AttributeFilter(BaseAttributeFilter):
 
     loss_avg_and_var = AttributeFilter(
         type_in=["float_series"],
-        name_matches_all=[r"loss$"],
+        name="loss$",
         aggregations=["average", "variance"],
     )
 
@@ -96,39 +91,44 @@ class AttributeFilter(BaseAttributeFilter):
     ```
     """
 
-    name_eq: Union[str, list[str], None] = None
+    name: Union[str, list[str], None] = None
     type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(types.ALL_TYPES))  # type: ignore
-    name_matches_all: Union[str, list[str], None] = None
-    name_matches_none: Union[str, list[str], None] = None
     aggregations: list[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
 
     def __post_init__(self) -> None:
-        _validate_string_or_string_list(self.name_eq, "name_eq")
-        _validate_string_or_string_list(self.name_matches_all, "name_matches_all")
-        _validate_string_or_string_list(self.name_matches_none, "name_matches_none")
-
+        _validate_string_or_string_list(self.name, "name")
         _validate_list_of_allowed_values(self.type_in, types.ALL_TYPES, "type_in")  # type: ignore
         _validate_list_of_allowed_values(self.aggregations, types.ALL_AGGREGATIONS, "aggregations")  # type: ignore
 
     def _to_internal(self) -> _filters._AttributeFilter:
-        matches_all = [self.name_matches_all] if isinstance(self.name_matches_all, str) else self.name_matches_all
-        matches_none = [self.name_matches_none] if isinstance(self.name_matches_none, str) else self.name_matches_none
+        if isinstance(self.name, str):
+            return _pattern.build_extended_regex_attribute_filter(
+                self.name,
+                type_in=self.type_in,
+                aggregations=self.aggregations,
+            )
 
-        if matches_all is not None or matches_none is not None:
-            must_match_any = [
-                _AttributeNameFilter(
-                    must_match_regexes=matches_all,
-                    must_not_match_regexes=matches_none,
-                )
-            ]
-        else:
-            must_match_any = None
+        if self.name is None:
+            return _filters._AttributeFilter(
+                type_in=self.type_in,
+                aggregations=self.aggregations,
+            )
 
-        return _filters._AttributeFilter(
-            name_eq=self.name_eq,
-            type_in=self.type_in,
-            must_match_any=must_match_any,
-            aggregations=self.aggregations,
+        if self.name == []:
+            raise ValueError(
+                "Invalid type for `name` attribute. Expected str, non-empty list of str, or None, but got empty list."
+            )
+
+        if isinstance(self.name, list):
+            return _filters._AttributeFilter.name_eq(
+                name=self.name,
+                type_in=self.type_in,
+                aggregations=self.aggregations,
+            )
+
+        raise ValueError(
+            "Invalid type for `name` attribute. Expected str, non-empty list of str, or None, but got "
+            f"{type(self.name)}."
         )
 
 

--- a/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
@@ -51,7 +51,7 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
         ),
         (
             r"^linear_history_root$",
-            AttributeFilter(name_matches_all=r"foo0$", aggregations=["last", "min", "max", "average", "variance"]),
+            AttributeFilter(name=r"foo0$", aggregations=["last", "min", "max", "average", "variance"]),
             {
                 "run": ["linear_history_root"],
                 ("foo0:float_series", "last"): [0.1 * 9],
@@ -63,8 +63,8 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
         ),
         (
             "^linear_history_root$",
-            AttributeFilter(name_matches_all="foo0$", aggregations=["last", "min", "max", "average", "variance"])
-            | AttributeFilter(name_matches_all=".*-value$"),
+            AttributeFilter(name="foo0$", aggregations=["last", "min", "max", "average", "variance"])
+            | AttributeFilter(name=".*-value$"),
             {
                 "run": ["linear_history_root"],
                 ("int-value:int", ""): [1],
@@ -81,7 +81,7 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
         ),
         (
             r"^linear_history_root$|^linear_history_fork2$",
-            AttributeFilter(name_matches_all=r"foo0$", aggregations=["last", "variance"]),
+            AttributeFilter(name=r"foo0$", aggregations=["last", "variance"]),
             {
                 "run": ["linear_history_root", "linear_history_fork2"],
                 ("foo0:float_series", "last"): [0.1 * 9, 0.7 * 19],
@@ -95,7 +95,7 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
         ),
         (
             ["linear_history_root", "linear_history_fork2"],
-            AttributeFilter(name_matches_all=r"foo0$", aggregations=["last", "variance"]),
+            AttributeFilter(name=r"foo0$", aggregations=["last", "variance"]),
             {
                 "run": ["linear_history_root", "linear_history_fork2"],
                 ("foo0:float_series", "last"): [0.1 * 9, 0.7 * 19],

--- a/tests/e2e/v1/runs/test_runs_list_attributes.py
+++ b/tests/e2e/v1/runs/test_runs_list_attributes.py
@@ -44,11 +44,11 @@ def test_list_attributes(new_project_id, arg_runs, expected):
     "_attr_filter, expected",
     [
         # DateTime attributes
-        (AttributeFilter(name_eq="datetime-value", type_in=["datetime"]), {"datetime-value"}),
+        (AttributeFilter(name="datetime-value", type_in=["datetime"]), {"datetime-value"}),
         # Numeric series
-        (AttributeFilter(name_eq="unique1/0", type_in=["float_series"]), {"unique1/0"}),
-        (AttributeFilter(name_eq="foo0", type_in=["float_series"]), {"foo0"}),
-        (AttributeFilter(name_eq="foo1", type_in=["float_series"]), {"foo1"}),
+        (AttributeFilter(name="unique1/0", type_in=["float_series"]), {"unique1/0"}),
+        (AttributeFilter(name="foo0", type_in=["float_series"]), {"foo0"}),
+        (AttributeFilter(name="foo1", type_in=["float_series"]), {"foo1"}),
         # Primitive types
         (AttributeFilter(type_in=["int"]), {"int-value"}),
         (AttributeFilter(type_in=["float"]), {"float-value"}),
@@ -57,14 +57,13 @@ def test_list_attributes(new_project_id, arg_runs, expected):
         # Multiple types
         (AttributeFilter(type_in=["float", "int"]), {"float-value", "int-value"}),
         # Name patterns
-        (AttributeFilter(name_matches_all="unique.*"), {"unique1/0", "unique2/0"}),
-        (AttributeFilter(name_matches_all="foo.*"), {"foo0", "foo1"}),
+        (AttributeFilter(name="unique.*"), {"unique1/0", "unique2/0"}),
+        (AttributeFilter(name="foo.*"), {"foo0", "foo1"}),
         # Combined filters
-        (AttributeFilter(name_matches_all=".*value.*", type_in=["float"]), {"float-value"}),
-        (AttributeFilter(name_matches_all=".*value.*", type_in=["int"]), {"int-value"}),
+        (AttributeFilter(name=".*value.*", type_in=["float"]), {"float-value"}),
+        (AttributeFilter(name=".*value.*", type_in=["int"]), {"int-value"}),
         (
-            AttributeFilter(name_matches_all=".*value.*", type_in=["float"])
-            | AttributeFilter(name_matches_all=".*value.*", type_in=["int"]),
+            AttributeFilter(name=".*value.*", type_in=["float"]) | AttributeFilter(name=".*value.*", type_in=["int"]),
             {"float-value", "int-value"},
         ),
     ],

--- a/tests/e2e/v1/test_attributes.py
+++ b/tests/e2e/v1/test_attributes.py
@@ -62,13 +62,14 @@ EXPERIMENTS_IN_THIS_TEST = Filter.name(TEST_DATA.experiment_names)
             },
         ),
         (rf"{PATH}/unique-value-[0-9]", {f"{PATH}/unique-value-{i}" for i in range(6)}),
-        (AttributeFilter(name_matches_all=PATH), TEST_DATA.all_attribute_names),
-        (AttributeFilter(name_eq=f"{PATH}/float-value"), {f"{PATH}/float-value"}),
+        (AttributeFilter(name=PATH), TEST_DATA.all_attribute_names),
+        (AttributeFilter(name=f"{PATH}/float-value"), {f"{PATH}/float-value"}),
         (
-            AttributeFilter.any(AttributeFilter(name_matches_all="^(foo)"), AttributeFilter(name_matches_all=PATH)),
+            AttributeFilter.any(AttributeFilter(name="^(foo)"), AttributeFilter(name=PATH)),
             TEST_DATA.all_attribute_names,
         ),
-        (AttributeFilter(name_matches_none=".*"), []),
+        (AttributeFilter(name=f"^(foo) | {PATH}"), TEST_DATA.all_attribute_names),  # ERS
+        (AttributeFilter(name="!.*"), []),
     ],
 )
 def test_list_attributes_known_in_all_experiments_with_name_filter_excluding_sys(
@@ -90,7 +91,7 @@ def test_list_attributes_known_in_all_experiments_with_name_filter_excluding_sys
         None,
         "",
         ".*",
-        AttributeFilter(name_matches_all=".*"),
+        AttributeFilter(name=".*"),
         AttributeFilter(),
     ),
 )
@@ -107,8 +108,7 @@ def test_list_attributes_all_names_from_all_experiments_excluding_sys(name_filte
         ".*unknown.*",
         "sys/abcdef",
         "\\x20",
-        AttributeFilter(name_eq=".*"),
-        AttributeFilter(name_matches_all="unknown"),
+        AttributeFilter(name="unknown"),
     ),
 )
 def test_list_attributes_unknown_name(filter_):
@@ -149,12 +149,12 @@ def test_list_attributes_unknown_name(filter_):
         ),
         (
             Filter.gt(Attribute(f"{PATH}/int-value", type="int"), 1234) & EXPERIMENTS_IN_THIS_TEST,
-            AttributeFilter(name_matches_none="sys/.*", name_matches_all=".*"),
+            AttributeFilter(name="!sys/.* & .*"),
             [],
         ),
         (
             Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_12345") & EXPERIMENTS_IN_THIS_TEST,
-            AttributeFilter(name_matches_none="sys/.*", name_matches_all=".*"),
+            AttributeFilter(name="!sys/.* & .*"),
             [],
         ),
         (
@@ -191,7 +191,8 @@ def test_list_attributes_depending_on_values_in_experiments(arg_experiments, arg
             {"sys/name", "sys/id"},
         ),
         (r"sys/.*id$", {"sys/custom_run_id", "sys/id", "sys/diagnostics/project_uuid", "sys/diagnostics/run_uuid"}),
-        (AttributeFilter(name_matches_all=r"sys/(name|id)"), {"sys/name", "sys/id"}),
+        (AttributeFilter(name="sys/(name|id)"), {"sys/name", "sys/id"}),
+        (AttributeFilter(name="sys/name | sys/id"), {"sys/name", "sys/id"}),  # ERS
     ],
 )
 def test_list_attributes_sys_attrs(attribute_filter, expected):

--- a/tests/e2e/v1/test_experiments.py
+++ b/tests/e2e/v1/test_experiments.py
@@ -223,11 +223,8 @@ def test__fetch_experiments_table_with_attributes_filter_for_series_wrong_aggreg
 @pytest.mark.parametrize(
     "attr_filter",
     [
-        AttributeFilter(name_matches_all=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}"),
-        AttributeFilter(
-            name_matches_all=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}",
-            name_matches_none=".*value_[5-9].*",
-        ),
+        AttributeFilter(name=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}"),
+        AttributeFilter(name=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]} & !.*value_[5-9].*"),
         f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}",
     ],
 )

--- a/tests/e2e/v1/test_fetch_metrics.py
+++ b/tests/e2e/v1/test_fetch_metrics.py
@@ -106,11 +106,11 @@ def create_expected_data(
 @pytest.mark.parametrize(
     "arg_attributes",
     [
-        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]),
+        AttributeFilter(name=r".*/metrics/.*", type_in=["float_series"]),
         ".*/metrics/.*",
         # Alternative should work too, see bug PY-137
-        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"])
-        | AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]),
+        AttributeFilter(name=r".*/metrics/.*", type_in=["float_series"])
+        | AttributeFilter(name=r".*/metrics/.*", type_in=["float_series"]),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/e2e/v1/test_fetch_series.py
+++ b/tests/e2e/v1/test_fetch_series.py
@@ -100,10 +100,9 @@ def create_expected_data(
 @pytest.mark.parametrize(
     "arg_attributes",
     [
-        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["string_series"]),
+        AttributeFilter(name=r".*/metrics/.*", type_in=["string_series"]),
         ".*/metrics/.*",
-        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["string_series"])
-        | AttributeFilter(name_matches_all=[".*/int-value"]),
+        AttributeFilter(name=r".*/metrics/.*", type_in=["string_series"]) | AttributeFilter(name=".*/int-value"),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/unit/v1/test_split.py
+++ b/tests/unit/v1/test_split.py
@@ -54,7 +54,7 @@ def test_list_attributes_patched(sys_id_length, exp_count, expected_calls):
         npt.list_attributes(
             project=project,
             experiments="ignored",
-            attributes=AttributeFilter(name_eq="ignored"),
+            attributes=AttributeFilter(name="ignored"),
         )
 
     # then
@@ -145,7 +145,7 @@ def test_fetch_experiments_table_patched(sys_id_length, exp_count, attr_name_len
         npt.fetch_experiments_table(
             project=project,
             experiments="ignored",
-            attributes=AttributeFilter(name_eq="ignored"),
+            attributes=AttributeFilter(name="ignored"),
         )
 
     # then
@@ -223,7 +223,7 @@ def test_fetch_series_patched(sys_id_length, exp_count, attr_name_length, attr_c
         npt.fetch_series(
             project=project,
             experiments="ignored",
-            attributes=AttributeFilter(name_eq="ignored"),
+            attributes=AttributeFilter(name="ignored"),
         )
 
     # then
@@ -301,7 +301,7 @@ def test_fetch_metrics_patched(sys_id_length, exp_count, attr_name_length, attr_
         npt.fetch_metrics(
             project=project,
             experiments="ignored",
-            attributes=AttributeFilter(name_eq="ignored"),
+            attributes=AttributeFilter(name="ignored"),
         )
 
     # then


### PR DESCRIPTION
## Summary by Sourcery

Consolidate and simplify the attribute filter API by replacing separate `name_eq`, `name_matches_all`, and `name_matches_none` parameters with a single `name` field that supports extended regex strings or exact name lists; update internal filter construction and pattern builder to handle the unified `name`, enforce validation on empty inputs, and adapt tests to the new interface and regex syntax.

Bug Fixes:
- Add error handling for empty list inputs in `name` and `runs` filters to prevent invalid usage

Enhancements:
- Unify all name‐based filtering parameters into a single `name` property accepting either a regex string with extended syntax or a list of exact names
- Refactor `AttributeFilter._to_internal` to choose between building extended regex filters, exact‐match filters, or default filters based on the `name` value
- Extend `build_extended_regex_attribute_filter` to accept optional `type_in` and `aggregations` arguments
- Streamline `resolve_attributes_filter` to directly use `_filters._AttributeFilter` constructors for list and filter inputs

Tests:
- Update e2e and unit tests to replace old name parameters with the new `name` field and cover exclusion (`!`), conjunction (`&`), and combined regex scenarios