### PR TITLE
Ms/async version (wrong - uses AsyncGenerators)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ pattern = "default-unprefixed"
 python = "^3.9"
 
 # Base neptune package
-neptune-api = "^0.15.0"
+neptune-api = { git = "https://github.com/neptune-ai/neptune-api.git", branch = "ms/a-version" }
 azure-storage-blob = "^12.7.0"
 pandas = { version = ">=1.4.0" }
 

--- a/src/neptune_fetcher/alpha/internal/composition/attribute_components.py
+++ b/src/neptune_fetcher/alpha/internal/composition/attribute_components.py
@@ -117,7 +117,7 @@ def fetch_attribute_definitions_complete(
         )
     else:
         return concurrency.generate_concurrently(
-            items=search.fetch_sys_ids(
+            items=search.fetch_experiment_sys_ids(
                 client=client,
                 project_identifier=project_identifier,
                 filter_=filter_,

--- a/src/neptune_fetcher/alpha/internal/composition/download_files.py
+++ b/src/neptune_fetcher/alpha/internal/composition/download_files.py
@@ -12,14 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import os
 import pathlib
-from typing import (
-    Generator,
-    Optional,
-)
+from typing import Optional
 
 import pandas as pd
+import requests
+from azure.core.pipeline.transport._requests_asyncio import AsyncioRequestsTransport
 
 from neptune_fetcher.alpha.filters import (
     AttributeFilter,
@@ -31,10 +31,7 @@ from neptune_fetcher.alpha.internal import (
     output_format,
 )
 from neptune_fetcher.alpha.internal.composition import attribute_components as _components
-from neptune_fetcher.alpha.internal.composition import (
-    concurrency,
-    type_inference,
-)
+from neptune_fetcher.alpha.internal.composition import type_inference
 from neptune_fetcher.alpha.internal.context import (
     Context,
     get_context,
@@ -61,94 +58,83 @@ def download_files(
 
     _ensure_write_access(destination)
 
-    with (
-        concurrency.create_thread_pool_executor() as executor,
-        concurrency.create_thread_pool_executor() as fetch_attribute_definitions_executor,
-    ):
-        type_inference.infer_attribute_types_in_filter(
+    type_inference.infer_attribute_types_in_filter(
+        client=client,
+        project_identifier=project,
+        filter_=filter_,
+        container_type=container_type,
+    )
+
+    if "file" in attributes.type_in:
+        attributes.type_in = ["file"]
+    else:
+        raise ValueError("Only file attributes are supported for file download.")
+
+    async def go(
+        transport: AsyncioRequestsTransport,
+    ) -> tuple[
+        dict[identifiers.SysId, str],
+        list[tuple[identifiers.RunIdentifier, attribute_definitions.AttributeDefinition, Optional[pathlib.Path]]],
+    ]:
+        sys_id_label_mapping: dict[identifiers.SysId, str] = {}
+        file_list: list[
+            tuple[identifiers.RunIdentifier, attribute_definitions.AttributeDefinition, Optional[pathlib.Path]]
+        ] = []
+
+        async for sys_ids_page in search.fetch_sys_id_labels(container_type)(
             client=client,
             project_identifier=project,
             filter_=filter_,
-            container_type=container_type,
-        )
+        ):
+            sys_ids = []
+            for item in sys_ids_page.items:
+                sys_id_label_mapping[item.sys_id] = item.label
+                sys_ids.append(item.sys_id)
 
-        if "file" in attributes.type_in:
-            attributes.type_in = ["file"]
-        else:
-            raise ValueError("Only file attributes are supported for file download.")
-
-        sys_id_label_mapping: dict[identifiers.SysId, str] = {}
-
-        def go_fetch_sys_attrs() -> Generator[list[identifiers.SysId], None, None]:
-            for page in search.fetch_sys_id_labels(container_type)(
-                client=client,
-                project_identifier=project,
-                filter_=filter_,
-            ):
-                sys_ids = []
-                for item in page.items:
-                    sys_id_label_mapping[item.sys_id] = item.label
-                    sys_ids.append(item.sys_id)
-                yield sys_ids
-
-        output = concurrency.generate_concurrently(
-            items=go_fetch_sys_attrs(),
-            executor=executor,
-            downstream=lambda sys_ids: _components.fetch_attribute_definition_aggregations_split(
+            # todo: each split in parallel
+            async for sys_ids_split, definitions_page in _components.fetch_attribute_definitions_split(
                 client=client,
                 project_identifier=project,
                 attribute_filter=attributes,
-                executor=executor,
-                fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
                 sys_ids=sys_ids,
-                downstream=lambda sys_ids_split, definitions_page, _: _components.fetch_attribute_values_split(
+            ):
+                # todo: each split in parallel
+                async for values_page in _components.fetch_attribute_values_split(
                     client=client,
                     project_identifier=project,
-                    executor=executor,
                     sys_ids=sys_ids_split,
                     attribute_definitions=definitions_page.items,
-                    downstream=lambda values_page: concurrency.generate_concurrently(
-                        items=(
-                            (value, file_)
-                            for value, file_ in zip(
-                                values_page.items,
-                                files.fetch_signed_urls(
-                                    client=client,
-                                    project_identifier=project,
-                                    file_paths=[value.value.path for value in values_page.items],
-                                ),
-                            )
-                        ),
-                        executor=executor,
-                        downstream=lambda run_file_tuple: concurrency.return_value(
-                            (
-                                run_file_tuple[0].run_identifier,
-                                run_file_tuple[0].attribute_definition,
-                                files.download_file_retry(
-                                    client=client,
-                                    project_identifier=project,
-                                    signed_file=run_file_tuple[1],
-                                    target_path=files.create_target_path(
-                                        destination=destination,
-                                        experiment_name=sys_id_label_mapping[run_file_tuple[0].run_identifier.sys_id],
-                                        attribute_path=run_file_tuple[0].attribute_definition.name,
-                                    ),
-                                ),
-                            )
-                        ),
-                    ),
-                ),
-            ),
-        )
+                ):
+                    signed_files = await files.fetch_signed_urls(
+                        client=client,
+                        project_identifier=project,
+                        file_paths=[value.value.path for value in values_page.items],
+                    )
 
-        results: Generator[
-            tuple[identifiers.RunIdentifier, attribute_definitions.AttributeDefinition, Optional[pathlib.Path]],
-            None,
-            None,
-        ] = concurrency.gather_results(output)
-        file_list = list(results)
+                    for file_value, signed_file in zip(values_page.items, signed_files):
+                        # todo: each in parallel
 
-        return output_format.create_files_dataframe(file_list, sys_id_label_mapping)
+                        target_path = await files.download_file_retry(
+                            client=client,
+                            project_identifier=project,
+                            signed_file=signed_file,
+                            target_path=files.create_target_path(
+                                destination=destination,
+                                experiment_name=sys_id_label_mapping[file_value.run_identifier.sys_id],
+                                attribute_path=file_value.attribute_definition.name,
+                            ),
+                            transport=transport,
+                        )
+                        file_list.append((file_value.run_identifier, file_value.attribute_definition, target_path))
+
+        return sys_id_label_mapping, file_list
+
+    with requests.Session() as request_session, AsyncioRequestsTransport(
+        session=request_session, session_owner=False
+    ) as transport:
+        sys_id_label_mapping, file_list = asyncio.run(go(transport))
+
+    return output_format.create_files_dataframe(file_list, sys_id_label_mapping)
 
 
 def _ensure_write_access(destination: pathlib.Path) -> None:

--- a/src/neptune_fetcher/alpha/internal/composition/download_files.py
+++ b/src/neptune_fetcher/alpha/internal/composition/download_files.py
@@ -69,8 +69,6 @@ def download_files(
             client=client,
             project_identifier=project,
             filter_=filter_,
-            executor=executor,
-            fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
             container_type=container_type,
         )
 

--- a/src/neptune_fetcher/alpha/internal/composition/fetch_metrics.py
+++ b/src/neptune_fetcher/alpha/internal/composition/fetch_metrics.py
@@ -93,8 +93,6 @@ def fetch_metrics(
             client=client,
             project_identifier=project_identifier,
             filter_=filter_,
-            executor=executor,
-            fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
             container_type=container_type,
         )
 

--- a/src/neptune_fetcher/alpha/internal/composition/fetch_series.py
+++ b/src/neptune_fetcher/alpha/internal/composition/fetch_series.py
@@ -74,8 +74,6 @@ def fetch_series(
             client=client,
             project_identifier=project_identifier,
             filter_=filter_,
-            executor=executor,
-            fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
             container_type=container_type,
         )
 

--- a/src/neptune_fetcher/alpha/internal/composition/fetch_table.py
+++ b/src/neptune_fetcher/alpha/internal/composition/fetch_table.py
@@ -75,8 +75,6 @@ def fetch_table(
             client=client,
             project_identifier=project,
             filter_=filter_,
-            executor=executor,
-            fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
             container_type=container_type,
         )
 
@@ -85,8 +83,6 @@ def fetch_table(
             project_identifier=project,
             filter_=filter_,
             sort_by=sort_by,
-            executor=executor,
-            fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
             container_type=container_type,
         )
 

--- a/src/neptune_fetcher/alpha/internal/retrieval/attribute_definitions.py
+++ b/src/neptune_fetcher/alpha/internal/retrieval/attribute_definitions.py
@@ -18,7 +18,7 @@ import re
 from dataclasses import dataclass
 from typing import (
     Any,
-    Generator,
+    AsyncGenerator,
     Iterable,
     Optional,
     Union,
@@ -63,7 +63,7 @@ def fetch_attribute_definitions_single_filter(
     run_identifiers: Optional[Iterable[identifiers.RunIdentifier]],
     attribute_filter: filters.AttributeFilter,
     batch_size: int = env.NEPTUNE_FETCHER_ATTRIBUTE_DEFINITIONS_BATCH_SIZE.get(),
-) -> Generator[util.Page[AttributeDefinition], None, None]:
+) -> AsyncGenerator[util.Page[AttributeDefinition], None]:
     params: dict[str, Any] = {
         "projectIdentifiers": list(project_identifiers),
         "attributeNameFilter": dict(),
@@ -94,7 +94,7 @@ def fetch_attribute_definitions_single_filter(
 
     # note: attribute_filter.aggregations is intentionally ignored
 
-    return util.fetch_pages(
+    return util.fetch_pages_async(
         client=client,
         fetch_page=_fetch_attribute_definitions_page,
         process_page=_process_attribute_definitions_page,
@@ -103,14 +103,14 @@ def fetch_attribute_definitions_single_filter(
     )
 
 
-def _fetch_attribute_definitions_page(
+async def _fetch_attribute_definitions_page(
     client: AuthenticatedClient,
     params: dict[str, Any],
 ) -> QueryAttributeDefinitionsResultDTO:
     body = QueryAttributeDefinitionsBodyDTO.from_dict(params)
 
-    response = util.backoff_retry(
-        query_attribute_definitions_within_project.sync_detailed,
+    response = await util.backoff_retry_async(
+        query_attribute_definitions_within_project.asyncio_detailed,
         client=client,
         body=body,
     )

--- a/src/neptune_fetcher/alpha/internal/retrieval/search.py
+++ b/src/neptune_fetcher/alpha/internal/retrieval/search.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import functools as ft
 from dataclasses import dataclass
 from enum import Enum
@@ -217,12 +218,14 @@ def _fetch_sys_attrs_page(
 ) -> ProtoLeaderboardEntriesSearchResultDTO:
     body = SearchLeaderboardEntriesParamsDTO.from_dict(params)
 
-    response = util.backoff_retry(
-        search_leaderboard_entries_proto.sync_detailed,
-        client=client,
-        project_identifier=project_identifier,
-        type=["run"],
-        body=body,
+    response = asyncio.run(
+        util.backoff_retry_async(
+            search_leaderboard_entries_proto.asyncio_detailed,
+            client=client,
+            project_identifier=project_identifier,
+            type=["run"],
+            body=body,
+        )
     )
 
     return ProtoLeaderboardEntriesSearchResultDTO.FromString(response.content)

--- a/src/neptune_fetcher/alpha/internal/retrieval/search.py
+++ b/src/neptune_fetcher/alpha/internal/retrieval/search.py
@@ -207,8 +207,6 @@ fetch_run_sys_ids = _create_fetch_sys_attrs(
     default_container_type=ContainerType.RUN,
 )
 
-fetch_sys_ids = fetch_experiment_sys_ids
-
 
 async def _fetch_sys_attrs_page(
     client: AuthenticatedClient,
@@ -225,7 +223,7 @@ async def _fetch_sys_attrs_page(
         body=body,
     )
 
-    yield ProtoLeaderboardEntriesSearchResultDTO.FromString(response.content)
+    return ProtoLeaderboardEntriesSearchResultDTO.FromString(response.content)
 
 
 def _process_sys_attrs_page(

--- a/src/neptune_fetcher/alpha/internal/retrieval/util.py
+++ b/src/neptune_fetcher/alpha/internal/retrieval/util.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import time
@@ -167,3 +168,78 @@ def _raise_for_response(status_code: int, content: bytes) -> Exception:
         status_code=status_code,
         content=content,
     )
+
+
+async def backoff_retry_async(
+    func: Callable,
+    *args: Any,
+    max_tries: int = 5,
+    backoff_factor: float = 0.5,
+    max_backoff: float = 30.0,
+    **kwargs: Any,
+) -> Response[Any]:
+    """
+    Retries a function with exponential backoff. The function will be called at most `max_tries` times.
+
+    :param func: The function to retry.
+    :param max_tries: Maximum number of times `func` will be called, including retries.
+    :param backoff_factor: Factor by which the backoff time increases.
+    :param max_backoff: Maximum backoff time.
+    :param args: Positional arguments to pass to the function.
+    :param kwargs: Keyword arguments to pass to the function.
+    :return: The result of the function call.
+    """
+
+    if max_tries < 1:
+        raise RuntimeError("max_tries must be greater than or equal to 1")
+
+    tries = 0
+    last_exc = None
+    last_response = None
+
+    while True:
+        tries += 1
+        try:
+            response = await func(*args, **kwargs)
+        except ApiKeyRejectedError as e:
+            # The API token is explicitly rejected by the backend -- don't retry anymore.
+            raise NeptuneInvalidCredentialsError from e
+        except httpx.TimeoutException as e:
+            response = None
+            last_exc = e
+            logger.warning(
+                "Neptune API request timed out. Retrying...\n"
+                "Check your network connection or increase the timeout by setting the "
+                "NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS environment variable (default: 60 seconds)."
+            )
+        except Exception as e:
+            response = None
+            last_exc = e
+
+        if response is not None:
+            last_response = response
+
+            code = response.status_code.value
+            if 0 <= code < 300:
+                return response
+
+            # Not a TooManyRequests or InternalServerError code
+            if not (code == 429 or 500 <= code < 600):
+                _raise_for_response(response.status_code, response.content)
+
+        if tries == max_tries:
+            break
+
+        # A retryable error occurred, back off and try again
+        backoff_time = min(backoff_factor * (2**tries), max_backoff)
+        await asyncio.sleep(backoff_time)
+
+    # No more retries left
+    if last_response:
+        error = exceptions.NeptuneRetryError(tries, last_response.status_code.value, last_response.content)
+    else:
+        error = exceptions.NeptuneRetryError(tries)
+    if last_exc:
+        raise error from last_exc
+    else:
+        raise error

--- a/tests/e2e/alpha/internal/composition/test_type_inference.py
+++ b/tests/e2e/alpha/internal/composition/test_type_inference.py
@@ -159,9 +159,7 @@ def test_infer_attribute_types_in_filter_no_filter(client, executor, project, ru
         ),
     ],
 )
-def test_infer_attribute_types_in_filter_single(
-    client, executor, project, run_with_attributes, filter_before, filter_after
-):
+def test_infer_attribute_types_in_filter_single(client, project, run_with_attributes, filter_before, filter_after):
     # given
     project_identifier = project.project_identifier
 
@@ -170,8 +168,6 @@ def test_infer_attribute_types_in_filter_single(
         client,
         project_identifier,
         filter_before,
-        executor,
-        executor,
     )
 
     # then
@@ -189,9 +185,7 @@ def test_infer_attribute_types_in_filter_single(
         (Attribute(f"{PATH}/float-series-value"), Attribute(f"{PATH}/float-series-value", type="float_series")),
     ],
 )
-def infer_attribute_types_in_sort_by_single(
-    client, executor, project, run_with_attributes, attribute_before, attribute_after
-):
+def infer_attribute_types_in_sort_by_single(client, project, run_with_attributes, attribute_before, attribute_after):
     # given
     project_identifier = project.project_identifier
 
@@ -201,8 +195,6 @@ def infer_attribute_types_in_sort_by_single(
         project_identifier,
         filter_=None,
         sort_by=attribute_before,
-        executor=executor,
-        fetch_attribute_definitions_executor=executor,
     )
 
     # then
@@ -215,7 +207,7 @@ def infer_attribute_types_in_sort_by_single(
         Filter.eq(f"{PATH}/does-not-exist", 10),
     ],
 )
-def test_infer_attribute_types_in_filter_missing(client, executor, project, filter_before):
+def test_infer_attribute_types_in_filter_missing(client, project, filter_before):
     # given
     project_identifier = project.project_identifier
 
@@ -225,8 +217,6 @@ def test_infer_attribute_types_in_filter_missing(client, executor, project, filt
             client,
             project_identifier,
             filter_=filter_before,
-            executor=executor,
-            fetch_attribute_definitions_executor=executor,
         )
 
 
@@ -238,7 +228,7 @@ def test_infer_attribute_types_in_filter_missing(client, executor, project, filt
         (Attribute(f"{PATH}/int-value"), Filter.name_in(EXPERIMENT_NAME + "does-not-exist")),
     ],
 )
-def test_infer_attribute_types_in_sort_by_missing(client, executor, project, attribute, experiment_filter):
+def test_infer_attribute_types_in_sort_by_missing(client, project, attribute, experiment_filter):
     # given
     project_identifier = project.project_identifier
 
@@ -249,8 +239,6 @@ def test_infer_attribute_types_in_sort_by_missing(client, executor, project, att
             project_identifier,
             filter_=experiment_filter,
             sort_by=attribute,
-            executor=executor,
-            fetch_attribute_definitions_executor=executor,
         )
 
 
@@ -261,7 +249,7 @@ def test_infer_attribute_types_in_sort_by_missing(client, executor, project, att
     ],
 )
 def test_infer_attribute_types_in_filter_conflicting_types(
-    client, executor, project, run_with_attributes, run_with_attributes_b, filter_before
+    client, project, run_with_attributes, run_with_attributes_b, filter_before
 ):
     # given
     project_identifier = project.project_identifier
@@ -272,8 +260,6 @@ def test_infer_attribute_types_in_filter_conflicting_types(
             client,
             project_identifier,
             filter_=filter_before,
-            executor=executor,
-            fetch_attribute_definitions_executor=executor,
         )
 
 
@@ -287,7 +273,7 @@ def test_infer_attribute_types_in_filter_conflicting_types(
     ],
 )
 def test_infer_attribute_types_in_filter_conflicting_types_todo(
-    client, executor, project, run_with_attributes, run_with_attributes_b, filter_before
+    client, project, run_with_attributes, run_with_attributes_b, filter_before
 ):
     # given
     project_identifier = project.project_identifier
@@ -298,8 +284,6 @@ def test_infer_attribute_types_in_filter_conflicting_types_todo(
             client,
             project_identifier,
             filter_=filter_before,
-            executor=executor,
-            fetch_attribute_definitions_executor=executor,
         )
 
 
@@ -314,7 +298,7 @@ def test_infer_attribute_types_in_filter_conflicting_types_todo(
     ],
 )
 def test_infer_attribute_types_in_sort_by_conflicting_types(
-    client, executor, project, run_with_attributes, run_with_attributes_b, attribute_before, experiment_filter
+    client, project, run_with_attributes, run_with_attributes_b, attribute_before, experiment_filter
 ):
     # given
     project_identifier = project.project_identifier
@@ -326,8 +310,6 @@ def test_infer_attribute_types_in_sort_by_conflicting_types(
             project_identifier,
             filter_=experiment_filter,
             sort_by=attribute_before,
-            executor=executor,
-            fetch_attribute_definitions_executor=executor,
         )
 
 
@@ -345,7 +327,7 @@ def test_infer_attribute_types_in_sort_by_conflicting_types(
     ],
 )
 def test_infer_attribute_types_in_sort_by_conflicting_types_todo(
-    client, executor, project, run_with_attributes, run_with_attributes_b, attribute_before, experiment_filter
+    client, project, run_with_attributes, run_with_attributes_b, attribute_before, experiment_filter
 ):
     # given
     project_identifier = project.project_identifier
@@ -357,8 +339,6 @@ def test_infer_attribute_types_in_sort_by_conflicting_types_todo(
             project_identifier,
             filter_=experiment_filter,
             sort_by=attribute_before,
-            executor=executor,
-            fetch_attribute_definitions_executor=executor,
         )
 
 
@@ -389,7 +369,6 @@ def test_infer_attribute_types_in_sort_by_conflicting_types_todo(
 )
 def test_infer_attribute_types_in_sort_by_conflicting_types_with_filter(
     client,
-    executor,
     project,
     run_with_attributes,
     run_with_attributes_b,
@@ -406,8 +385,6 @@ def test_infer_attribute_types_in_sort_by_conflicting_types_with_filter(
         project_identifier,
         filter_=experiment_filter,
         sort_by=attribute_before,
-        executor=executor,
-        fetch_attribute_definitions_executor=executor,
     )
 
     # then


### PR DESCRIPTION
## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Migrate core composition and retrieval modules to native asyncio paradigms, replacing custom thread‐pool executors and concurrency utilities with async functions and AsyncGenerator streams, and updating downstream call sites and tests accordingly.

New Features:
- Allow file downloads to run over AsyncioRequestsTransport with retry and signed URL support

Enhancements:
- Convert all fetch_* functions to async and return AsyncGenerator instead of using thread executors and concurrency helpers
- Introduce util.fetch_pages_async and util.backoff_retry_async to standardize async pagination and retry logic
- Remove custom concurrency and executor parameters across composition and type_inference modules
- Simplify file download and attribute/series fetching workflows with nested async loops and AsyncioRequestsTransport

Build:
- Point neptune-api dependency to the new git branch "ms/a-version" in pyproject.toml

Tests:
- Update e2e tests to drop executor fixtures and consume async generators via asyncio.run wrappers