### PR TITLE
feat(sre): New GitHub Actions runners setup

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: tools-gha-runners 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: tools-gha-runners 
+    runs-on: tools-gha-runners
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-neptune-fetcher:
-    runs-on: tools-gha-runners 
+    runs-on: tools-gha-runners
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
     needs:
       - build-neptune-fetcher
       - test-install
-    runs-on: tools-gha-runners 
+    runs-on: tools-gha-runners
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-neptune-fetcher:
-    runs-on: ubuntu-latest
+    runs-on: tools-gha-runners 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
 
   test-install:
     needs: [ build-neptune-fetcher ]
-    runs-on: ubuntu-latest
+    runs-on: tools-gha-runners
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -57,7 +57,7 @@ jobs:
     needs:
       - build-neptune-fetcher
       - test-install
-    runs-on: ubuntu-latest
+    runs-on: tools-gha-runners 
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   test:
-    runs-on: arc-runner-set
+    runs-on: tools-gha-runners 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   test:
-    runs-on: tools-gha-runners 
+    runs-on: tools-gha-runners
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Migrate all GitHub Actions workflows to use the new self-hosted “tools-gha-runners” label instead of ubuntu-latest and arc-runner-set

CI:
- Update release workflow jobs to run on tools-gha-runners
- Switch pre-commit workflow to tools-gha-runners
- Change E2E test workflow runner to tools-gha-runners