### PR TITLE
feat: expose histogram series

### DIFF
--- a/src/neptune_fetcher/alpha/__init__.py
+++ b/src/neptune_fetcher/alpha/__init__.py
@@ -160,7 +160,7 @@ def fetch_metrics(
     """
     _experiments = resolve_experiments_filter(experiments)
     assert _experiments is not None
-    _attributes = resolve_attributes_filter(attributes, forced_type=["float_series"])
+    _attributes = resolve_attributes_filter(attributes)
     project_identifier = get_default_project_identifier(context)
 
     return _fetch_metrics.fetch_metrics(
@@ -263,7 +263,7 @@ def fetch_series(
     """
     _experiments = resolve_experiments_filter(experiments)
     assert _experiments is not None
-    _attributes = resolve_attributes_filter(attributes, forced_type=["string_series"])
+    _attributes = resolve_attributes_filter(attributes)
     project_identifier = get_default_project_identifier(context)
 
     return _fetch_series.fetch_series(
@@ -305,7 +305,7 @@ def download_files(
     Returns a DataFrame mapping experiments and attributes to the paths of downloaded files.
     """
     _experiments = resolve_experiments_filter(experiments)
-    _attributes = resolve_attributes_filter(attributes, forced_type=["file"])
+    _attributes = resolve_attributes_filter(attributes)
     destination_path = resolve_destination_path(destination)
     project_identifier = get_default_project_identifier(context)
 

--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -63,17 +63,15 @@ def resolve_attributes_filter(
 ) -> _filters._AttributeFilter:
     if forced_type is None:
         if attributes is None:
-            return _filters._AttributeFilter()
+            return filters.AttributeFilter()._to_internal()
         if isinstance(attributes, str):
-            return _filters._AttributeFilter(
-                must_match_any=[_filters._AttributeNameFilter(must_match_regexes=[attributes])]
-            )
+            return filters.AttributeFilter(name_matches_all=attributes)._to_internal()
         if attributes == []:
             # In alpha, passing attributes=[] gives us un-filtered results
             # In v1, we're going to return no results or raise an error
-            return _filters._AttributeFilter()
+            return filters.AttributeFilter()._to_internal()
         if isinstance(attributes, list):
-            return _filters._AttributeFilter(name_eq=attributes)
+            return filters.AttributeFilter(name_eq=attributes)._to_internal()
         if isinstance(attributes, filters.BaseAttributeFilter):
             return attributes._to_internal()
         raise ValueError(
@@ -82,18 +80,15 @@ def resolve_attributes_filter(
         )
     else:
         if attributes is None:
-            return _filters._AttributeFilter(type_in=forced_type)
+            return filters.AttributeFilter(type_in=forced_type)._to_internal()
         if isinstance(attributes, str):
-            return _filters._AttributeFilter(
-                must_match_any=[_filters._AttributeNameFilter(must_match_regexes=[attributes])],
-                type_in=forced_type,
-            )
+            return filters.AttributeFilter(name_matches_all=attributes)._to_internal()
         if attributes == []:
             # In alpha, passing attributes=[] gives us un-filtered results
             # In v1, we're going to return no results or raise an error
-            return _filters._AttributeFilter(type_in=forced_type)
+            return filters.AttributeFilter(type_in=forced_type)._to_internal()
         if isinstance(attributes, list):
-            return _filters._AttributeFilter(name_eq=attributes, type_in=forced_type)
+            return filters.AttributeFilter(name_eq=attributes, type_in=forced_type)._to_internal()
         if isinstance(attributes, filters.BaseAttributeFilter):
             return attributes._to_internal()
         raise ValueError(
@@ -104,7 +99,7 @@ def resolve_attributes_filter(
 
 def resolve_sort_by(sort_by: Union[str, filters.Attribute]) -> _filters._Attribute:
     if isinstance(sort_by, str):
-        return _filters._Attribute(sort_by)
+        return filters.Attribute(sort_by)._to_internal()
     if isinstance(sort_by, filters.Attribute):
         return sort_by._to_internal()
     raise ValueError(f"Invalid type for sort_by. Expected str or Attribute object, but got {type(sort_by)}.")
@@ -119,15 +114,17 @@ def resolve_destination_path(destination: Optional[str]) -> pathlib.Path:
 
 def resolve_runs_filter(runs: Optional[Union[str, list[str], filters.Filter]]) -> Optional[_filters._Filter]:
     if isinstance(runs, str):
-        return _filters._Filter.matches_all(_filters._Attribute("sys/custom_run_id", type="string"), regex=runs)
+        return filters.Filter.matches_all(
+            filters.Attribute("sys/custom_run_id", type="string"), regex=runs
+        )._to_internal()
     if runs == []:
         # In alpha, passing runs=[] gives us un-filtered results
         # In v1, we're going to return no results or raise an error
         return None
     if isinstance(runs, list):
-        return _filters._Filter.any(
-            [_filters._Filter.eq(_filters._Attribute("sys/custom_run_id", type="string"), value=run) for run in runs]
-        )
+        return filters.Filter.any(
+            *[filters.Filter.eq(filters.Attribute("sys/custom_run_id", type="string"), value=run) for run in runs]
+        )._to_internal()
     if isinstance(runs, filters.Filter):
         return runs._to_internal()
     if runs is None:

--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -38,13 +38,13 @@ def resolve_experiments_filter(
     experiments: Optional[Union[str, list[str], filters.Filter]],
 ) -> Optional[_filters._Filter]:
     if isinstance(experiments, str):
-        return _filters._Filter.matches_all(_filters._Attribute("sys/name", type="string"), experiments)
+        return filters.Filter.matches_all(filters.Attribute("sys/name", type="string"), experiments)._to_internal()
     if experiments == []:
         # In alpha, passing experiments=[] gives us un-filtered results
         # In v1, we're going to return no results or raise an error
         return None
     if isinstance(experiments, list):
-        return _filters._Filter.name_in(*experiments)
+        return filters.Filter.name_in(*experiments)._to_internal()
     if isinstance(experiments, filters.Filter):
         return experiments._to_internal()
     if experiments is None:
@@ -59,42 +59,23 @@ def resolve_attributes_filter(
     # TODO: this function also accepts filters._AlternateAttributeFilter, but this is not fully tested...
     # see test_list_attributes_with_attribute_filter with "Combined filters" input
     attributes: Optional[Union[str, list[str], filters.AttributeFilter]],
-    forced_type: Optional[list[filters.ATTRIBUTE_LITERAL]] = None,
 ) -> _filters._AttributeFilter:
-    if forced_type is None:
-        if attributes is None:
-            return filters.AttributeFilter()._to_internal()
-        if isinstance(attributes, str):
-            return filters.AttributeFilter(name_matches_all=attributes)._to_internal()
-        if attributes == []:
-            # In alpha, passing attributes=[] gives us un-filtered results
-            # In v1, we're going to return no results or raise an error
-            return filters.AttributeFilter()._to_internal()
-        if isinstance(attributes, list):
-            return filters.AttributeFilter(name_eq=attributes)._to_internal()
-        if isinstance(attributes, filters.BaseAttributeFilter):
-            return attributes._to_internal()
-        raise ValueError(
-            "Invalid type for attributes filter. Expected str, list of str, or AttributeFilter object, but got "
-            f"{type(attributes)}."
-        )
-    else:
-        if attributes is None:
-            return filters.AttributeFilter(type_in=forced_type)._to_internal()
-        if isinstance(attributes, str):
-            return filters.AttributeFilter(name_matches_all=attributes)._to_internal()
-        if attributes == []:
-            # In alpha, passing attributes=[] gives us un-filtered results
-            # In v1, we're going to return no results or raise an error
-            return filters.AttributeFilter(type_in=forced_type)._to_internal()
-        if isinstance(attributes, list):
-            return filters.AttributeFilter(name_eq=attributes, type_in=forced_type)._to_internal()
-        if isinstance(attributes, filters.BaseAttributeFilter):
-            return attributes._to_internal()
-        raise ValueError(
-            "Invalid type for attributes filter. Expected str, list of str, or AttributeFilter object, but got "
-            f"{type(attributes)}."
-        )
+    if attributes is None:
+        return filters.AttributeFilter()._to_internal()
+    if isinstance(attributes, str):
+        return filters.AttributeFilter(name_matches_all=attributes)._to_internal()
+    if attributes == []:
+        # In alpha, passing attributes=[] gives us un-filtered results
+        # In v1, we're going to return no results or raise an error
+        return filters.AttributeFilter()._to_internal()
+    if isinstance(attributes, list):
+        return filters.AttributeFilter(name_eq=attributes)._to_internal()
+    if isinstance(attributes, filters.BaseAttributeFilter):
+        return attributes._to_internal()
+    raise ValueError(
+        "Invalid type for attributes filter. Expected str, list of str, or AttributeFilter object, but got "
+        f"{type(attributes)}."
+    )
 
 
 def resolve_sort_by(sort_by: Union[str, filters.Attribute]) -> _filters._Attribute:

--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -94,14 +94,6 @@ def resolve_attributes_filter(
             return _filters._AttributeFilter(type_in=forced_type)
         if isinstance(attributes, list):
             return _filters._AttributeFilter(name_eq=attributes, type_in=forced_type)
-        if isinstance(attributes, filters.AttributeFilter):
-            modified_attributes = filters.AttributeFilter(
-                name_eq=attributes.name_eq,
-                name_matches_all=attributes.name_matches_all,
-                type_in=forced_type,
-                aggregations=attributes.aggregations,
-            )
-            return modified_attributes._to_internal()
         if isinstance(attributes, filters.BaseAttributeFilter):
             return attributes._to_internal()
         raise ValueError(

--- a/src/neptune_fetcher/alpha/filters.py
+++ b/src/neptune_fetcher/alpha/filters.py
@@ -38,7 +38,9 @@ from neptune_fetcher.internal.util import (
 __all__ = ["Filter", "AttributeFilter", "Attribute"]
 
 
-ALL_TYPES = ("float", "int", "string", "bool", "datetime", "float_series", "string_set", "string_series", "file")
+KNOWN_TYPES = frozenset(
+    {"float", "int", "string", "bool", "datetime", "float_series", "string_set", "string_series", "file"}
+)
 ALL_AGGREGATIONS = types.FLOAT_SERIES_AGGREGATIONS | types.STRING_SERIES_AGGREGATIONS
 ATTRIBUTE_LITERAL = Literal[
     "float", "int", "string", "bool", "datetime", "float_series", "string_set", "string_series", "file"
@@ -99,7 +101,7 @@ class AttributeFilter(BaseAttributeFilter):
     """
 
     name_eq: Union[str, list[str], None] = None
-    type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(ALL_TYPES))  # type: ignore
+    type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(KNOWN_TYPES))  # type: ignore
     name_matches_all: Union[str, list[str], None] = None
     name_matches_none: Union[str, list[str], None] = None
     aggregations: list[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
@@ -109,7 +111,7 @@ class AttributeFilter(BaseAttributeFilter):
         _validate_string_or_string_list(self.name_matches_all, "name_matches_all")
         _validate_string_or_string_list(self.name_matches_none, "name_matches_none")
 
-        _validate_list_of_allowed_values(self.type_in, ALL_TYPES, "type_in")
+        _validate_list_of_allowed_values(self.type_in, KNOWN_TYPES, "type_in")
         _validate_list_of_allowed_values(self.aggregations, ALL_AGGREGATIONS, "aggregations")
 
     def _to_internal(self) -> _filters._AttributeFilter:
@@ -189,7 +191,7 @@ class Attribute:
 
     def __post_init__(self) -> None:
         _validate_allowed_value(self.aggregation, ALL_AGGREGATIONS, "aggregation")
-        _validate_allowed_value(self.type, ALL_TYPES, "type")
+        _validate_allowed_value(self.type, KNOWN_TYPES, "type")
 
     def to_query(self) -> str:
         query = f"`{self.name}`"

--- a/src/neptune_fetcher/alpha/filters.py
+++ b/src/neptune_fetcher/alpha/filters.py
@@ -38,6 +38,8 @@ from neptune_fetcher.internal.util import (
 __all__ = ["Filter", "AttributeFilter", "Attribute"]
 
 
+ALL_TYPES = ("float", "int", "string", "bool", "datetime", "float_series", "string_set", "string_series", "file")
+ALL_AGGREGATIONS = types.FLOAT_SERIES_AGGREGATIONS | types.STRING_SERIES_AGGREGATIONS
 ATTRIBUTE_LITERAL = Literal[
     "float", "int", "string", "bool", "datetime", "float_series", "string_set", "string_series", "file"
 ]
@@ -97,7 +99,7 @@ class AttributeFilter(BaseAttributeFilter):
     """
 
     name_eq: Union[str, list[str], None] = None
-    type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(types.ALL_TYPES))  # type: ignore
+    type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(ALL_TYPES))  # type: ignore
     name_matches_all: Union[str, list[str], None] = None
     name_matches_none: Union[str, list[str], None] = None
     aggregations: list[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
@@ -107,8 +109,8 @@ class AttributeFilter(BaseAttributeFilter):
         _validate_string_or_string_list(self.name_matches_all, "name_matches_all")
         _validate_string_or_string_list(self.name_matches_none, "name_matches_none")
 
-        _validate_list_of_allowed_values(self.type_in, types.ALL_TYPES, "type_in")
-        _validate_list_of_allowed_values(self.aggregations, types.ALL_AGGREGATIONS, "aggregations")
+        _validate_list_of_allowed_values(self.type_in, ALL_TYPES, "type_in")
+        _validate_list_of_allowed_values(self.aggregations, ALL_AGGREGATIONS, "aggregations")
 
     def _to_internal(self) -> _filters._AttributeFilter:
         matches_all = [self.name_matches_all] if isinstance(self.name_matches_all, str) else self.name_matches_all
@@ -186,8 +188,8 @@ class Attribute:
     type: Optional[ATTRIBUTE_LITERAL] = None
 
     def __post_init__(self) -> None:
-        _validate_allowed_value(self.aggregation, types.ALL_AGGREGATIONS, "aggregation")
-        _validate_allowed_value(self.type, types.ALL_TYPES, "type")
+        _validate_allowed_value(self.aggregation, ALL_AGGREGATIONS, "aggregation")
+        _validate_allowed_value(self.type, ALL_TYPES, "type")
 
     def to_query(self) -> str:
         query = f"`{self.name}`"

--- a/src/neptune_fetcher/alpha/runs.py
+++ b/src/neptune_fetcher/alpha/runs.py
@@ -148,7 +148,7 @@ def fetch_metrics(
     """
     _runs = resolve_runs_filter(runs)
     assert _runs is not None
-    _attributes = resolve_attributes_filter(attributes, forced_type=["float_series"])
+    _attributes = resolve_attributes_filter(attributes)
     project_identifier = get_default_project_identifier(context)
 
     return _fetch_metrics.fetch_metrics(
@@ -251,7 +251,7 @@ def fetch_series(
     """
     _runs = resolve_runs_filter(runs)
     assert _runs is not None
-    _attributes = resolve_attributes_filter(attributes, forced_type=["string_series"])
+    _attributes = resolve_attributes_filter(attributes)
     project_identifier = get_default_project_identifier(context)
 
     return _fetch_series.fetch_series(
@@ -293,7 +293,7 @@ def download_files(
     Returns a DataFrame mapping runs and attributes to the paths of downloaded files.
     """
     _runs = resolve_runs_filter(runs)
-    _attributes = resolve_attributes_filter(attributes, forced_type=["file"])
+    _attributes = resolve_attributes_filter(attributes)
     destination_path = resolve_destination_path(destination)
     project_identifier = get_default_project_identifier(context)
 

--- a/src/neptune_fetcher/internal/composition/download_files.py
+++ b/src/neptune_fetcher/internal/composition/download_files.py
@@ -59,7 +59,7 @@ def download_files(
     valid_context = validate_context(context or get_context())
     client = _client.get_client(context=valid_context)
 
-    attributes = validation.restrict_attribute_filter_type(attributes, type_in="file")
+    attributes = validation.restrict_attribute_filter_type(attributes, type_in={"file"})
     validation.ensure_write_access(destination)
 
     with (

--- a/src/neptune_fetcher/internal/composition/fetch_metrics.py
+++ b/src/neptune_fetcher/internal/composition/fetch_metrics.py
@@ -71,7 +71,7 @@ def fetch_metrics(
     validation.validate_step_range(step_range)
     validation.validate_tail_limit(tail_limit)
     validation.validate_include_time(include_time)
-    attributes = validation.restrict_attribute_filter_type(attributes, type_in="float_series")
+    attributes = validation.restrict_attribute_filter_type(attributes, type_in={"float_series"})
 
     valid_context = validate_context(context or get_context())
     client = get_client(context=valid_context)

--- a/src/neptune_fetcher/internal/composition/fetch_series.py
+++ b/src/neptune_fetcher/internal/composition/fetch_series.py
@@ -66,7 +66,7 @@ def fetch_series(
     validation.validate_step_range(step_range)
     validation.validate_tail_limit(tail_limit)
     validation.validate_include_time(include_time)
-    attributes = validation.restrict_attribute_filter_type(attributes, type_in="string_series")
+    attributes = validation.restrict_attribute_filter_type(attributes, type_in={"string_series", "histogram_series"})
 
     valid_context = validate_context(context or get_context())
     client = get_client(context=valid_context)

--- a/src/neptune_fetcher/internal/filters.py
+++ b/src/neptune_fetcher/internal/filters.py
@@ -87,11 +87,6 @@ class _AttributeFilter(_BaseAttributeFilter):
         "string_series", "file"]]):
             A list of allowed attribute types. Defaults to all available types.
             For a reference, see: https://docs.neptune.ai/attribute_types
-        name_matches_all (Union[str, list[str], None]): A regular expression or list of expressions that the attribute
-            name must match. If `None`, this filter is not applied.
-        name_matches_none (Union[str, list[str], None]): A regular expression or list of expressions that the attribute
-            names mustn't match. Attributes matching any of the regexes are excluded.
-            If `None`, this filter is not applied.
         must_match_any (Optional[list[_AttributeNameFilter]]):
             If `None`, this filter is not applied. Otherwise, it's a list of `_AttributeNameFilter` instances.
             Each instance specifies a set of regexes that the attribute name must match or not match.

--- a/src/neptune_fetcher/v1/__init__.py
+++ b/src/neptune_fetcher/v1/__init__.py
@@ -252,7 +252,7 @@ def fetch_series(
     """
     project_identifier = get_default_project_identifier(project)
     experiments_filter = resolve_experiments_filter(experiments)
-    attributes_filter = resolve_attributes_filter(attributes, forced_type=["string_series"])
+    attributes_filter = resolve_attributes_filter(attributes, forced_type=["string_series", "histogram_series"])
 
     return _fetch_series.fetch_series(
         project_identifier=project_identifier,

--- a/src/neptune_fetcher/v1/__init__.py
+++ b/src/neptune_fetcher/v1/__init__.py
@@ -151,7 +151,7 @@ def fetch_metrics(
     """
     project_identifier = get_default_project_identifier(project)
     experiments_filter = resolve_experiments_filter(experiments)
-    attributes_filter = resolve_attributes_filter(attributes, forced_type=["float_series"])
+    attributes_filter = resolve_attributes_filter(attributes)
 
     return _fetch_metrics.fetch_metrics(
         project_identifier=project_identifier,
@@ -252,7 +252,7 @@ def fetch_series(
     """
     project_identifier = get_default_project_identifier(project)
     experiments_filter = resolve_experiments_filter(experiments)
-    attributes_filter = resolve_attributes_filter(attributes, forced_type=["string_series", "histogram_series"])
+    attributes_filter = resolve_attributes_filter(attributes)
 
     return _fetch_series.fetch_series(
         project_identifier=project_identifier,

--- a/src/neptune_fetcher/v1/_internal.py
+++ b/src/neptune_fetcher/v1/_internal.py
@@ -85,15 +85,6 @@ def resolve_attributes_filter(
             return _filters._AttributeFilter(type_in=forced_type)
         if isinstance(attributes, list):
             return filters.AttributeFilter(name_eq=attributes, type_in=forced_type)._to_internal()
-        if isinstance(attributes, filters.AttributeFilter):
-            modified_attributes = filters.AttributeFilter(
-                name_eq=attributes.name_eq,
-                name_matches_all=attributes.name_matches_all,
-                name_matches_none=attributes.name_matches_none,
-                type_in=forced_type,
-                aggregations=attributes.aggregations,
-            )
-            return modified_attributes._to_internal()
         if isinstance(attributes, filters.BaseAttributeFilter):
             return attributes._to_internal()
         raise ValueError(

--- a/src/neptune_fetcher/v1/filters.py
+++ b/src/neptune_fetcher/v1/filters.py
@@ -40,7 +40,16 @@ __all__ = ["Filter", "AttributeFilter", "Attribute"]
 
 
 ATTRIBUTE_LITERAL = Literal[
-    "float", "int", "string", "bool", "datetime", "float_series", "string_set", "string_series", "file"
+    "float",
+    "int",
+    "string",
+    "bool",
+    "datetime",
+    "float_series",
+    "string_set",
+    "string_series",
+    "file",
+    "histogram_series",
 ]
 AGGREGATION_LITERAL = Literal["last", "min", "max", "average", "variance"]
 

--- a/src/neptune_fetcher/v1/filters.py
+++ b/src/neptune_fetcher/v1/filters.py
@@ -39,6 +39,23 @@ from neptune_fetcher.internal.util import (
 __all__ = ["Filter", "AttributeFilter", "Attribute"]
 
 
+KNOWN_TYPES = frozenset(
+    {
+        "float",
+        "int",
+        "string",
+        "bool",
+        "datetime",
+        "float_series",
+        "string_set",
+        "string_series",
+        "file",
+        "histogram_series",
+    }
+)
+ALL_AGGREGATIONS = (
+    types.FLOAT_SERIES_AGGREGATIONS | types.STRING_SERIES_AGGREGATIONS | types.HISTOGRAM_SERIES_AGGREGATIONS
+)
 ATTRIBUTE_LITERAL = Literal[
     "float",
     "int",
@@ -106,7 +123,7 @@ class AttributeFilter(BaseAttributeFilter):
     """
 
     name_eq: Union[str, list[str], None] = None
-    type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(types.ALL_TYPES))  # type: ignore
+    type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(KNOWN_TYPES))  # type: ignore
     name_matches_all: Union[str, list[str], None] = None
     name_matches_none: Union[str, list[str], None] = None
     aggregations: list[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
@@ -116,8 +133,8 @@ class AttributeFilter(BaseAttributeFilter):
         _validate_string_or_string_list(self.name_matches_all, "name_matches_all")
         _validate_string_or_string_list(self.name_matches_none, "name_matches_none")
 
-        _validate_list_of_allowed_values(self.type_in, types.ALL_TYPES, "type_in")
-        _validate_list_of_allowed_values(self.aggregations, types.ALL_AGGREGATIONS, "aggregations")
+        _validate_list_of_allowed_values(self.type_in, KNOWN_TYPES, "type_in")
+        _validate_list_of_allowed_values(self.aggregations, ALL_AGGREGATIONS, "aggregations")
 
     def _to_internal(self) -> _filters._AttributeFilter:
         matches_all = [self.name_matches_all] if isinstance(self.name_matches_all, str) else self.name_matches_all

--- a/src/neptune_fetcher/v1/runs.py
+++ b/src/neptune_fetcher/v1/runs.py
@@ -249,7 +249,7 @@ def fetch_series(
     """
     project_identifier = get_default_project_identifier(project)
     runs_filter = resolve_runs_filter(runs)
-    attributes_filter = resolve_attributes_filter(attributes, forced_type=["string_series"])
+    attributes_filter = resolve_attributes_filter(attributes, forced_type=["string_series", "histogram_series"])
 
     return _fetch_series.fetch_series(
         project_identifier=project_identifier,

--- a/src/neptune_fetcher/v1/runs.py
+++ b/src/neptune_fetcher/v1/runs.py
@@ -149,7 +149,7 @@ def fetch_metrics(
     """
     project_identifier = get_default_project_identifier(project)
     runs_filter = resolve_runs_filter(runs)
-    attributes_filter = resolve_attributes_filter(attributes, forced_type=["float_series"])
+    attributes_filter = resolve_attributes_filter(attributes)
 
     return _fetch_metrics.fetch_metrics(
         project_identifier=project_identifier,
@@ -249,7 +249,7 @@ def fetch_series(
     """
     project_identifier = get_default_project_identifier(project)
     runs_filter = resolve_runs_filter(runs)
-    attributes_filter = resolve_attributes_filter(attributes, forced_type=["string_series", "histogram_series"])
+    attributes_filter = resolve_attributes_filter(attributes)
 
     return _fetch_series.fetch_series(
         project_identifier=project_identifier,

--- a/tests/e2e/data.py
+++ b/tests/e2e/data.py
@@ -11,10 +11,10 @@ from datetime import (
 )
 from typing import Any
 
-from neptune_scale.types import (
-    File,
-    Histogram,
-)
+from neptune_scale.types import File
+from neptune_scale.types import Histogram as ScaleHistogram
+
+from neptune_fetcher.internal.retrieval.attribute_types import Histogram as FetcherHistogram
 
 TEST_DATA_VERSION = "2025-06-27"
 PATH = f"test/test-alpha-{TEST_DATA_VERSION}"
@@ -37,7 +37,7 @@ class ExperimentData:
     string_series: dict[str, list[str]]
     files: dict[str, bytes]
     file_series: dict[str, list[bytes]]
-    histogram_series: dict[str, list[Histogram]]
+    histogram_series: dict[str, list[ScaleHistogram]]
     long_path_configs: dict[str, int]
     long_path_series: dict[str, str]
     long_path_metrics: dict[str, float]
@@ -60,6 +60,12 @@ class ExperimentData:
                 self.long_path_metrics.keys(),
             )
         )
+
+    def fetcher_histogram_series(self) -> dict[str, list[FetcherHistogram]]:
+        return {
+            key: [FetcherHistogram(type="COUNTING", edges=value.bin_edges, values=value.counts) for value in values]
+            for key, values in self.histogram_series.items()
+        }
 
 
 @dataclass
@@ -98,7 +104,7 @@ class TestData:
 
                 histogram_series = {
                     path: [
-                        Histogram(
+                        ScaleHistogram(
                             bin_edges=[n + j for n in range(6)],
                             counts=[n * j for n in range(5)],
                         )
@@ -122,6 +128,7 @@ class TestData:
                     }
                 else:
                     files = {}
+                    file_series = {}
 
                 if i <= 2:
                     long_path_prefix = f"{PATH}/long/int-value-"

--- a/tests/e2e/internal/retrieval/test_attributes.py
+++ b/tests/e2e/internal/retrieval/test_attributes.py
@@ -22,7 +22,6 @@ from neptune_fetcher.internal.identifiers import (
 from neptune_fetcher.internal.retrieval.attribute_definitions import fetch_attribute_definitions_single_filter
 from neptune_fetcher.internal.retrieval.attribute_types import (
     FloatSeriesAggregations,
-    Histogram,
     HistogramSeriesAggregations,
     StringSeriesAggregations,
 )
@@ -603,9 +602,8 @@ def test_fetch_attribute_values_single_histogram_series_all_aggregations(client,
     )
 
     # then
-    data = TEST_DATA.experiments[0].histogram_series[path]
     aggregates = HistogramSeriesAggregations(
-        last=Histogram(type="COUNTING", edges=data[-1].bin_edges, values=data[-1].counts),
+        last=TEST_DATA.experiments[0].fetcher_histogram_series()[path][-1],
         last_step=NUMBER_OF_STEPS - 1,
     )
     assert values == [AttributeValue(AttributeDefinition(path, "histogram_series"), aggregates, experiment_identifier)]

--- a/tests/e2e/internal/retrieval/test_series.py
+++ b/tests/e2e/internal/retrieval/test_series.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 import pytest
 
 from neptune_fetcher.internal.identifiers import AttributeDefinition
-from neptune_fetcher.internal.retrieval.attribute_types import Histogram
 from neptune_fetcher.internal.retrieval.series import (
     RunAttributeDefinition,
     fetch_series_values,
@@ -62,10 +61,7 @@ def test_fetch_series_values_does_not_exist(client, project, experiment_identifi
         (
             HISTOGRAM_SERIES_PATHS[0],
             "histogram_series",
-            [
-                Histogram(type="COUNTING", edges=value.bin_edges, values=value.counts)
-                for value in TEST_DATA.experiments[0].histogram_series[HISTOGRAM_SERIES_PATHS[0]]
-            ],
+            TEST_DATA.experiments[0].fetcher_histogram_series()[HISTOGRAM_SERIES_PATHS[0]],
         ),
         (
             FILE_SERIES_PATHS[0],
@@ -112,10 +108,7 @@ def test_fetch_series_values_single_series(
         (
             HISTOGRAM_SERIES_PATHS[0],
             "histogram_series",
-            [
-                Histogram(type="COUNTING", edges=value.bin_edges, values=value.counts)
-                for value in TEST_DATA.experiments[0].histogram_series[HISTOGRAM_SERIES_PATHS[0]]
-            ],
+            TEST_DATA.experiments[0].fetcher_histogram_series()[HISTOGRAM_SERIES_PATHS[0]],
         ),
         (
             FILE_SERIES_PATHS[0],
@@ -180,10 +173,7 @@ def test_fetch_series_values_single_series_stop_range(
         (
             HISTOGRAM_SERIES_PATHS[0],
             "histogram_series",
-            [
-                Histogram(type="COUNTING", edges=value.bin_edges, values=value.counts)
-                for value in TEST_DATA.experiments[0].histogram_series[HISTOGRAM_SERIES_PATHS[0]]
-            ],
+            TEST_DATA.experiments[0].fetcher_histogram_series()[HISTOGRAM_SERIES_PATHS[0]],
         ),
         (
             FILE_SERIES_PATHS[0],

--- a/tests/e2e/v1/test_attributes.py
+++ b/tests/e2e/v1/test_attributes.py
@@ -75,6 +75,16 @@ EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
             TEST_DATA.all_attribute_names,
         ),
         (AttributeFilter(name_matches_none=".*"), []),
+        (
+            AttributeFilter(name_matches_all=rf"{PATH}/metrics/string-series-value_.*", type_in=["string_series"]),
+            set(STRING_SERIES_PATHS),
+        ),
+        (
+            AttributeFilter(
+                name_matches_all=rf"{PATH}/metrics/histogram-series-value_.*", type_in=["histogram_series"]
+            ),
+            set(HISTOGRAM_SERIES_PATHS),
+        ),
     ],
 )
 def test_list_attributes_known_in_all_experiments_with_name_filter_excluding_sys(

--- a/tests/e2e/v1/test_fetch_series.py
+++ b/tests/e2e/v1/test_fetch_series.py
@@ -23,10 +23,7 @@ from neptune_fetcher.internal.identifiers import (
 from neptune_fetcher.internal.output_format import create_series_dataframe
 from neptune_fetcher.internal.retrieval.series import SeriesValue
 from neptune_fetcher.v1 import fetch_series
-from neptune_fetcher.v1.filters import (
-    AttributeFilter,
-    Filter,
-)
+from neptune_fetcher.v1.filters import AttributeFilter
 from tests.e2e.data import (
     NOW,
     NUMBER_OF_STEPS,
@@ -37,7 +34,7 @@ from tests.e2e.data import (
 NEPTUNE_PROJECT: str = os.getenv("NEPTUNE_E2E_PROJECT")
 
 
-def create_expected_data(
+def create_expected_data_string_series(
     experiments: list[ExperimentData],
     include_time: Union[Literal["absolute"], None],
     step_range: Tuple[Optional[int], Optional[int]],
@@ -101,7 +98,7 @@ def create_expected_data(
     "arg_attributes",
     [
         AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["string_series"]),
-        ".*/metrics/.*",
+        ".*/metrics/string-series.*",
         AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["string_series"])
         | AttributeFilter(name_matches_all=[".*/int-value"]),
     ],
@@ -109,13 +106,12 @@ def create_expected_data(
 @pytest.mark.parametrize(
     "arg_experiments",
     [
-        Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
         f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
         [exp.name for exp in TEST_DATA.experiments[:3]],
     ],
 )
 @pytest.mark.parametrize("include_time", [None, "absolute"])
-def test__fetch_series(
+def test__fetch_string_series(
     project,
     type_suffix_in_column_names,
     step_range,
@@ -136,7 +132,117 @@ def test__fetch_series(
         project=project.project_identifier,
     )
 
-    expected, columns, filtered_exps = create_expected_data(experiments, include_time, step_range, tail_limit)
+    expected, columns, filtered_exps = create_expected_data_string_series(
+        experiments, include_time, step_range, tail_limit
+    )
+
+    pd.testing.assert_frame_equal(result, expected)
+    assert result.columns.tolist() == columns
+    assert result.index.names == ["experiment", "step"]
+    assert {t[0] for t in result.index.tolist()} == filtered_exps
+
+
+def create_expected_data_histogram_series(
+    experiments: list[ExperimentData],
+    include_time: Union[Literal["absolute"], None],
+    step_range: Tuple[Optional[int], Optional[int]],
+    tail_limit: Optional[int],
+) -> Tuple[pd.DataFrame, List[str], set[str]]:
+    series_data: dict[RunAttributeDefinition, list[SeriesValue]] = {}
+    sys_id_label_mapping: dict[SysId, str] = {}
+
+    columns = set()
+    filtered_exps = set()
+
+    step_filter = (
+        step_range[0] if step_range[0] is not None else -np.inf,
+        step_range[1] if step_range[1] is not None else np.inf,
+    )
+    for experiment in experiments:
+        steps = range(NUMBER_OF_STEPS)
+        sys_id_label_mapping[SysId(experiment.run_id)] = experiment.name
+
+        for path, series in experiment.fetcher_histogram_series().items():
+            run_attr = RunAttributeDefinition(
+                RunIdentifier(identifiers.ProjectIdentifier(NEPTUNE_PROJECT), SysId(experiment.run_id)),
+                AttributeDefinition(path, type="histogram_series"),
+            )
+
+            filtered = []
+            for step in steps:
+                if step_filter[0] <= step <= step_filter[1]:
+                    columns.add(path)
+                    filtered_exps.add(experiment.name)
+                    filtered.append(
+                        SeriesValue(
+                            step,
+                            series[step],
+                            int((NOW + timedelta(seconds=int(step))).timestamp()) * 1000,
+                        )
+                    )
+            limited = filtered[-tail_limit:] if tail_limit is not None else filtered
+
+            series_data.setdefault(run_attr, []).extend(limited)
+
+    df = create_series_dataframe(
+        series_data,
+        sys_id_label_mapping,
+        index_column_name="experiment",
+        timestamp_column_name="absolute_time" if include_time == "absolute" else None,
+    )
+
+    sorted_columns = list(sorted(columns))
+    if include_time == "absolute":
+        absolute_columns = [[(c, "absolute_time"), (c, "value")] for c in sorted_columns]
+        return df, list(it.chain.from_iterable(absolute_columns)), filtered_exps
+    else:
+        return df, sorted_columns, filtered_exps
+
+
+@pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
+@pytest.mark.parametrize("step_range", [(0.0, 5), (0, None), (None, 5), (None, None), (100, 200)])
+@pytest.mark.parametrize("tail_limit", [None, 3, 5])
+@pytest.mark.parametrize(
+    "arg_attributes",
+    [
+        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["histogram_series"]),
+        ".*/metrics/histogram-series.*",
+        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["histogram_series"])
+        | AttributeFilter(name_matches_all=[".*/int-value"]),
+    ],
+)
+@pytest.mark.parametrize(
+    "arg_experiments",
+    [
+        f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
+        [exp.name for exp in TEST_DATA.experiments[:3]],
+    ],
+)
+@pytest.mark.parametrize("include_time", [None, "absolute"])
+def test__fetch_histogram_series(
+    project,
+    type_suffix_in_column_names,
+    step_range,
+    tail_limit,
+    include_time,
+    arg_experiments,
+    arg_attributes,
+):
+    experiments = TEST_DATA.experiments[:3]
+
+    result = fetch_series(
+        experiments=arg_experiments,
+        attributes=arg_attributes,
+        include_time=include_time,
+        step_range=step_range,
+        tail_limit=tail_limit,
+        lineage_to_the_root=True,
+        project=project.project_identifier,
+    )
+
+    expected, columns, filtered_exps = create_expected_data_histogram_series(
+        experiments, include_time, step_range, tail_limit
+    )
 
     pd.testing.assert_frame_equal(result, expected)
     assert result.columns.tolist() == columns


### PR DESCRIPTION
fixes PY-143

## Summary by Sourcery

Expose histogram series retrieval and filtering support throughout the fetcher module, enhance attribute filter validation to handle multiple types, and update tests to cover histogram series and clarify existing string series behavior

New Features:
- Add support for fetching histogram series in fetch_series and fetch_experiments_table across v1 and alpha APIs
- Expose 'histogram_series' as an allowable attribute type in filters with default forced types

Enhancements:
- Extend restrict_attribute_filter_type to accept multiple types and provide clearer error messages on mismatch
- Introduce ALL_TYPES and ALL_AGGREGATIONS constants in alpha filters to centralize allowed values
- Rename helper functions and tests for string series to clarify naming and avoid ambiguity

Tests:
- Add end-to-end tests for histogram series fetching (create_expected_data_histogram_series, test__fetch_histogram_series)
- Add E2E tests for histogram_series filtering in fetch_experiments_table and attribute listing
- Update unit tests for attribute filter validation to cover list-based type_in and updated error message formatting