### PR TITLE
fix: fix histogram series 

### DIFF
--- a/src/neptune_fetcher/alpha/filters.py
+++ b/src/neptune_fetcher/alpha/filters.py
@@ -35,7 +35,7 @@ from neptune_fetcher.internal.util import (
     _validate_string_or_string_list,
 )
 
-__all__ = ["Filter", "AttributeFilter", "Attribute"]
+__all__ = ["Filter", "AttributeFilter", "Attribute", "KNOWN_TYPES"]
 
 
 KNOWN_TYPES = frozenset(

--- a/src/neptune_fetcher/v1/_internal.py
+++ b/src/neptune_fetcher/v1/_internal.py
@@ -22,13 +22,13 @@ from typing import (
     Union,
 )
 
-from neptune_fetcher.alpha.filters import KNOWN_TYPES
 from neptune_fetcher.exceptions import NeptuneProjectNotProvided
 from neptune_fetcher.internal import filters as _filters
 from neptune_fetcher.internal import pattern as _pattern
 from neptune_fetcher.internal.context import get_context
 from neptune_fetcher.internal.identifiers import ProjectIdentifier
 from neptune_fetcher.v1 import filters
+from neptune_fetcher.v1.filters import KNOWN_TYPES
 
 
 def resolve_experiments_filter(

--- a/src/neptune_fetcher/v1/filters.py
+++ b/src/neptune_fetcher/v1/filters.py
@@ -36,7 +36,7 @@ from neptune_fetcher.internal.util import (
     _validate_string_or_string_list,
 )
 
-__all__ = ["Filter", "AttributeFilter", "Attribute"]
+__all__ = ["Filter", "AttributeFilter", "Attribute", "KNOWN_TYPES"]
 
 
 KNOWN_TYPES = frozenset(

--- a/tests/e2e/v1/test_attributes.py
+++ b/tests/e2e/v1/test_attributes.py
@@ -1,3 +1,4 @@
+import itertools as it
 import os
 from typing import Iterable
 
@@ -10,7 +11,6 @@ from neptune_fetcher.v1.filters import (
     Filter,
 )
 from tests.e2e.data import (
-    FILE_SERIES_PATHS,
     FLOAT_SERIES_PATHS,
     HISTOGRAM_SERIES_PATHS,
     PATH,
@@ -30,6 +30,10 @@ def _drop_sys_attr_names(attributes: Iterable[str]) -> list[str]:
 # in case the run has some extra experiments.
 EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
 
+ALL_V1_ATTRIBUTE_NAMES = set(
+    it.chain.from_iterable(exp.all_attribute_names - exp.file_series.keys() for exp in TEST_DATA.experiments)
+)
+
 
 @pytest.mark.parametrize(
     "arg_experiments",
@@ -44,7 +48,7 @@ EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
 @pytest.mark.parametrize(
     "arg_attributes, expected",
     [
-        (PATH, TEST_DATA.all_attribute_names),
+        (PATH, ALL_V1_ATTRIBUTE_NAMES),
         (f"{PATH}/int-value", {f"{PATH}/int-value"}),
         (
             rf"{PATH}/metrics/.*",
@@ -52,8 +56,7 @@ EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
         ),
         (
             rf"{PATH}/files/.*",
-            {f"{PATH}/files/file-value", f"{PATH}/files/file-value.txt", f"{PATH}/files/object-does-not-exist"}
-            | set(FILE_SERIES_PATHS),
+            {f"{PATH}/files/file-value", f"{PATH}/files/file-value.txt", f"{PATH}/files/object-does-not-exist"},
         ),
         (
             rf"{PATH}/.*-value$",
@@ -68,11 +71,11 @@ EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
             },
         ),
         (rf"{PATH}/unique-value-[0-9]", {f"{PATH}/unique-value-{i}" for i in range(6)}),
-        (AttributeFilter(name_matches_all=PATH), TEST_DATA.all_attribute_names),
+        (AttributeFilter(name_matches_all=PATH), ALL_V1_ATTRIBUTE_NAMES),
         (AttributeFilter(name_eq=f"{PATH}/float-value"), {f"{PATH}/float-value"}),
         (
             AttributeFilter.any(AttributeFilter(name_matches_all="^(foo)"), AttributeFilter(name_matches_all=PATH)),
-            TEST_DATA.all_attribute_names,
+            ALL_V1_ATTRIBUTE_NAMES,
         ),
         (AttributeFilter(name_matches_none=".*"), []),
         (
@@ -112,8 +115,8 @@ def test_list_attributes_known_in_all_experiments_with_name_filter_excluding_sys
 )
 def test_list_attributes_all_names_from_all_experiments_excluding_sys(name_filter):
     attributes = _drop_sys_attr_names(list_attributes(experiments=EXPERIMENTS_IN_THIS_TEST, attributes=name_filter))
-    assert set(attributes) == set(TEST_DATA.all_attribute_names)
-    assert len(attributes) == len(TEST_DATA.all_attribute_names)
+    assert set(attributes) == set(ALL_V1_ATTRIBUTE_NAMES)
+    assert len(attributes) == len(ALL_V1_ATTRIBUTE_NAMES)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
(after staging came back to life)

## Summary by Sourcery

Exclude file-series keys from V1 attribute listings, export KNOWN_TYPES in filter modules, and add a retry e2e test to ensure stable attribute fetching.

Bug Fixes:
- Exclude file-series attribute keys from V1 attribute name sets in tests to correct histogram series handling

Enhancements:
- Add KNOWN_TYPES export to both alpha and v1 filter modules and update v1 internal import to reference it

Tests:
- Introduce ALL_V1_ATTRIBUTE_NAMES and update attribute filtering tests accordingly
- Add test_retry_e2e to verify consistent single attribute retrieval across repeated fetch operations