### PR TITLE
PY-122 Improve the API of Filter and AttributeFilter in v1 (rebased)

### DIFF
--- a/src/neptune_fetcher/alpha/_internal.py
+++ b/src/neptune_fetcher/alpha/_internal.py
@@ -83,7 +83,7 @@ def resolve_sort_by(sort_by: Union[str, filters.Attribute]) -> _filters._Attribu
         return filters.Attribute(sort_by)._to_internal()
     if isinstance(sort_by, filters.Attribute):
         return sort_by._to_internal()
-    raise ValueError(f"Invalid type for sort_by. Expected str or Attribute object, but got {type(sort_by)}.")
+    raise ValueError(f"Invalid type for `sort_by`. Expected str or Attribute object, but got {type(sort_by)}.")
 
 
 def resolve_destination_path(destination: Optional[str]) -> pathlib.Path:

--- a/src/neptune_fetcher/internal/composition/fetch_table.py
+++ b/src/neptune_fetcher/internal/composition/fetch_table.py
@@ -61,6 +61,9 @@ def fetch_table(
     type_suffix_in_column_names: bool,
     context: Optional[_context.Context] = None,
     container_type: search.ContainerType,
+    # flatten_aggregations: Only allow "last" aggregation and skip the aggregation sub-column in the output
+    flatten_aggregations: bool = False,
+    # flatten_file_properties: for file attributes, return 3 sub-columns: path, size_bytes, mime_type
     flatten_file_properties: bool = False,
 ) -> pd.DataFrame:
     validation.validate_limit(limit)
@@ -162,6 +165,7 @@ def fetch_table(
         selected_aggregations=selected_aggregations,
         type_suffix_in_column_names=type_suffix_in_column_names,
         index_column_name="experiment" if container_type == search.ContainerType.EXPERIMENT else "run",
+        flatten_aggregations=flatten_aggregations,
         flatten_file_properties=flatten_file_properties,
     )
     return dataframe

--- a/src/neptune_fetcher/internal/filters.py
+++ b/src/neptune_fetcher/internal/filters.py
@@ -365,14 +365,6 @@ class _Filter(ABC):
         name_attribute = _Attribute(name="sys/name", type="string")
         return _Filter.eq(name_attribute, name)
 
-    @staticmethod
-    def name_in(*names: str) -> "_Filter":
-        if len(names) == 1:
-            return _Filter.name_eq(names[0])
-        else:
-            filters = [_Filter.name_eq(name) for name in names]
-            return _Filter.any(filters)
-
     @abc.abstractmethod
     def to_query(self) -> str:
         ...

--- a/src/neptune_fetcher/internal/output_format.py
+++ b/src/neptune_fetcher/internal/output_format.py
@@ -74,6 +74,11 @@ def convert_table_to_dataframe(
             index=pd.Index([], name=index_column_name),
             columns=pd.MultiIndex.from_tuples([], names=["attribute", "aggregation"]),
         )
+    if not table_data and flatten_aggregations:
+        return pd.DataFrame(
+            index=pd.Index([], name=index_column_name),
+            columns=[],
+        )
 
     def convert_row(values: list[AttributeValue]) -> dict[tuple[str, str], Any]:
         row = {}

--- a/src/neptune_fetcher/internal/pattern.py
+++ b/src/neptune_fetcher/internal/pattern.py
@@ -15,14 +15,17 @@
 
 import re
 from dataclasses import dataclass
+from typing import Optional
 
 from neptune_fetcher.internal.filters import (
+    AGGREGATION_LITERAL,
     ATTRIBUTE_LITERAL,
     _Attribute,
     _AttributeFilter,
     _AttributeNameFilter,
     _Filter,
 )
+from neptune_fetcher.internal.retrieval.attribute_types import ALL_TYPES
 
 _WS_PATTERN = re.compile(r"[ \t\r\n]")
 _OR_PATTERN = re.compile(rf"{_WS_PATTERN.pattern}+\|{_WS_PATTERN.pattern}+")
@@ -92,8 +95,16 @@ def build_extended_regex_filter(attribute: _Attribute, pattern: str) -> _Filter:
     )
 
 
-def build_extended_regex_attribute_filter(pattern: str, type_in: list[ATTRIBUTE_LITERAL]) -> _AttributeFilter:
+def build_extended_regex_attribute_filter(
+    pattern: str,
+    type_in: Optional[list[ATTRIBUTE_LITERAL]] = None,
+    aggregations: Optional[list[AGGREGATION_LITERAL]] = None,
+) -> _AttributeFilter:
     parsed = parse_extended_regex(pattern)
+
+    # properly set defaults:
+    type_in = ALL_TYPES if type_in is None else type_in
+    aggregations = ["last"] if aggregations is None else aggregations
 
     return _AttributeFilter(
         type_in=type_in,
@@ -104,4 +115,5 @@ def build_extended_regex_attribute_filter(pattern: str, type_in: list[ATTRIBUTE_
             )
             for conj in parsed.children
         ],
+        aggregations=aggregations,
     )

--- a/src/neptune_fetcher/internal/pattern.py
+++ b/src/neptune_fetcher/internal/pattern.py
@@ -15,7 +15,6 @@
 
 import re
 from dataclasses import dataclass
