### PR TITLE
Use empty attribute list by default in fetch_x_table

### DIFF
--- a/src/neptune_fetcher/internal/composition/attributes.py
+++ b/src/neptune_fetcher/internal/composition/attributes.py
@@ -128,7 +128,9 @@ def _fetch_attribute_definitions(
 
     filters_ = att_defs.split_attribute_filters(attribute_filter)
 
-    if len(filters_) == 1:
+    if len(filters_) == 0:
+        yield from []
+    elif len(filters_) == 1:
         head = filters_[0]
         for page in go_fetch_single(head):
             yield page, head

--- a/src/neptune_fetcher/internal/filters.py
+++ b/src/neptune_fetcher/internal/filters.py
@@ -158,6 +158,13 @@ class _AttributeFilterAlternative(_BaseAttributeFilter):
         return _AttributeFilterAlternative(transformed_filters)
 
 
+class _EmptyAttributeFilter(_BaseAttributeFilter):
+    def transform(
+        self, map_attribute_filter: Callable[["_AttributeFilter"], "_AttributeFilter"]
+    ) -> "_BaseAttributeFilter":
+        return self
+
+
 @dataclass
 class _Attribute:
     """Helper for specifying an attribute and picking a metric aggregation function.

--- a/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
+++ b/src/neptune_fetcher/internal/retrieval/attribute_definitions.py
@@ -44,7 +44,9 @@ from neptune_fetcher.internal.retrieval import retry
 def split_attribute_filters(
     _attribute_filter: filters._BaseAttributeFilter,
 ) -> list[filters._AttributeFilter]:
-    if isinstance(_attribute_filter, filters._AttributeFilter):
+    if isinstance(_attribute_filter, filters._EmptyAttributeFilter):
+        return []
+    elif isinstance(_attribute_filter, filters._AttributeFilter):
         return [_attribute_filter]
     elif isinstance(_attribute_filter, filters._AttributeFilterAlternative):
         return list(it.chain.from_iterable(split_attribute_filters(child) for child in _attribute_filter.filters))

--- a/src/neptune_fetcher/v1/__init__.py
+++ b/src/neptune_fetcher/v1/__init__.py
@@ -167,7 +167,7 @@ def fetch_experiments_table(
     *,
     project: Optional[str] = None,
     experiments: Optional[Union[str, list[str], filters.Filter]] = None,
-    attributes: Union[str, list[str], filters.AttributeFilter] = "^sys/name$",
+    attributes: Union[str, list[str], filters.AttributeFilter] = [],
     sort_by: Union[str, filters.Attribute] = filters.Attribute("sys/creation_time", type="datetime"),
     sort_direction: Literal["asc", "desc"] = "desc",
     limit: Optional[int] = None,

--- a/src/neptune_fetcher/v1/_internal.py
+++ b/src/neptune_fetcher/v1/_internal.py
@@ -58,16 +58,13 @@ def resolve_experiments_filter(
 
 def resolve_attributes_filter(
     attributes: Optional[Union[str, list[str], filters.AttributeFilter]],
-) -> _filters._AttributeFilter:
+) -> Union[_filters._AttributeFilter, _filters._EmptyAttributeFilter]:
     if attributes is None:
         return filters.AttributeFilter()._to_internal()
     if isinstance(attributes, str):
         return filters.AttributeFilter(name=attributes)._to_internal()
     if attributes == []:
-        raise ValueError(
-            "Invalid type for `attributes` filter. Expected str, non-empty list of str, or AttributeFilter object, "
-            "but got empty list."
-        )
+        return _filters._EmptyAttributeFilter()
     if isinstance(attributes, list):
         return filters.AttributeFilter(name=attributes)._to_internal()
     if isinstance(attributes, filters.BaseAttributeFilter):

--- a/src/neptune_fetcher/v1/filters.py
+++ b/src/neptune_fetcher/v1/filters.py
@@ -116,7 +116,7 @@ class AttributeFilter(BaseAttributeFilter):
         _validate_string_or_string_list(self.name, "name")
         _validate_list_of_allowed_values(self.type, KNOWN_TYPES, "type")
 
-    def _to_internal(self) -> _filters._AttributeFilter:
+    def _to_internal(self) -> Union[_filters._AttributeFilter, _filters._EmptyAttributeFilter]:
         if isinstance(self.name, str):
             return _pattern.build_extended_regex_attribute_filter(
                 self.name,
@@ -131,9 +131,7 @@ class AttributeFilter(BaseAttributeFilter):
             )
 
         if self.name == []:
-            raise ValueError(
-                "Invalid type for `name` attribute. Expected str, non-empty list of str, or None, but got empty list."
-            )
+            return _filters._EmptyAttributeFilter()
 
         if isinstance(self.name, list):
             return _filters._AttributeFilter(

--- a/src/neptune_fetcher/v1/runs.py
+++ b/src/neptune_fetcher/v1/runs.py
@@ -165,7 +165,7 @@ def fetch_runs_table(
     *,
     project: Optional[str] = None,
     runs: Optional[Union[str, list[str], filters.Filter]] = None,
-    attributes: Union[str, list[str], filters.AttributeFilter] = "^sys/name$",
+    attributes: Union[str, list[str], filters.AttributeFilter] = [],
     sort_by: Union[str, filters.Attribute] = filters.Attribute("sys/creation_time", type="datetime"),
     sort_direction: Literal["asc", "desc"] = "desc",
     limit: Optional[int] = None,

--- a/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
+++ b/tests/e2e/v1/runs/test_runs_fetch_runs_table.py
@@ -33,6 +33,13 @@ NEPTUNE_PROJECT = os.getenv("NEPTUNE_E2E_PROJECT")
             },
         ),
         (
+            r"^linear_history_root$",
+            [],
+            {
+                "run": ["linear_history_root"],
+            },
+        ),
+        (
             "^non_exist$",
             "^foo0$",
             {

--- a/tests/e2e/v1/test_experiments.py
+++ b/tests/e2e/v1/test_experiments.py
@@ -37,7 +37,25 @@ def test__fetch_experiments_table(project, run_with_attributes, sort_direction):
     expected = pd.DataFrame(
         {
             "experiment": experiments if sort_direction == "asc" else experiments[::-1],
-            "sys/name": experiments if sort_direction == "asc" else experiments[::-1],
+        }
+    ).set_index("experiment", drop=True)
+    assert len(df) == 6
+    pd.testing.assert_frame_equal(df, expected)
+
+
+def test__fetch_experiments_table_empty_attribute_list(project):
+    df = fetch_experiments_table(
+        project=project.project_identifier,
+        experiments=[exp.name for exp in TEST_DATA.experiments],
+        attributes=[],
+        sort_by=Attribute("sys/name", type="string"),
+        sort_direction="asc",
+    )
+
+    experiments = [experiment.name for experiment in TEST_DATA.experiments]
+    expected = pd.DataFrame(
+        {
+            "experiment": experiments,
         }
     ).set_index("experiment", drop=True)
     assert len(df) == 6

--- a/tests/unit/internal/test_filters.py
+++ b/tests/unit/internal/test_filters.py
@@ -33,7 +33,7 @@ def test_attribute_invalid_type():
     assert f"type must be one of: {sorted(types.ALL_TYPES)}" in str(exc_info.value)
 
 
-@pytest.mark.parametrize("aggregation", types.ALL_AGGREGATIONS)
+@pytest.mark.parametrize("aggregation", sorted(types.ALL_AGGREGATIONS))
 def test_attribute_all_valid_aggregations(aggregation):
     # Test all valid aggregation values
     attr = _Attribute(name="test", aggregation=aggregation)


### PR DESCRIPTION
Fixes PY-154

## Summary by Sourcery

Use an explicit `EmptyAttributeFilter` for empty attribute lists, adjust internal filter composition and data fetching logic to treat empty filters as no-ops, default to no attributes in fetch functions, and update tests accordingly.

New Features:
- Introduce `_EmptyAttributeFilter` to explicitly represent absence of attribute filters

Enhancements:
- Return `_EmptyAttributeFilter` instead of raising errors for empty attribute lists in filter constructors and resolver
- Adapt `split_attribute_filters` and `go_fetch_single` to recognize `_EmptyAttributeFilter` and produce no filters or results
- Change default `attributes` in `fetch_experiments_table` and `fetch_runs_table` to an empty list instead of a default pattern

Tests:
- Remove default `sys/name` column expectation in the experiments table end-to-end test