-from typing import Optional
 
 from neptune_fetcher.internal.filters import (
     AGGREGATION_LITERAL,
@@ -25,7 +24,6 @@ from neptune_fetcher.internal.filters import (
     _AttributeNameFilter,
     _Filter,
 )
-from neptune_fetcher.internal.retrieval.attribute_types import ALL_TYPES
 
 _WS_PATTERN = re.compile(r"[ \t\r\n]")
 _OR_PATTERN = re.compile(rf"{_WS_PATTERN.pattern}+\|{_WS_PATTERN.pattern}+")
@@ -97,17 +95,12 @@ def build_extended_regex_filter(attribute: _Attribute, pattern: str) -> _Filter:
 
 def build_extended_regex_attribute_filter(
     pattern: str,
-    type_in: Optional[list[ATTRIBUTE_LITERAL]] = None,
-    aggregations: Optional[list[AGGREGATION_LITERAL]] = None,
+    type_in: list[ATTRIBUTE_LITERAL],
+    aggregations: list[AGGREGATION_LITERAL],
 ) -> _AttributeFilter:
     parsed = parse_extended_regex(pattern)
 
-    # properly set defaults:
-    type_in = ALL_TYPES if type_in is None else type_in
-    aggregations = ["last"] if aggregations is None else aggregations
-
     return _AttributeFilter(
-        type_in=type_in,
         must_match_any=[
             _AttributeNameFilter(
                 must_match_regexes=conj.positive_patterns if conj.positive_patterns else None,
@@ -116,4 +109,5 @@ def build_extended_regex_attribute_filter(
             for conj in parsed.children
         ],
         aggregations=aggregations,
+        type_in=type_in,
     )

--- a/src/neptune_fetcher/internal/util.py
+++ b/src/neptune_fetcher/internal/util.py
@@ -43,7 +43,7 @@ def _validate_string_list(value: Optional[list[str]], field_name: str, disallow_
 def _validate_list_of_allowed_values(value: Sequence[str], allowed_values: Collection[str], field_name: str) -> None:
     """Validate that a value is a list containing only allowed values."""
     if not isinstance(value, Sequence) or not all(isinstance(v, str) and v in allowed_values for v in value):
-        raise ValueError(f"{field_name} must be a list of valid values: {sorted(allowed_values)}")
+        raise ValueError(f"{field_name} must be a list of valid values: {sorted(allowed_values)} (got {value!r})")
 
 
 def _validate_allowed_value(value: Optional[str], allowed_values: Collection[str], field_name: str) -> None:

--- a/src/neptune_fetcher/internal/util.py
+++ b/src/neptune_fetcher/internal/util.py
@@ -30,11 +30,14 @@ def _validate_string_or_string_list(value: Optional[Union[str, list[str]]], fiel
             raise ValueError(f"{field_name} must be a string or list of strings")
 
 
-def _validate_string_list(value: Optional[list[str]], field_name: str) -> None:
+def _validate_string_list(value: Optional[list[str]], field_name: str, disallow_empty: bool = False) -> None:
     """Validate that a value is either None or a list of strings."""
+    msg = f"{field_name} must not be a non-empty list" if disallow_empty else f"{field_name} must be a list of strings"
     if value is not None:
         if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-            raise ValueError(f"{field_name} must be a list of strings")
+            raise ValueError(msg)
+        if disallow_empty and len(value) == 0:
+            raise ValueError(msg)
 
 
 def _validate_list_of_allowed_values(value: Sequence[str], allowed_values: Collection[str], field_name: str) -> None:

--- a/src/neptune_fetcher/v1/__init__.py
+++ b/src/neptune_fetcher/v1/__init__.py
@@ -213,6 +213,7 @@ def fetch_experiments_table(
         limit=limit,
         type_suffix_in_column_names=type_suffix_in_column_names,
         container_type=_search.ContainerType.EXPERIMENT,
+        flatten_aggregations=True,
     )
 
 

--- a/src/neptune_fetcher/v1/_internal.py
+++ b/src/neptune_fetcher/v1/_internal.py
@@ -70,12 +70,12 @@ def resolve_attributes_filter(
             "but got empty list."
         )
     if isinstance(attributes, list):
-        return filters.AttributeFilter(name_eq=attributes)._to_internal()
+        return filters.AttributeFilter(name=attributes)._to_internal()
     if isinstance(attributes, filters.BaseAttributeFilter):
         return attributes._to_internal()
     raise ValueError(
-        "Invalid type for `attributes` filter. Expected str, list of str, or AttributeFilter object, but got "
-        f"{type(attributes)}."
+        "Invalid type for `attributes` filter. Expected str, non-empty list of str, or AttributeFilter object, "
+        f"but got {type(attributes)}."
     )
 
 

--- a/src/neptune_fetcher/v1/filters.py
+++ b/src/neptune_fetcher/v1/filters.py
@@ -92,11 +92,11 @@ class AttributeFilter(BaseAttributeFilter):
         name (str|list[str], optional):
             if str given: an extended regular expression to match attribute names.
             if list[str] given: a list of attribute names to match exactly.
-        type_in (list[Literal["float", "int", "string", "bool", "datetime", "float_series", "string_set",
-        "string_series", "file"]]):
+        type (list[Literal["float", "int", "string", "bool", "datetime", "float_series", "string_set",
+        "string_series", "file"]], optional):
             A list of allowed attribute types. Defaults to all available types.
             For a reference, see: https://docs.neptune.ai/attribute_types
-        aggregations (list[Literal["last", "min", "max", "average", "variance"]]): List of
+        aggregations (list[Literal["last", "min", "max", "average", "variance"]], optional, deprecated): List of
             aggregation functions to apply when fetching metrics of type FloatSeries or StringSeries.
             Defaults to ["last"].
 
@@ -108,7 +108,7 @@ class AttributeFilter(BaseAttributeFilter):
 
 
     loss_avg_and_var = AttributeFilter(
-        type_in=["float_series"],
+        type=["float_series"],
         name="loss$",
         aggregations=["average", "variance"],
     )
@@ -118,25 +118,25 @@ class AttributeFilter(BaseAttributeFilter):
     """
 
     name: Union[str, list[str], None] = None
-    type_in: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(KNOWN_TYPES))  # type: ignore
+    type: list[ATTRIBUTE_LITERAL] = field(default_factory=lambda: list(KNOWN_TYPES))  # type: ignore
     aggregations: list[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
 
     def __post_init__(self) -> None:
         _validate_string_or_string_list(self.name, "name")
-        _validate_list_of_allowed_values(self.type_in, KNOWN_TYPES, "type_in")
+        _validate_list_of_allowed_values(self.type, KNOWN_TYPES, "type")
         _validate_list_of_allowed_values(self.aggregations, ALL_AGGREGATIONS, "aggregations")
 
     def _to_internal(self) -> _filters._AttributeFilter:
         if isinstance(self.name, str):
             return _pattern.build_extended_regex_attribute_filter(
                 self.name,
-                type_in=self.type_in,
+                type_in=self.type,
                 aggregations=self.aggregations,
             )
 
         if self.name is None:
             return _filters._AttributeFilter(
-                type_in=self.type_in,
+                type_in=self.type,
                 aggregations=self.aggregations,
             )
 
@@ -148,7 +148,7 @@ class AttributeFilter(BaseAttributeFilter):
         if isinstance(self.name, list):
             return _filters._AttributeFilter(
                 name_eq=self.name,
-                type_in=self.type_in,
+                type_in=self.type,
                 aggregations=self.aggregations,
             )
 

--- a/src/neptune_fetcher/v1/filters.py
+++ b/src/neptune_fetcher/v1/filters.py
@@ -337,6 +337,12 @@ class Filter:
         if isinstance(values, str):
             values = [values]
 
+        if values == []:
+            raise ValueError(
+                "Invalid value for `contains_all` filter. Expected str, or non-empty list of str, but got "
+                "an empty list"
+            )
+
         internal_filters = [
             _filters._AttributeValuePredicate(operator="CONTAINS", attribute=attribute._to_internal(), value=value)
             for value in values
@@ -345,9 +351,18 @@ class Filter:
         return Filter(_filters._Filter.all(internal_filters))
 
     @staticmethod
-    def contains_none(attribute: Union[str, Attribute], values: list[str]) -> "Filter":
+    def contains_none(attribute: Union[str, Attribute], values: Union[str, list[str]]) -> "Filter":
         if isinstance(attribute, str):
             attribute = Attribute(name=attribute)
+
+        if values == []:
+            raise ValueError(
+                "Invalid value for `contains_none` filter. Expected str, or non-empty list of str, but got "
+                "an empty list"
+            )
+
+        if isinstance(values, str):
+            values = [values]
 
         internal_filters = [
             _filters._AttributeValuePredicate(operator="NOT CONTAINS", attribute=attribute._to_internal(), value=value)

--- a/src/neptune_fetcher/v1/filters.py
+++ b/src/neptune_fetcher/v1/filters.py
@@ -14,10 +14,7 @@
 # limitations under the License.
 import abc
 from abc import ABC
-from dataclasses import (
-    dataclass,
-    field,
-)
+from dataclasses import dataclass
 from datetime import datetime
 from typing import (
     Iterable,
@@ -52,10 +49,8 @@ KNOWN_TYPES = frozenset(
         "histogram_series",
     }
 )
-ALL_AGGREGATIONS = (
-    types.FLOAT_SERIES_AGGREGATIONS | types.STRING_SERIES_AGGREGATIONS | types.HISTOGRAM_SERIES_AGGREGATIONS
-)
-AGGREGATION_LITERAL = Literal["last", "min", "max", "average", "variance"]
+ALL_AGGREGATIONS = ("last",)
+AGGREGATION_LITERAL = Literal["last"]
 
 
 class BaseAttributeFilter(ABC):
@@ -85,10 +80,8 @@ class AttributeFilter(BaseAttributeFilter):
                 ["float", "int", "string", "bool", "datetime", "float_series", "string_set", "string_series",
                 "file", "histogram_series"]
             For reference, see: https://docs.neptune.ai/attribute_types
-        aggregations (list[Literal["last", "min", "max", "average", "variance"]], optional, deprecated): List of
-            aggregation functions to apply when fetching metrics of type FloatSeries or StringSeries.
-            Defaults to ["last"].
 
+    # TODO: Update docs post-PY-156
     Example:
 
     ```
@@ -136,12 +129,14 @@ class AttributeFilter(BaseAttributeFilter):
         ],
         None,
     ] = None
-    aggregations: list[AGGREGATION_LITERAL] = field(default_factory=lambda: ["last"])
+    aggregations: Literal["last"] = "last"
 
     def __post_init__(self) -> None:
         self.type = self.type or list(KNOWN_TYPES)
         if isinstance(self.type, str):
             self.type = [self.type]
+        if isinstance(self.aggregations, str):
+            self.aggregations = [self.aggregations]
         _validate_string_or_string_list(self.name, "name")
         _validate_list_of_allowed_values(self.type, KNOWN_TYPES, "type")
         _validate_list_of_allowed_values(self.aggregations, ALL_AGGREGATIONS, "aggregations")

--- a/src/neptune_fetcher/v1/filters.py
+++ b/src/neptune_fetcher/v1/filters.py
@@ -230,22 +230,21 @@ class Filter:
     """Filter used to specify criteria when fetching experiments or runs.
 
     Examples of filters:
-        - Name or attribute must match regular expression.
+        - Name or attribute value must match regular expression.
         - Attribute value must pass a condition, like "greater than 0.9".
+        - Attribute of a given name must exist or not exist.
 
     You can negate a filter or join multiple filters with logical operators.
 
     Methods available for attribute values:
-    - `name_eq()`: Run or experiment name equals
-    - `name_in()`: Run or experiment name equals any of the provided names
-    - `eq()`: Value equals
-    - `ne()`: Value doesn't equal
-    - `gt()`: Value is greater than
-    - `ge()`: Value is greater than or equal to
-    - `lt()`: Value is less than
-    - `le()`: Value is less than or equal to
-    - `matches_all()`: Value matches regex or all in list of regexes
-    - `matches_none()`: Value doesn't match regex or any of list of regexes
+    - `name()`: Name of experiment matches an extended regular expression or a list of names.
+    - `eq()`: Attribute value equals
+    - `ne()`: Attribute value doesn't equal
+    - `gt()`: Attribute value is greater than
+    - `ge()`: Attribute value is greater than or equal to
+    - `lt()`: Attribute value is less than
+    - `le()`: Attribute value is less than or equal to
+    - `matches()`: Name of experiment matches an extended regular expression
     - `contains_all()`: Tagset contains all tags, or string contains substrings
     - `contains_none()`: Tagset doesn't contain any of the tags, or string doesn't contain the substrings
     - `exists()`: Attribute exists
@@ -257,7 +256,7 @@ class Filter:
     from neptune_fetcher.v1.filters import Filter
 
     # Fetch metadata from specific experiments
-    specific_experiments = Filter.name_in("flying-123", "swimming-77")
+    specific_experiments = Filter.name(["flying-123", "swimming-77"])
     npt.fetch_experiments_table(experiments=specific_experiments)
 
     # Define various criteria
@@ -273,6 +272,14 @@ class Filter:
 
     def __init__(self, internal: _filters._Filter) -> None:
         self._internal = internal
+
+    @staticmethod
+    def name(name: Union[str, list[str]]) -> "Filter":
+        name_attribute = Attribute(name="sys/name", type="string")
+        if isinstance(name, str):
+            return Filter.matches(name_attribute, name)
+        else:
+            return Filter(_filters._Filter.any([_filters._Filter.eq(name_attribute, n) for n in name]))
 
     @staticmethod
     def eq(attribute: Union[str, Attribute], value: Union[int, float, str, datetime]) -> "Filter":
@@ -323,56 +330,31 @@ class Filter:
         )
 
     @staticmethod
-    def matches_all(attribute: Union[str, Attribute], regex: Union[str, list[str]]) -> "Filter":
+    def contains_all(attribute: Union[str, Attribute], values: Union[str, list[str]]) -> "Filter":
         if isinstance(attribute, str):
             attribute = Attribute(name=attribute)
-        if isinstance(regex, str):
-            return Filter(
-                _filters._AttributeValuePredicate(operator="MATCHES", attribute=attribute._to_internal(), value=regex)
-            )
-        else:
-            filters = [Filter.matches_all(attribute, r) for r in regex]
-            return Filter.all(*filters)
+
+        if isinstance(values, str):
+            values = [values]
+
+        internal_filters = [
+            _filters._AttributeValuePredicate(operator="CONTAINS", attribute=attribute._to_internal(), value=value)
+            for value in values
+        ]
+
+        return Filter(_filters._Filter.all(internal_filters))
 
     @staticmethod
-    def matches_none(attribute: Union[str, Attribute], regex: Union[str, list[str]]) -> "Filter":
+    def contains_none(attribute: Union[str, Attribute], values: list[str]) -> "Filter":
         if isinstance(attribute, str):
             attribute = Attribute(name=attribute)
-        if isinstance(regex, str):
-            return Filter(
-                _filters._AttributeValuePredicate(
-                    operator="NOT MATCHES", attribute=attribute._to_internal(), value=regex
-                )
-            )
-        else:
-            filters = [Filter.matches_none(attribute, r) for r in regex]
-            return Filter.all(*filters)
 
-    @staticmethod
-    def contains_all(attribute: Union[str, Attribute], value: Union[str, list[str]]) -> "Filter":
-        if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
-        if isinstance(value, str):
-            return Filter(
-                _filters._AttributeValuePredicate(operator="CONTAINS", attribute=attribute._to_internal(), value=value)
-            )
-        else:
-            filters = [Filter.contains_all(attribute, v) for v in value]
-            return Filter.all(*filters)
+        internal_filters = [
+            _filters._AttributeValuePredicate(operator="NOT CONTAINS", attribute=attribute._to_internal(), value=value)
+            for value in values
+        ]
 
-    @staticmethod
-    def contains_none(attribute: Union[str, Attribute], value: Union[str, list[str]]) -> "Filter":
-        if isinstance(attribute, str):
-            attribute = Attribute(name=attribute)
-        if isinstance(value, str):
-            return Filter(
-                _filters._AttributeValuePredicate(
-                    operator="NOT CONTAINS", attribute=attribute._to_internal(), value=value
-                )
-            )
-        else:
-            filters = [Filter.contains_none(attribute, v) for v in value]
-            return Filter.all(*filters)
+        return Filter(_filters._Filter.all(internal_filters))
 
     @staticmethod
     def exists(attribute: Union[str, Attribute]) -> "Filter":
@@ -380,47 +362,17 @@ class Filter:
             attribute = Attribute(name=attribute)
         return Filter(_filters._AttributePredicate(postfix_operator="EXISTS", attribute=attribute._to_internal()))
 
-    @staticmethod
-    def all(*filters: "Filter") -> "Filter":
-        return Filter(_filters._AssociativeOperator(operator="AND", filters=[f._to_internal() for f in filters]))
-
-    @staticmethod
-    def any(*filters: "Filter") -> "Filter":
-        return Filter(_filters._AssociativeOperator(operator="OR", filters=[f._to_internal() for f in filters]))
-
-    @staticmethod
-    def negate(filter_: "Filter") -> "Filter":
-        return Filter(_filters._PrefixOperator(operator="NOT", filter_=filter_._to_internal()))
-
     def __and__(self, other: "Filter") -> "Filter":
-        return self.all(self, other)
+        """Logical AND operator to combine two filters."""
+        return Filter(_filters._Filter.all([self._to_internal(), other._to_internal()]))
 
     def __or__(self, other: "Filter") -> "Filter":
-        return self.any(self, other)
+        """Logical OR operator to combine two filters."""
+        return Filter(_filters._Filter.any([self._to_internal(), other._to_internal()]))
 
     def __invert__(self) -> "Filter":
-        return self.negate(self)
-
-    @staticmethod
-    def name(name: Union[str, list[str]]) -> "Filter":
-        if isinstance(name, str):
-            name_attribute = Attribute(name="sys/name", type="string")
-            return Filter.matches(name_attribute, name)
-        else:
-            return Filter.name_in(*name)
-
-    @staticmethod
-    def name_eq(name: str) -> "Filter":
-        name_attribute = Attribute(name="sys/name", type="string")
-        return Filter.eq(name_attribute, name)
-
-    @staticmethod
-    def name_in(*names: str) -> "Filter":
-        if len(names) == 1:
-            return Filter.name_eq(names[0])
-        else:
-            filters = [Filter.name_eq(name) for name in names]
-            return Filter.any(*filters)
+        """Logical NOT operator to negate the filter."""
+        return Filter(_filters._Filter.negate(self._to_internal()))
 
     def _to_internal(self) -> _filters._Filter:
         return self._internal

--- a/src/neptune_fetcher/v1/runs.py
+++ b/src/neptune_fetcher/v1/runs.py
@@ -211,6 +211,7 @@ def fetch_runs_table(
         limit=limit,
         type_suffix_in_column_names=type_suffix_in_column_names,
         container_type=_search.ContainerType.RUN,
+        flatten_aggregations=True,
     )
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -76,7 +76,7 @@ def run_with_attributes(project, client):
             fetch_experiment_sys_attrs(
                 client,
                 identifiers.ProjectIdentifier(project_id),
-                _Filter.name_in(experiment.name),
+                _Filter.name_eq(experiment.name),
             )
         )
         if existing.items:
@@ -123,7 +123,7 @@ def run_with_attributes(project, client):
             fetch_experiment_sys_attrs(
                 client,
                 identifiers.ProjectIdentifier(project.project_identifier),
-                _Filter.name_in(*TEST_DATA.experiment_names),
+                _Filter.any([_Filter.name_eq(experiment_name) for experiment_name in TEST_DATA.experiment_names]),
             )
         )
 
@@ -142,7 +142,9 @@ def experiment_identifiers(client, project, run_with_attributes) -> list[RunIden
 
     project_identifier = project.project_identifier
 
-    experiment_filter = _Filter.name_in(*TEST_DATA.experiment_names)
+    experiment_filter = _Filter.any(
+        [_Filter.name_eq(experiment_name) for experiment_name in TEST_DATA.experiment_names]
+    )
     experiment_attrs = extract_pages(
         fetch_experiment_sys_attrs(client, project_identifier=project_identifier, filter_=experiment_filter)
     )

--- a/tests/e2e/internal/composition/test_attributes.py
+++ b/tests/e2e/internal/composition/test_attributes.py
@@ -44,7 +44,7 @@ def run_with_attributes(client, project):
         fetch_experiment_sys_attrs(
             client,
             identifiers.ProjectIdentifier(project_identifier),
-            _Filter.name_in(EXPERIMENT_NAME),
+            _Filter.name_eq(EXPERIMENT_NAME),
         )
     )
     if existing.items:
@@ -94,7 +94,7 @@ def experiment_identifier(client, project, run_with_attributes) -> RunIdentifier
 
     project_identifier = project.project_identifier
 
-    experiment_filter = _Filter.name_in(EXPERIMENT_NAME)
+    experiment_filter = _Filter.name_eq(EXPERIMENT_NAME)
     experiment_attrs = extract_pages(
         fetch_experiment_sys_attrs(client, project_identifier=project_identifier, filter_=experiment_filter)
     )

--- a/tests/e2e/internal/composition/test_download_files.py
+++ b/tests/e2e/internal/composition/test_download_files.py
@@ -30,7 +30,7 @@ def test_download_files_missing(client, project, experiment_identifier, temp_dir
     # when
     result_df = download_files(
         project_identifier=project.project_identifier,
-        filter_=_Filter.name_in(EXPERIMENT_NAME),
+        filter_=_Filter.name_eq(EXPERIMENT_NAME),
         attributes=_AttributeFilter(name_eq=[f"{PATH}/files/object-does-not-exist"]),
         destination=temp_dir,
         context=None,
@@ -56,7 +56,7 @@ def test_download_files_no_permission(client, project, experiment_identifier, te
     with pytest.raises(PermissionError):
         download_files(
             project_identifier=project.project_identifier,
-            filter_=_Filter.name_in(EXPERIMENT_NAME),
+            filter_=_Filter.name_eq(EXPERIMENT_NAME),
             attributes=_AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
             destination=temp_dir,
             context=None,
@@ -88,7 +88,7 @@ def test_download_files_single(client, project, experiment_identifier, temp_dir,
     # when
     result_df = download_files(
         project_identifier=project.project_identifier,
-        filter_=_Filter.name_in(EXPERIMENT_NAME),
+        filter_=_Filter.name_eq(EXPERIMENT_NAME),
         attributes=attributes,
         destination=temp_dir,
         context=None,
@@ -118,7 +118,7 @@ def test_download_files_multiple(client, project, experiment_identifier, temp_di
     # when
     result_df = download_files(
         project_identifier=project.project_identifier,
-        filter_=_Filter.name_in(EXPERIMENT_NAME),
+        filter_=_Filter.name_eq(EXPERIMENT_NAME),
         attributes=_AttributeFilter(name_eq=[f"{PATH}/files/file-value", f"{PATH}/files/file-value.txt"]),
         destination=temp_dir,
         context=None,
@@ -158,7 +158,7 @@ def test_download_files_destination_a_file(client, project, experiment_identifie
     with pytest.raises(NotADirectoryError):
         download_files(
             project_identifier=project.project_identifier,
-            filter_=_Filter.name_in(EXPERIMENT_NAME),
+            filter_=_Filter.name_eq(EXPERIMENT_NAME),
             attributes=_AttributeFilter(name_eq=[f"{PATH}/files/file-value.txt"]),
             destination=destination,
             context=None,

--- a/tests/e2e/internal/composition/test_type_inference.py
+++ b/tests/e2e/internal/composition/test_type_inference.py
@@ -41,7 +41,7 @@ def run_with_attributes(client, project):
         fetch_experiment_sys_attrs(
             client,
             identifiers.ProjectIdentifier(project_identifier),
-            _Filter.name_in(EXPERIMENT_NAME),
+            _Filter.name_eq(EXPERIMENT_NAME),
         )
     )
     if existing.items:
@@ -89,7 +89,7 @@ def run_with_attributes_b(client, project):
         fetch_experiment_sys_attrs(
             client,
             identifiers.ProjectIdentifier(project_identifier),
-            _Filter.name_in(EXPERIMENT_NAME_B),
+            _Filter.name_eq(EXPERIMENT_NAME_B),
         )
     )
     if existing.items:
@@ -234,8 +234,8 @@ def test_infer_attribute_types_in_filter_missing(client, executor, project, filt
     "attribute,experiment_filter",
     [
         (_Attribute(f"{PATH}/does-not-exist"), None),
-        (_Attribute(f"{PATH}/does-not-exist"), _Filter.name_in(EXPERIMENT_NAME)),
-        (_Attribute(f"{PATH}/int-value"), _Filter.name_in(EXPERIMENT_NAME + "does-not-exist")),
+        (_Attribute(f"{PATH}/does-not-exist"), _Filter.name_eq(EXPERIMENT_NAME)),
+        (_Attribute(f"{PATH}/int-value"), _Filter.name_eq(EXPERIMENT_NAME + "does-not-exist")),
     ],
 )
 def test_infer_attribute_types_in_sort_by_missing(client, executor, project, attribute, experiment_filter):
@@ -309,7 +309,7 @@ def test_infer_attribute_types_in_filter_conflicting_types_todo(
         (_Attribute(f"{PATH}/conflicting-type-int-str-value"), None),
         (
             _Attribute(f"{PATH}/conflicting-type-int-str-value"),
-            _Filter.name_in(EXPERIMENT_NAME, EXPERIMENT_NAME_B),
+            _Filter.any([_Filter.name_eq(EXPERIMENT_NAME), _Filter.name_eq(EXPERIMENT_NAME_B)]),
         ),
     ],
 )
@@ -340,7 +340,7 @@ def test_infer_attribute_types_in_sort_by_conflicting_types(
         (_Attribute(f"{PATH}/conflicting-type-int-float-value"), None),
         (
             _Attribute(f"{PATH}/conflicting-type-int-float-value"),
-            _Filter.name_in(EXPERIMENT_NAME, EXPERIMENT_NAME_B),
+            _Filter.any([_Filter.name_eq(EXPERIMENT_NAME), _Filter.name_eq(EXPERIMENT_NAME_B)]),
         ),
     ],
 )
@@ -367,22 +367,22 @@ def test_infer_attribute_types_in_sort_by_conflicting_types_todo(
     [
         (
             _Attribute(f"{PATH}/conflicting-type-int-str-value"),
-            _Filter.name_in(EXPERIMENT_NAME),
+            _Filter.name_eq(EXPERIMENT_NAME),
             _Attribute(f"{PATH}/conflicting-type-int-str-value", type="int"),
         ),
         (
             _Attribute(f"{PATH}/conflicting-type-int-str-value"),
-            _Filter.name_in(EXPERIMENT_NAME_B),
+            _Filter.name_eq(EXPERIMENT_NAME_B),
             _Attribute(f"{PATH}/conflicting-type-int-str-value", type="string"),
         ),
         (
             _Attribute(f"{PATH}/conflicting-type-int-float-value"),
-            _Filter.name_in(EXPERIMENT_NAME),
+            _Filter.name_eq(EXPERIMENT_NAME),
             _Attribute(f"{PATH}/conflicting-type-int-float-value", type="int"),
         ),
         (
             _Attribute(f"{PATH}/conflicting-type-int-float-value"),
-            _Filter.name_in(EXPERIMENT_NAME_B),
+            _Filter.name_eq(EXPERIMENT_NAME_B),
             _Attribute(f"{PATH}/conflicting-type-int-float-value", type="float"),
         ),
     ],

--- a/tests/e2e/internal/retrieval/test_search.py
+++ b/tests/e2e/internal/retrieval/test_search.py
@@ -87,7 +87,7 @@ def test_find_experiments_by_name(client, project, run_with_attributes):
     assert experiment_names == [EXPERIMENT_NAME]
 
     #  when
-    experiment_filter = _Filter.name_in(EXPERIMENT_NAME, "experiment_not_found")
+    experiment_filter = _Filter.any([_Filter.name_eq(EXPERIMENT_NAME), _Filter.name_eq("experiment_not_found")])
     experiment_names = _extract_names(fetch_experiment_sys_attrs(client, project_identifier, experiment_filter))
 
     # then

--- a/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
@@ -4,7 +4,6 @@ from datetime import (
     timezone,
 )
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -26,11 +25,11 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
             r".*-value$",
             {
                 "run": ["linear_history_root"],
-                ("int-value:int", ""): [1],
-                ("float-value:float", ""): [1.0],
-                ("str-value:string", ""): ["hello_1"],
-                ("bool-value:bool", ""): [False],
-                ("datetime-value:datetime", ""): [datetime(2025, 1, 1, 1, 0, 0, 0, timezone.utc)],
+                "int-value:int": [1],
+                "float-value:float": [1.0],
+                "str-value:string": ["hello_1"],
+                "bool-value:bool": [False],
+                "datetime-value:datetime": [datetime(2025, 1, 1, 1, 0, 0, 0, timezone.utc)],
             },
         ),
         (
@@ -45,66 +44,59 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
             r"^foo.*$",
             {
                 "run": ["linear_history_root"],
-                ("foo0:float_series", "last"): [0.1 * 9],
-                ("foo1:float_series", "last"): [0.2 * 9],
+                "foo0:float_series": [0.1 * 9],
+                "foo1:float_series": [0.2 * 9],
             },
         ),
         (
             r"^linear_history_root$",
-            AttributeFilter(name=r"foo0$", aggregations=["last", "min", "max", "average", "variance"]),
+            AttributeFilter(name=r"foo0$", aggregations=["last"]),
             {
                 "run": ["linear_history_root"],
-                ("foo0:float_series", "last"): [0.1 * 9],
-                ("foo0:float_series", "min"): [0.1 * 0],
-                ("foo0:float_series", "max"): [0.1 * 9],
-                ("foo0:float_series", "average"): [np.mean([0.1 * i for i in range(10)])],
-                ("foo0:float_series", "variance"): [np.var([0.1 * i for i in range(10)])],
+                "foo0:float_series": [0.1 * 9],
+                # "foo0:float_series": [0.1 * 0],
+                # "foo0:float_series": [0.1 * 9],
+                # "foo0:float_series": [np.mean([0.1 * i for i in range(10)])],
+                # "foo0:float_series": [np.var([0.1 * i for i in range(10)])],
             },
         ),
         (
             "^linear_history_root$",
-            AttributeFilter(name="foo0$", aggregations=["last", "min", "max", "average", "variance"])
-            | AttributeFilter(name=".*-value$"),
+            AttributeFilter(name="foo0$", aggregations=["last"]) | AttributeFilter(name=".*-value$"),
             {
                 "run": ["linear_history_root"],
-                ("int-value:int", ""): [1],
-                ("float-value:float", ""): [1.0],
-                ("str-value:string", ""): ["hello_1"],
-                ("bool-value:bool", ""): [False],
-                ("datetime-value:datetime", ""): [datetime(2025, 1, 1, 1, 0, 0, 0, timezone.utc)],
-                ("foo0:float_series", "last"): [0.1 * 9],
-                ("foo0:float_series", "min"): [0.1 * 0],
-                ("foo0:float_series", "max"): [0.1 * 9],
-                ("foo0:float_series", "average"): [np.mean([0.1 * i for i in range(10)])],
-                ("foo0:float_series", "variance"): [np.var([0.1 * i for i in range(10)])],
+                "int-value:int": [1],
+                "float-value:float": [1.0],
+                "str-value:string": ["hello_1"],
+                "bool-value:bool": [False],
+                "datetime-value:datetime": [datetime(2025, 1, 1, 1, 0, 0, 0, timezone.utc)],
+                "foo0:float_series": [0.1 * 9],
+                # ("foo0:float_series", "min"): [0.1 * 0],
+                # ("foo0:float_series", "max"): [0.1 * 9],
+                # ("foo0:float_series", "average"): [np.mean([0.1 * i for i in range(10)])],
+                # ("foo0:float_series", "variance"): [np.var([0.1 * i for i in range(10)])],
             },
         ),
         (
             r"^linear_history_root$|^linear_history_fork2$",
-            AttributeFilter(name=r"foo0$", aggregations=["last", "variance"]),
+            AttributeFilter(name=r"foo0$", aggregations=["last"]),
             {
                 "run": ["linear_history_root", "linear_history_fork2"],
-                ("foo0:float_series", "last"): [0.1 * 9, 0.7 * 19],
-                ("foo0:float_series", "variance"): [
-                    np.var([0.1 * i for i in range(10)]),
-                    np.var(
-                        [0.1 * i for i in range(5)] + [0.4 * i for i in range(5, 9)] + [0.7 * i for i in range(9, 20)]
-                    ),
-                ],
+                "foo0:float_series": [0.1 * 9, 0.7 * 19],
             },
         ),
         (
             ["linear_history_root", "linear_history_fork2"],
-            AttributeFilter(name=r"foo0$", aggregations=["last", "variance"]),
+            AttributeFilter(name=r"foo0$", aggregations=["last"]),
             {
                 "run": ["linear_history_root", "linear_history_fork2"],
-                ("foo0:float_series", "last"): [0.1 * 9, 0.7 * 19],
-                ("foo0:float_series", "variance"): [
-                    np.var([0.1 * i for i in range(10)]),
-                    np.var(
-                        [0.1 * i for i in range(5)] + [0.4 * i for i in range(5, 9)] + [0.7 * i for i in range(9, 20)]
-                    ),
-                ],
+                "foo0:float_series": [0.1 * 9, 0.7 * 19],
+                # ("foo0:float_series", "variance"): [
+                #     np.var([0.1 * i for i in range(10)]),
+                #     np.var(
+                #         [0.1 * i for i in range(5)] + [0.4 * i for i in range(5, 9)] + [0.7 * i for i in range(9, 20)]
+                #     ),
+                # ],
             },
         ),
         (
@@ -112,11 +104,11 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
             r".*-value$",
             {
                 "run": ["forked_history_root", "forked_history_fork1"],
-                ("int-value:int", ""): [1, 2],
-                ("float-value:float", ""): [1.0, 2.0],
-                ("str-value:string", ""): ["hello_1", "hello_2"],
-                ("bool-value:bool", ""): [False, True],
-                ("datetime-value:datetime", ""): [
+                "int-value:int": [1, 2],
+                "float-value:float": [1.0, 2.0],
+                "str-value:string": ["hello_1", "hello_2"],
+                "bool-value:bool": [False, True],
+                "datetime-value:datetime": [
                     datetime(2025, 1, 1, 1, 0, 0, 0, timezone.utc),
                     datetime(2025, 1, 1, 2, 0, 0, 0, timezone.utc),
                 ],
@@ -127,11 +119,11 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
             r".*-value$",
             {
                 "run": ["forked_history_root", "forked_history_fork1"],
-                ("int-value:int", ""): [1, 2],
-                ("float-value:float", ""): [1.0, 2.0],
-                ("str-value:string", ""): ["hello_1", "hello_2"],
-                ("bool-value:bool", ""): [False, True],
-                ("datetime-value:datetime", ""): [
+                "int-value:int": [1, 2],
+                "float-value:float": [1.0, 2.0],
+                "str-value:string": ["hello_1", "hello_2"],
+                "bool-value:bool": [False, True],
+                "datetime-value:datetime": [
                     datetime(2025, 1, 1, 1, 0, 0, 0, timezone.utc),
                     datetime(2025, 1, 1, 2, 0, 0, 0, timezone.utc),
                 ],
@@ -143,11 +135,11 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
             r".*-value$",
             {
                 "run": ["linear_history_fork1", "linear_history_fork2", "linear_history_root"],
-                ("int-value:int", ""): [2, 3, 1],
-                ("float-value:float", ""): [2.0, 3.0, 1.0],
-                ("str-value:string", ""): ["hello_2", "hello_3", "hello_1"],
-                ("bool-value:bool", ""): [True, False, False],
-                ("datetime-value:datetime", ""): [
+                "int-value:int": [2, 3, 1],
+                "float-value:float": [2.0, 3.0, 1.0],
+                "str-value:string": ["hello_2", "hello_3", "hello_1"],
+                "bool-value:bool": [True, False, False],
+                "datetime-value:datetime": [
                     datetime(2025, 1, 1, 2, 0, 0, 0, timezone.utc),
                     datetime(2025, 1, 1, 3, 0, 0, 0, timezone.utc),
                     datetime(2025, 1, 1, 1, 0, 0, 0, timezone.utc),
@@ -166,11 +158,11 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
                     "linear_history_fork2",
                     "linear_history_root",
                 ],
-                ("int-value:int", ""): [2, 3, 1, 2, 3, 1],
-                ("float-value:float", ""): [2.0, 3.0, 1.0, 2.0, 3.0, 1.0],
-                ("str-value:string", ""): ["hello_2", "hello_3", "hello_1", "hello_2", "hello_3", "hello_1"],
-                ("bool-value:bool", ""): [True, False, False, True, False, False],
-                ("datetime-value:datetime", ""): [
+                "int-value:int": [2, 3, 1, 2, 3, 1],
+                "float-value:float": [2.0, 3.0, 1.0, 2.0, 3.0, 1.0],
+                "str-value:string": ["hello_2", "hello_3", "hello_1", "hello_2", "hello_3", "hello_1"],
+                "bool-value:bool": [True, False, False, True, False, False],
+                "datetime-value:datetime": [
                     datetime(2025, 1, 1, 2, 0, 0, 0, timezone.utc),
                     datetime(2025, 1, 1, 3, 0, 0, 0, timezone.utc),
                     datetime(2025, 1, 1, 1, 0, 0, 0, timezone.utc),
@@ -207,7 +199,7 @@ def test_fetch_runs_table(
     expected["run"] = expected["run"].astype(object)
     expected.set_index("run", drop=True, inplace=True)
 
-    expected.columns = pd.MultiIndex.from_tuples(expected.columns, names=["attribute", "aggregation"])
+    # expected.columns = pd.MultiIndex.from_tuples(expected.columns, names=["attribute", "aggregation"])
 
     pd.testing.assert_frame_equal(df, expected)
 

--- a/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
@@ -54,10 +54,6 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
             {
                 "run": ["linear_history_root"],
                 "foo0:float_series": [0.1 * 9],
-                # "foo0:float_series": [0.1 * 0],
-                # "foo0:float_series": [0.1 * 9],
-                # "foo0:float_series": [np.mean([0.1 * i for i in range(10)])],
-                # "foo0:float_series": [np.var([0.1 * i for i in range(10)])],
             },
         ),
         (
@@ -71,10 +67,6 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
                 "bool-value:bool": [False],
                 "datetime-value:datetime": [datetime(2025, 1, 1, 1, 0, 0, 0, timezone.utc)],
                 "foo0:float_series": [0.1 * 9],
-                # ("foo0:float_series", "min"): [0.1 * 0],
-                # ("foo0:float_series", "max"): [0.1 * 9],
-                # ("foo0:float_series", "average"): [np.mean([0.1 * i for i in range(10)])],
-                # ("foo0:float_series", "variance"): [np.var([0.1 * i for i in range(10)])],
             },
         ),
         (
@@ -91,12 +83,6 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
             {
                 "run": ["linear_history_root", "linear_history_fork2"],
                 "foo0:float_series": [0.1 * 9, 0.7 * 19],
-                # ("foo0:float_series", "variance"): [
-                #     np.var([0.1 * i for i in range(10)]),
-                #     np.var(
-                #         [0.1 * i for i in range(5)] + [0.4 * i for i in range(5, 9)] + [0.7 * i for i in range(9, 20)]
-                #     ),
-                # ],
             },
         ),
         (
@@ -198,8 +184,6 @@ def test_fetch_runs_table(
     expected = pd.DataFrame(expected_data).sort_values("run", ascending=False)
     expected["run"] = expected["run"].astype(object)
     expected.set_index("run", drop=True, inplace=True)
-
-    # expected.columns = pd.MultiIndex.from_tuples(expected.columns, names=["attribute", "aggregation"])
 
     pd.testing.assert_frame_equal(df, expected)
 

--- a/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
@@ -51,7 +51,7 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
         ),
         (
             r"^linear_history_root$",
-            AttributeFilter(name_matches_all=r"foo0$", aggregations=["last", "min", "max", "average", "variance"]),
+            AttributeFilter(name=r"foo0$", aggregations=["last", "min", "max", "average", "variance"]),
             {
                 "run": ["linear_history_root"],
                 ("foo0:float_series", "last"): [0.1 * 9],
@@ -63,8 +63,8 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
         ),
         (
             "^linear_history_root$",
-            AttributeFilter(name_matches_all="foo0$", aggregations=["last", "min", "max", "average", "variance"])
-            | AttributeFilter(name_matches_all=".*-value$"),
+            AttributeFilter(name="foo0$", aggregations=["last", "min", "max", "average", "variance"])
+            | AttributeFilter(name=".*-value$"),
             {
                 "run": ["linear_history_root"],
                 ("int-value:int", ""): [1],
@@ -81,7 +81,7 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
         ),
         (
             r"^linear_history_root$|^linear_history_fork2$",
-            AttributeFilter(name_matches_all=r"foo0$", aggregations=["last", "variance"]),
+            AttributeFilter(name=r"foo0$", aggregations=["last", "variance"]),
             {
                 "run": ["linear_history_root", "linear_history_fork2"],
                 ("foo0:float_series", "last"): [0.1 * 9, 0.7 * 19],
@@ -95,7 +95,7 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
         ),
         (
             ["linear_history_root", "linear_history_fork2"],
-            AttributeFilter(name_matches_all=r"foo0$", aggregations=["last", "variance"]),
+            AttributeFilter(name=r"foo0$", aggregations=["last", "variance"]),
             {
                 "run": ["linear_history_root", "linear_history_fork2"],
                 ("foo0:float_series", "last"): [0.1 * 9, 0.7 * 19],

--- a/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
@@ -123,7 +123,7 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
             },
         ),
         (
-            Filter.matches_all("sys/custom_run_id", r"forked_history_root|forked_history_fork1"),
+            Filter.matches("sys/custom_run_id", r"forked_history_root|forked_history_fork1"),
             r".*-value$",
             {
                 "run": ["forked_history_root", "forked_history_fork1"],

--- a/tests/e2e/v1/runs/test_runs_list.py
+++ b/tests/e2e/v1/runs/test_runs_list.py
@@ -21,7 +21,8 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
         ".*",
         None,
         [run.custom_run_id for run in ALL_STATIC_RUNS],
-        Filter.name_in(*[run.experiment_name for run in ALL_STATIC_RUNS]),
+        Filter.name([run.experiment_name for run in ALL_STATIC_RUNS]),
+        Filter.name(" | ".join(run.experiment_name for run in ALL_STATIC_RUNS)),
     ],
 )
 def test_list_all_runs(new_project_id, arg_runs):
@@ -38,7 +39,8 @@ def test_list_all_runs(new_project_id, arg_runs):
     [
         "linear.*",
         [run.custom_run_id for run in LINEAR_HISTORY_TREE],
-        Filter.name_in(*[run.experiment_name for run in LINEAR_HISTORY_TREE]),
+        Filter.name([run.experiment_name for run in LINEAR_HISTORY_TREE]),
+        Filter.name(" | ".join(run.experiment_name for run in LINEAR_HISTORY_TREE)),
         Filter.eq("linear-history", True),
         Filter.eq(Attribute(name="linear-history", type="bool"), True),
         Filter.eq(Attribute(name="linear-history"), True),

--- a/tests/e2e/v1/runs/test_runs_list_attributes.py
+++ b/tests/e2e/v1/runs/test_runs_list_attributes.py
@@ -44,11 +44,11 @@ def test_list_attributes(new_project_id, arg_runs, expected):
     "_attr_filter, expected",
     [
         # DateTime attributes
-        (AttributeFilter(name_eq="datetime-value", type_in=["datetime"]), {"datetime-value"}),
+        (AttributeFilter(name="datetime-value", type_in=["datetime"]), {"datetime-value"}),
         # Numeric series
-        (AttributeFilter(name_eq="unique1/0", type_in=["float_series"]), {"unique1/0"}),
-        (AttributeFilter(name_eq="foo0", type_in=["float_series"]), {"foo0"}),
-        (AttributeFilter(name_eq="foo1", type_in=["float_series"]), {"foo1"}),
+        (AttributeFilter(name="unique1/0", type_in=["float_series"]), {"unique1/0"}),
+        (AttributeFilter(name="foo0", type_in=["float_series"]), {"foo0"}),
+        (AttributeFilter(name="foo1", type_in=["float_series"]), {"foo1"}),
         # Primitive types
         (AttributeFilter(type_in=["int"]), {"int-value"}),
         (AttributeFilter(type_in=["float"]), {"float-value"}),
@@ -57,14 +57,13 @@ def test_list_attributes(new_project_id, arg_runs, expected):
         # Multiple types
         (AttributeFilter(type_in=["float", "int"]), {"float-value", "int-value"}),
         # Name patterns
-        (AttributeFilter(name_matches_all="unique.*"), {"unique1/0", "unique2/0"}),
-        (AttributeFilter(name_matches_all="foo.*"), {"foo0", "foo1"}),
+        (AttributeFilter(name="unique.*"), {"unique1/0", "unique2/0"}),
+        (AttributeFilter(name="foo.*"), {"foo0", "foo1"}),
         # Combined filters
-        (AttributeFilter(name_matches_all=".*value.*", type_in=["float"]), {"float-value"}),
-        (AttributeFilter(name_matches_all=".*value.*", type_in=["int"]), {"int-value"}),
+        (AttributeFilter(name=".*value.*", type_in=["float"]), {"float-value"}),
+        (AttributeFilter(name=".*value.*", type_in=["int"]), {"int-value"}),
         (
-            AttributeFilter(name_matches_all=".*value.*", type_in=["float"])
-            | AttributeFilter(name_matches_all=".*value.*", type_in=["int"]),
+            AttributeFilter(name=".*value.*", type_in=["float"]) | AttributeFilter(name=".*value.*", type_in=["int"]),
             {"float-value", "int-value"},
         ),
     ],

--- a/tests/e2e/v1/runs/test_runs_list_attributes.py
+++ b/tests/e2e/v1/runs/test_runs_list_attributes.py
@@ -44,26 +44,26 @@ def test_list_attributes(new_project_id, arg_runs, expected):
     "_attr_filter, expected",
     [
         # DateTime attributes
-        (AttributeFilter(name="datetime-value", type_in=["datetime"]), {"datetime-value"}),
+        (AttributeFilter(name="datetime-value", type=["datetime"]), {"datetime-value"}),
         # Numeric series
-        (AttributeFilter(name="unique1/0", type_in=["float_series"]), {"unique1/0"}),
-        (AttributeFilter(name="foo0", type_in=["float_series"]), {"foo0"}),
-        (AttributeFilter(name="foo1", type_in=["float_series"]), {"foo1"}),
+        (AttributeFilter(name="unique1/0", type=["float_series"]), {"unique1/0"}),
+        (AttributeFilter(name="foo0", type=["float_series"]), {"foo0"}),
+        (AttributeFilter(name="foo1", type=["float_series"]), {"foo1"}),
         # Primitive types
-        (AttributeFilter(type_in=["int"]), {"int-value"}),
-        (AttributeFilter(type_in=["float"]), {"float-value"}),
-        (AttributeFilter(type_in=["string"]), {"str-value"}),
-        (AttributeFilter(type_in=["bool"]), {"bool-value"}),
+        (AttributeFilter(type=["int"]), {"int-value"}),
+        (AttributeFilter(type=["float"]), {"float-value"}),
+        (AttributeFilter(type=["string"]), {"str-value"}),
+        (AttributeFilter(type=["bool"]), {"bool-value"}),
         # Multiple types
-        (AttributeFilter(type_in=["float", "int"]), {"float-value", "int-value"}),
+        (AttributeFilter(type=["float", "int"]), {"float-value", "int-value"}),
         # Name patterns
         (AttributeFilter(name="unique.*"), {"unique1/0", "unique2/0"}),
         (AttributeFilter(name="foo.*"), {"foo0", "foo1"}),
         # Combined filters
-        (AttributeFilter(name=".*value.*", type_in=["float"]), {"float-value"}),
-        (AttributeFilter(name=".*value.*", type_in=["int"]), {"int-value"}),
+        (AttributeFilter(name=".*value.*", type=["float"]), {"float-value"}),
+        (AttributeFilter(name=".*value.*", type=["int"]), {"int-value"}),
         (
-            AttributeFilter(name=".*value.*", type_in=["float"]) | AttributeFilter(name=".*value.*", type_in=["int"]),
+            AttributeFilter(name=".*value.*", type=["float"]) | AttributeFilter(name=".*value.*", type=["int"]),
             {"float-value", "int-value"},
         ),
     ],

--- a/tests/e2e/v1/runs/test_runs_list_attributes.py
+++ b/tests/e2e/v1/runs/test_runs_list_attributes.py
@@ -21,10 +21,10 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
     [
         (".*", ALL_STATIC_RUNS),
         (None, ALL_STATIC_RUNS),
-        (Filter.name_in(*[run.experiment_name for run in ALL_STATIC_RUNS]), ALL_STATIC_RUNS),
+        (Filter.name([run.experiment_name for run in ALL_STATIC_RUNS]), ALL_STATIC_RUNS),
         ([run.custom_run_id for run in ALL_STATIC_RUNS], ALL_STATIC_RUNS),
         ("linear.*", LINEAR_HISTORY_TREE),
-        (Filter.name_in(*[run.experiment_name for run in LINEAR_HISTORY_TREE]), LINEAR_HISTORY_TREE),
+        (Filter.name([run.experiment_name for run in LINEAR_HISTORY_TREE]), LINEAR_HISTORY_TREE),
         (Filter.eq("linear-history", True), LINEAR_HISTORY_TREE),
         (Filter.eq(Attribute(name="linear-history", type="bool"), True), LINEAR_HISTORY_TREE),
     ],

--- a/tests/e2e/v1/test_attributes.py
+++ b/tests/e2e/v1/test_attributes.py
@@ -71,23 +71,22 @@ ALL_V1_ATTRIBUTE_NAMES = set(
             },
         ),
         (rf"{PATH}/unique-value-[0-9]", {f"{PATH}/unique-value-{i}" for i in range(6)}),
-        (AttributeFilter(name_matches_all=PATH), ALL_V1_ATTRIBUTE_NAMES),
-        (AttributeFilter(name_eq=f"{PATH}/float-value"), {f"{PATH}/float-value"}),
+        (AttributeFilter(name=PATH), ALL_V1_ATTRIBUTE_NAMES),
+        (AttributeFilter(name=f"{PATH}/float-value"), {f"{PATH}/float-value"}),
         (
-            AttributeFilter.any(AttributeFilter(name_matches_all="^(foo)"), AttributeFilter(name_matches_all=PATH)),
+            AttributeFilter.any(AttributeFilter(name="^(foo)"), AttributeFilter(name=PATH)),
             ALL_V1_ATTRIBUTE_NAMES,
         ),
-        (AttributeFilter(name_matches_none=".*"), []),
         (
-            AttributeFilter(name_matches_all=rf"{PATH}/metrics/string-series-value_.*", type_in=["string_series"]),
+            AttributeFilter(name=rf"{PATH}/metrics/string-series-value_.*", type_in=["string_series"]),
             set(STRING_SERIES_PATHS),
         ),
         (
-            AttributeFilter(
-                name_matches_all=rf"{PATH}/metrics/histogram-series-value_.*", type_in=["histogram_series"]
-            ),
+            AttributeFilter(name=rf"{PATH}/metrics/histogram-series-value_.*", type_in=["histogram_series"]),
             set(HISTOGRAM_SERIES_PATHS),
         ),
+        (AttributeFilter(name=f"^(foo) | {PATH}"), ALL_V1_ATTRIBUTE_NAMES),  # ERS OR
+        (AttributeFilter(name="!.*"), []),  # ERS NOT
     ],
 )
 def test_list_attributes_known_in_all_experiments_with_name_filter_excluding_sys(
@@ -109,7 +108,7 @@ def test_list_attributes_known_in_all_experiments_with_name_filter_excluding_sys
         None,
         "",
         ".*",
-        AttributeFilter(name_matches_all=".*"),
+        AttributeFilter(name=".*"),
         AttributeFilter(),
     ),
 )
@@ -126,8 +125,7 @@ def test_list_attributes_all_names_from_all_experiments_excluding_sys(name_filte
         ".*unknown.*",
         "sys/abcdef",
         "\\x20",
-        AttributeFilter(name_eq=".*"),
-        AttributeFilter(name_matches_all="unknown"),
+        AttributeFilter(name="unknown"),
     ),
 )
 def test_list_attributes_unknown_name(filter_):
@@ -168,12 +166,12 @@ def test_list_attributes_unknown_name(filter_):
         ),
         (
             Filter.gt(Attribute(f"{PATH}/int-value", type="int"), 1234) & EXPERIMENTS_IN_THIS_TEST,
-            AttributeFilter(name_matches_none="sys/.*", name_matches_all=".*"),
+            AttributeFilter(name="!sys/.* & .*"),
             [],
         ),
         (
             Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_12345") & EXPERIMENTS_IN_THIS_TEST,
-            AttributeFilter(name_matches_none="sys/.*", name_matches_all=".*"),
+            AttributeFilter(name="!sys/.* & .*"),
             [],
         ),
         (
@@ -210,7 +208,8 @@ def test_list_attributes_depending_on_values_in_experiments(arg_experiments, arg
             {"sys/name", "sys/id"},
         ),
         (r"sys/.*id$", {"sys/custom_run_id", "sys/id", "sys/diagnostics/project_uuid", "sys/diagnostics/run_uuid"}),
-        (AttributeFilter(name_matches_all=r"sys/(name|id)"), {"sys/name", "sys/id"}),
+        (AttributeFilter(name="sys/(name|id)"), {"sys/name", "sys/id"}),
+        (AttributeFilter(name="sys/name | sys/id"), {"sys/name", "sys/id"}),  # ERS
     ],
 )
 def test_list_attributes_sys_attrs(attribute_filter, expected):

--- a/tests/e2e/v1/test_attributes.py
+++ b/tests/e2e/v1/test_attributes.py
@@ -28,7 +28,7 @@ def _drop_sys_attr_names(attributes: Iterable[str]) -> list[str]:
 
 # Convenience filter to limit searches to experiments belonging to this test,
 # in case the run has some extra experiments.
-EXPERIMENTS_IN_THIS_TEST = Filter.name_in(*TEST_DATA.experiment_names)
+EXPERIMENTS_IN_THIS_TEST = Filter.name(TEST_DATA.experiment_names)
 
 ALL_V1_ATTRIBUTE_NAMES = set(
     it.chain.from_iterable(exp.all_attribute_names - exp.file_series.keys() for exp in TEST_DATA.experiments)

--- a/tests/e2e/v1/test_attributes.py
+++ b/tests/e2e/v1/test_attributes.py
@@ -78,11 +78,11 @@ ALL_V1_ATTRIBUTE_NAMES = set(
             ALL_V1_ATTRIBUTE_NAMES,
         ),
         (
-            AttributeFilter(name=rf"{PATH}/metrics/string-series-value_.*", type_in=["string_series"]),
+            AttributeFilter(name=rf"{PATH}/metrics/string-series-value_.*", type=["string_series"]),
             set(STRING_SERIES_PATHS),
         ),
         (
-            AttributeFilter(name=rf"{PATH}/metrics/histogram-series-value_.*", type_in=["histogram_series"]),
+            AttributeFilter(name=rf"{PATH}/metrics/histogram-series-value_.*", type=["histogram_series"]),
             set(HISTOGRAM_SERIES_PATHS),
         ),
         (AttributeFilter(name=f"^(foo) | {PATH}"), ALL_V1_ATTRIBUTE_NAMES),  # ERS OR

--- a/tests/e2e/v1/test_experiments.py
+++ b/tests/e2e/v1/test_experiments.py
@@ -28,7 +28,7 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
 @pytest.mark.parametrize("sort_direction", ["asc", "desc"])
 def test__fetch_experiments_table(project, run_with_attributes, sort_direction):
     df = fetch_experiments_table(
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments]),
+        experiments=[exp.name for exp in TEST_DATA.experiments],
         sort_by=Attribute("sys/name", type="string"),
         sort_direction=sort_direction,
         project=project.project_identifier,
@@ -51,12 +51,8 @@ def test__fetch_experiments_table(project, run_with_attributes, sort_direction):
     [
         f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
         [TEST_DATA.exp_name(0), TEST_DATA.exp_name(1), TEST_DATA.exp_name(2)],
-        Filter.name_in(TEST_DATA.exp_name(0), TEST_DATA.exp_name(1), TEST_DATA.exp_name(2)),
-        (
-            Filter.name_eq(TEST_DATA.exp_name(0))
-            | Filter.name_eq(TEST_DATA.exp_name(1))
-            | Filter.name_eq(TEST_DATA.exp_name(2))
-        ),
+        Filter.name(" | ".join([TEST_DATA.exp_name(0), TEST_DATA.exp_name(1), TEST_DATA.exp_name(2)])),
+        (Filter.name(TEST_DATA.exp_name(0)) | Filter.name(TEST_DATA.exp_name(1)) | Filter.name(TEST_DATA.exp_name(2))),
     ],
 )
 @pytest.mark.parametrize(
@@ -125,7 +121,7 @@ def test__fetch_experiments_table_with_attributes_filter_for_metrics(
 ):
     df = fetch_experiments_table(
         project=project.project_identifier,
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        experiments=[exp.name for exp in TEST_DATA.experiments[:3]],
         sort_by=Attribute("sys/name", type="string"),
         sort_direction="asc",
         attributes=attr_filter,
@@ -181,7 +177,7 @@ def test__fetch_experiments_table_with_attributes_filter_for_string_series(
 ):
     df = fetch_experiments_table(
         project=project.project_identifier,
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:2]]),
+        experiments=[exp.name for exp in TEST_DATA.experiments[:2]],
         sort_by=Attribute("sys/name", type="string"),
         sort_direction="asc",
         attributes=attr_filter,
@@ -219,7 +215,7 @@ def test__fetch_experiments_table_with_attributes_filter_for_histogram_series(
 ):
     df = fetch_experiments_table(
         project=project.project_identifier,
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:2]]),
+        experiments=Filter.name(exp.name for exp in TEST_DATA.experiments[:2]),
         sort_by=Attribute("sys/name", type="string"),
         sort_direction="asc",
         attributes=attr_filter,
@@ -258,7 +254,7 @@ def test__fetch_experiments_table_with_attributes_filter_for_series_wrong_aggreg
 ):
     df = fetch_experiments_table(
         project=project.project_identifier,
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:2]]),
+        experiments=[exp.name for exp in TEST_DATA.experiments[:2]],
         sort_by=Attribute("sys/name", type="string"),
         sort_direction="asc",
         attributes=attr_filter,
@@ -284,7 +280,7 @@ def test__fetch_experiments_table_with_attributes_regex_filter_for_metrics(
 ):
     df = fetch_experiments_table(
         project=project.project_identifier,
-        experiments=Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        experiments=[exp.name for exp in TEST_DATA.experiments[:3]],
         sort_by=Attribute("sys/name", type="string"),
         sort_direction="asc",
         attributes=attr_filter,
@@ -319,7 +315,7 @@ def test__fetch_experiments_table_with_attributes_regex_filter_for_metrics(
         (".*", TEST_DATA.experiment_names),
         ("", TEST_DATA.experiment_names),
         ("test_alpha", TEST_DATA.experiment_names),
-        (Filter.matches_all(Attribute("sys/name", type="string"), ".*"), TEST_DATA.experiment_names),
+        (Filter.matches(Attribute("sys/name", type="string"), ".*"), TEST_DATA.experiment_names),
     ],
 )
 def test_list_experiments_with_regex_and_filters_matching_all(project, arg_experiments, expected_subset):
@@ -359,15 +355,15 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
     "arg_experiments, expected",
     [
         (Filter.eq(Attribute("sys/name", type="string"), ""), []),
-        (Filter.name_in(*TEST_DATA.experiment_names), TEST_DATA.experiment_names),
+        (TEST_DATA.experiment_names, TEST_DATA.experiment_names),
         (
-            Filter.matches_all(Attribute("sys/name", type="string"), [f"alpha.*{TEST_DATA_VERSION}", "_3"]),
+            Filter.matches(Attribute("sys/name", type="string"), f"alpha.*{TEST_DATA_VERSION} & _3"),
             [f"test_alpha_3" f"_{TEST_DATA_VERSION}"],
         ),
         (TEST_DATA.experiment_names, TEST_DATA.experiment_names),
         (
-            Filter.matches_none(Attribute("sys/name", type="string"), ["alpha_3", "alpha_4", "alpha_5"])
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            Filter.matches(Attribute("sys/name", type="string"), "!alpha_3 & !alpha_4 & !alpha_5")
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [
                 f"test_alpha_0_{TEST_DATA_VERSION}",
                 f"test_alpha_1_{TEST_DATA_VERSION}",
@@ -377,7 +373,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
         (Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_123"), []),
         (
             Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_1")
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_1_{TEST_DATA_VERSION}"],
         ),
         (
@@ -385,36 +381,36 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
                 Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_1")
                 | Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_2")
             )
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_1_{TEST_DATA_VERSION}", f"test_alpha_2_{TEST_DATA_VERSION}"],
         ),
         (
             Filter.ne(Attribute(f"{PATH}/str-value", type="string"), "hello_1")
             & Filter.eq(Attribute(f"{PATH}/str-value", type="string"), "hello_2")
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_2_{TEST_DATA_VERSION}"],
         ),
         (Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 12345), []),
         (
             Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 2)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_2_{TEST_DATA_VERSION}"],
         ),
         (
             Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 2)
             | Filter.eq(Attribute(f"{PATH}/int-value", type="int"), 3)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_2_{TEST_DATA_VERSION}", f"test_alpha_3_{TEST_DATA_VERSION}"],
         ),
         (Filter.eq(Attribute(f"{PATH}/float-value", type="float"), 1.2345), []),
         (
             Filter.eq(Attribute(f"{PATH}/float-value", type="float"), 3)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_3_{TEST_DATA_VERSION}"],
         ),
         (
             Filter.eq(Attribute(f"{PATH}/bool-value", type="bool"), False)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [
                 f"test_alpha_1_{TEST_DATA_VERSION}",
                 f"test_alpha_3_{TEST_DATA_VERSION}",
@@ -423,7 +419,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
         ),
         (
             Filter.eq(Attribute(f"{PATH}/bool-value", type="bool"), True)
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [
                 f"test_alpha_0_{TEST_DATA_VERSION}",
                 f"test_alpha_2_{TEST_DATA_VERSION}",
@@ -437,7 +433,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
         ),
         (
             Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), ["string-1-0", "string-1-1"])
-            & Filter.matches_all(Attribute("sys/name", type="string"), TEST_DATA_VERSION),
+            & Filter.matches(Attribute("sys/name", type="string"), TEST_DATA_VERSION),
             [f"test_alpha_1_{TEST_DATA_VERSION}"],
         ),
         (
@@ -445,7 +441,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
                 Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "string-1-0")
                 | Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "string-0-0")
             )
-            & Filter.matches_all(Attribute("sys/name", type="string"), TEST_DATA_VERSION),
+            & Filter.matches(Attribute("sys/name", type="string"), TEST_DATA_VERSION),
             [f"test_alpha_0_{TEST_DATA_VERSION}", f"test_alpha_1_{TEST_DATA_VERSION}"],
         ),
         (
@@ -453,7 +449,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
                 Attribute(f"{PATH}/string_set-value", type="string_set"),
                 ["string-1-0", "string-2-0", "string-3-0"],
             )
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [
                 f"test_alpha_0_{TEST_DATA_VERSION}",
                 f"test_alpha_4_{TEST_DATA_VERSION}",
@@ -466,7 +462,7 @@ def test_list_experiments_with_regex_matching_some(project, regex, expected):
                 ["string-1-0", "string-2-0", "string-3-0"],
             )
             & Filter.contains_all(Attribute(f"{PATH}/string_set-value", type="string_set"), "string-0-0")
-            & Filter.matches_all(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
+            & Filter.matches(Attribute("sys/name", type="string"), f"test_alpha_[0-9]_{TEST_DATA_VERSION}"),
             [f"test_alpha_0_{TEST_DATA_VERSION}"],
         ),
         (
@@ -498,3 +494,13 @@ def test_list_experiments_with_filter_matching_some(project, arg_experiments, ex
     )
     assert set(names) == set(expected)
     assert len(names) == len(expected)
+
+
+def test_empty_experiment_list(project):
+    """Test the behavior of filtering by experiments=[]
+
+    In alpha, this used to return all experiments, but in v1 it will raises an error
+    """
+
+    with pytest.raises(ValueError, match="got an empty list"):
+        list_experiments(project=project, experiments=[])

--- a/tests/e2e/v1/test_experiments.py
+++ b/tests/e2e/v1/test_experiments.py
@@ -267,11 +267,8 @@ def test__fetch_experiments_table_with_attributes_filter_for_series_wrong_aggreg
 @pytest.mark.parametrize(
     "attr_filter",
     [
-        AttributeFilter(name_matches_all=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}"),
-        AttributeFilter(
-            name_matches_all=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}",
-            name_matches_none=".*value_[5-9].*",
-        ),
+        AttributeFilter(name=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}"),
+        AttributeFilter(name=f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]} & !.*value_[5-9].*"),
         f"{PATH}/metrics/step|{FLOAT_SERIES_PATHS[0]}|{FLOAT_SERIES_PATHS[1]}",
     ],
 )

--- a/tests/e2e/v1/test_experiments.py
+++ b/tests/e2e/v1/test_experiments.py
@@ -61,13 +61,13 @@ def test__fetch_experiments_table(project, run_with_attributes, sort_direction):
         f"{PATH}/int-value|{PATH}/float-value|{PATH}/metrics/step",
         [f"{PATH}/int-value", f"{PATH}/float-value", f"{PATH}/metrics/step"],
         AttributeFilter.any(
-            AttributeFilter(f"{PATH}/int-value", type_in=["int"]),
-            AttributeFilter(f"{PATH}/float-value", type_in=["float"]),
-            AttributeFilter(f"{PATH}/metrics/step", type_in=["float_series"]),
+            AttributeFilter(f"{PATH}/int-value", type=["int"]),
+            AttributeFilter(f"{PATH}/float-value", type=["float"]),
+            AttributeFilter(f"{PATH}/metrics/step", type=["float_series"]),
         ),
-        AttributeFilter(f"{PATH}/int-value", type_in=["int"])
-        | AttributeFilter(f"{PATH}/float-value", type_in=["float"])
-        | AttributeFilter(f"{PATH}/metrics/step", type_in=["float_series"]),
+        AttributeFilter(f"{PATH}/int-value", type=["int"])
+        | AttributeFilter(f"{PATH}/float-value", type=["float"])
+        | AttributeFilter(f"{PATH}/metrics/step", type=["float_series"]),
     ],
 )
 @pytest.mark.parametrize("type_suffix_in_column_names", [True, False])
@@ -110,10 +110,10 @@ def test__fetch_experiments_table_with_attributes_filter(
     "attr_filter",
     [
         AttributeFilter(
-            f"{PATH}/metrics/step", type_in=["float_series"], aggregations=["last", "min", "max", "average", "variance"]
+            f"{PATH}/metrics/step", type=["float_series"], aggregations=["last", "min", "max", "average", "variance"]
         )
-        | AttributeFilter(FLOAT_SERIES_PATHS[0], type_in=["float_series"], aggregations=["average", "variance"])
-        | AttributeFilter(FLOAT_SERIES_PATHS[1], type_in=["float_series"]),
+        | AttributeFilter(FLOAT_SERIES_PATHS[0], type=["float_series"], aggregations=["average", "variance"])
+        | AttributeFilter(FLOAT_SERIES_PATHS[1], type=["float_series"]),
     ],
 )
 def test__fetch_experiments_table_with_attributes_filter_for_metrics(
@@ -168,8 +168,8 @@ def test__fetch_experiments_table_with_attributes_filter_for_metrics(
 @pytest.mark.parametrize(
     "attr_filter",
     [
-        AttributeFilter(f"{PATH}/metrics/string-series-value_0", type_in=["string_series"], aggregations=["last"])
-        | AttributeFilter(f"{PATH}/metrics/string-series-value_1", type_in=["string_series"])
+        AttributeFilter(f"{PATH}/metrics/string-series-value_0", type=["string_series"], aggregations=["last"])
+        | AttributeFilter(f"{PATH}/metrics/string-series-value_1", type=["string_series"])
     ],
 )
 def test__fetch_experiments_table_with_attributes_filter_for_string_series(
@@ -206,8 +206,8 @@ def test__fetch_experiments_table_with_attributes_filter_for_string_series(
 @pytest.mark.parametrize(
     "attr_filter",
     [
-        AttributeFilter(f"{PATH}/metrics/histogram-series-value_0", type_in=["histogram_series"], aggregations=["last"])
-        | AttributeFilter(f"{PATH}/metrics/histogram-series-value_1", type_in=["histogram_series"])
+        AttributeFilter(f"{PATH}/metrics/histogram-series-value_0", type=["histogram_series"], aggregations=["last"])
+        | AttributeFilter(f"{PATH}/metrics/histogram-series-value_1", type=["histogram_series"])
     ],
 )
 def test__fetch_experiments_table_with_attributes_filter_for_histogram_series(
@@ -245,8 +245,8 @@ def test__fetch_experiments_table_with_attributes_filter_for_histogram_series(
 @pytest.mark.parametrize(
     "attr_filter",
     [
-        AttributeFilter(f"{PATH}/metrics/string-series-value_0", type_in=["string_series"], aggregations=[]),
-        AttributeFilter(f"{PATH}/metrics/string-series-value_0", type_in=["string_series"], aggregations=["min"]),
+        AttributeFilter(f"{PATH}/metrics/string-series-value_0", type=["string_series"], aggregations=[]),
+        AttributeFilter(f"{PATH}/metrics/string-series-value_0", type=["string_series"], aggregations=["min"]),
     ],
 )
 def test__fetch_experiments_table_with_attributes_filter_for_series_wrong_aggregation(

--- a/tests/e2e/v1/test_fetch_metrics.py
+++ b/tests/e2e/v1/test_fetch_metrics.py
@@ -106,11 +106,11 @@ def create_expected_data(
 @pytest.mark.parametrize(
     "arg_attributes",
     [
-        AttributeFilter(name=r".*/metrics/.*", type_in=["float_series"]),
+        AttributeFilter(name=r".*/metrics/.*", type=["float_series"]),
         ".*/metrics/.*",
         # Alternative should work too, see bug PY-137
-        AttributeFilter(name=r".*/metrics/.*", type_in=["float_series"])
-        | AttributeFilter(name=r".*/metrics/.*", type_in=["float_series"]),
+        AttributeFilter(name=r".*/metrics/.*", type=["float_series"])
+        | AttributeFilter(name=r".*/metrics/.*", type=["float_series"]),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/e2e/v1/test_fetch_metrics.py
+++ b/tests/e2e/v1/test_fetch_metrics.py
@@ -116,8 +116,9 @@ def create_expected_data(
 @pytest.mark.parametrize(
     "arg_experiments",
     [
-        Filter.name_in(*[exp.name for exp in TEST_DATA.experiments[:3]]),
+        Filter.name([exp.name for exp in TEST_DATA.experiments[:3]]),
         f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
+        f"{TEST_DATA.exp_name(0)} | {TEST_DATA.exp_name(1)} | {TEST_DATA.exp_name(2)}",  # ERS
         [exp.name for exp in TEST_DATA.experiments[:3]],
     ],
 )

--- a/tests/e2e/v1/test_fetch_metrics.py
+++ b/tests/e2e/v1/test_fetch_metrics.py
@@ -106,11 +106,11 @@ def create_expected_data(
 @pytest.mark.parametrize(
     "arg_attributes",
     [
-        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]),
+        AttributeFilter(name=r".*/metrics/.*", type_in=["float_series"]),
         ".*/metrics/.*",
         # Alternative should work too, see bug PY-137
-        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"])
-        | AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["float_series"]),
+        AttributeFilter(name=r".*/metrics/.*", type_in=["float_series"])
+        | AttributeFilter(name=r".*/metrics/.*", type_in=["float_series"]),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/e2e/v1/test_fetch_series.py
+++ b/tests/e2e/v1/test_fetch_series.py
@@ -100,10 +100,9 @@ def create_expected_data_string_series(
 @pytest.mark.parametrize(
     "arg_attributes",
     [
-        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["string_series"]),
+        AttributeFilter(name=r".*/metrics/.*", type_in=["string_series"]),
         ".*/metrics/string-series.*",
-        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["string_series"])
-        | AttributeFilter(name_matches_all=[".*/int-value"]),
+        AttributeFilter(name=r".*/metrics/.*", type_in=["string_series"]) | AttributeFilter(name=".*/int-value"),
     ],
 )
 @pytest.mark.parametrize(
@@ -210,10 +209,9 @@ def create_expected_data_histogram_series(
 @pytest.mark.parametrize(
     "arg_attributes",
     [
-        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["histogram_series"]),
+        AttributeFilter(name=".*/metrics/.*", type_in=["histogram_series"]),
         ".*/metrics/histogram-series.*",
-        AttributeFilter(name_matches_all=[r".*/metrics/.*"], type_in=["histogram_series"])
-        | AttributeFilter(name_matches_all=[".*/int-value"]),
+        AttributeFilter(name=".*/metrics/.*", type_in=["histogram_series"]) | AttributeFilter(name=".*/int-value"),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/e2e/v1/test_fetch_series.py
+++ b/tests/e2e/v1/test_fetch_series.py
@@ -23,7 +23,10 @@ from neptune_fetcher.internal.identifiers import (
 from neptune_fetcher.internal.output_format import create_series_dataframe
 from neptune_fetcher.internal.retrieval.series import SeriesValue
 from neptune_fetcher.v1 import fetch_series
-from neptune_fetcher.v1.filters import AttributeFilter
+from neptune_fetcher.v1.filters import (
+    AttributeFilter,
+    Filter,
+)
 from tests.e2e.data import (
     NOW,
     NUMBER_OF_STEPS,
@@ -106,7 +109,9 @@ def create_expected_data_string_series(
 @pytest.mark.parametrize(
     "arg_experiments",
     [
+        Filter.name([exp.name for exp in TEST_DATA.experiments[:3]]),
         f"{TEST_DATA.exp_name(0)}|{TEST_DATA.exp_name(1)}|{TEST_DATA.exp_name(2)}",
+        f"{TEST_DATA.exp_name(0)} | {TEST_DATA.exp_name(1)} | {TEST_DATA.exp_name(2)}",  # ERS
         [exp.name for exp in TEST_DATA.experiments[:3]],
     ],
 )

--- a/tests/e2e/v1/test_fetch_series.py
+++ b/tests/e2e/v1/test_fetch_series.py
@@ -100,9 +100,9 @@ def create_expected_data_string_series(
 @pytest.mark.parametrize(
     "arg_attributes",
     [
-        AttributeFilter(name=r".*/metrics/.*", type_in=["string_series"]),
+        AttributeFilter(name=r".*/metrics/.*", type=["string_series"]),
         ".*/metrics/string-series.*",
-        AttributeFilter(name=r".*/metrics/.*", type_in=["string_series"]) | AttributeFilter(name=".*/int-value"),
+        AttributeFilter(name=r".*/metrics/.*", type=["string_series"]) | AttributeFilter(name=".*/int-value"),
     ],
 )
 @pytest.mark.parametrize(
@@ -209,9 +209,9 @@ def create_expected_data_histogram_series(
 @pytest.mark.parametrize(
     "arg_attributes",
     [
-        AttributeFilter(name=".*/metrics/.*", type_in=["histogram_series"]),
+        AttributeFilter(name=".*/metrics/.*", type=["histogram_series"]),
         ".*/metrics/histogram-series.*",
-        AttributeFilter(name=".*/metrics/.*", type_in=["histogram_series"]) | AttributeFilter(name=".*/int-value"),
+        AttributeFilter(name=".*/metrics/.*", type=["histogram_series"]) | AttributeFilter(name=".*/int-value"),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/unit/internal/test_pattern.py
+++ b/tests/unit/internal/test_pattern.py
@@ -182,6 +182,6 @@ def test_build_extended_regex_filter(attribute, pattern, query):
     ],
 )
 def test_build_extended_regex_attribute_filter(type_in, pattern, expected):
-    result = build_extended_regex_attribute_filter(pattern, type_in)
+    result = build_extended_regex_attribute_filter(pattern, type_in=type_in, aggregations=["last"])
 
     assert result == expected

--- a/tests/unit/v1/test_split.py
+++ b/tests/unit/v1/test_split.py
@@ -54,7 +54,7 @@ def test_list_attributes_patched(sys_id_length, exp_count, expected_calls):
         npt.list_attributes(
             project=project,
             experiments="ignored",
-            attributes=AttributeFilter(name_eq="ignored"),
+            attributes=AttributeFilter(name="ignored"),
         )
 
     # then
@@ -145,7 +145,7 @@ def test_fetch_experiments_table_patched(sys_id_length, exp_count, attr_name_len
         npt.fetch_experiments_table(
             project=project,
             experiments="ignored",
-            attributes=AttributeFilter(name_eq="ignored"),
+            attributes=AttributeFilter(name="ignored"),
         )
 
     # then
@@ -223,7 +223,7 @@ def test_fetch_series_patched(sys_id_length, exp_count, attr_name_length, attr_c
         npt.fetch_series(
             project=project,
             experiments="ignored",
-            attributes=AttributeFilter(name_eq="ignored"),
+            attributes=AttributeFilter(name="ignored"),
         )
 
     # then
@@ -301,7 +301,7 @@ def test_fetch_metrics_patched(sys_id_length, exp_count, attr_name_length, attr_
         npt.fetch_metrics(
             project=project,
             experiments="ignored",
-            attributes=AttributeFilter(name_eq="ignored"),
+            attributes=AttributeFilter(name="ignored"),
         )
 
     # then


### PR DESCRIPTION
`Filter`

* `matches_all` & `matches_none` -> `matches` (with ERS support)
* `name_in` & `name_eq` -> `name()` (with ERS support if single string, and direct match alternative if list of strings)

`AttributeFilter`

* `name_matches_all` & `name_matches_none` -> remove
* `name_eq` -> `name` (with ERS support if single string, and direct match alternative if list of strings)
* `type_in` -> `type`

## Summary by Sourcery

Improve the v1 Filter and AttributeFilter APIs by consolidating and renaming methods for name and regex matching, adding extended regular expression support (including OR and NOT operations), and enforcing stricter validation by rejecting empty list filters.

New Features:
- Support extended regex (ERS) patterns in Filter.name and Filter.matches, including OR (|) and NOT (!) operators
- Enable ERS-based patterns in AttributeFilter.name for both inclusion and exclusion

Bug Fixes:
- Raise ValueError on empty experiment, attributes, or runs lists instead of silently returning all or none

Enhancements:
- Merge Filter.name_eq and name_in into a single Filter.name method that accepts either a regex string or list of names
- Rename Filter.matches_all and matches_none to Filter.matches for simplified regex matching
- Refactor AttributeFilter to replace name_eq, name_matches_all, and name_matches_none with a unified name parameter and rename type_in to type
- Update internal resolvers (experiments, attributes, runs) to handle list inputs directly and reject empty lists
- Extend build_extended_regex_attribute_filter to accept optional type_in and aggregations arguments

Tests:
- Update E2E and unit tests to use the new Filter.name and Filter.matches APIs and AttributeFilter.name parameter
- Add tests confirming errors are raised when filtering with empty lists

Chores:
- Update test conftest lockfile naming for v1 sessions
- Improve docstrings for Filter logical operators