### PR TITLE
 PY-129 Extract api utilities used in new code from util.py to internal/api_utils.py

### DIFF
--- a/src/neptune_fetcher/api/api_client.py
+++ b/src/neptune_fetcher/api/api_client.py
@@ -15,11 +15,7 @@
 
 from __future__ import annotations
 
-__all__ = (
-    "ApiClient",
-    "create_auth_api_client",
-    "get_config_and_token_urls",
-)
+__all__ = ("ApiClient",)
 
 import re
 from dataclasses import dataclass
@@ -72,11 +68,13 @@ from neptune_fetcher.fields import (
     FieldType,
     FloatPointValue,
 )
+from neptune_fetcher.internal.api_utils import (
+    create_auth_api_client,
+    get_config_and_token_urls,
+)
 from neptune_fetcher.internal.retrieval.retry import handle_errors_default
 from neptune_fetcher.util import (
     NeptuneException,
-    create_auth_api_client,
-    get_config_and_token_urls,
     rethrow_neptune_error,
 )
 

--- a/src/neptune_fetcher/exceptions.py
+++ b/src/neptune_fetcher/exceptions.py
@@ -57,6 +57,24 @@ For details, see https://docs.neptune.ai/fetcher_setup
         )
 
 
+class NeptuneFailedToFetchClientConfig(NeptuneError):
+    def __init__(self, exception: Exception) -> None:
+        super().__init__(
+            """
+{h1}NeptuneFailedToFetchClientConfigException: Failed to fetch the client configuration.{end}
+
+This can happen due to network issues or if Neptune is unreachable.
+
+Make sure that you have a stable internet connection and that your Neptune instance is running and accessible.
+
+If the issue persists, please contact Neptune support with the following information:
+
+{exception}
+""",
+            exception=exception,
+        )
+
+
 class NeptuneProjectInaccessible(NeptuneError):
     def __init__(self) -> None:
         super().__init__(

--- a/src/neptune_fetcher/internal/api_utils.py
+++ b/src/neptune_fetcher/internal/api_utils.py
@@ -1,0 +1,135 @@
+#
+# Copyright (c) 2025, Neptune Labs Sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from http import HTTPStatus
+from typing import (
+    Callable,
+    Dict,
+    Optional,
+)
+
+import httpx
+from neptune_api import (
+    AuthenticatedClient,
+    Client,
+)
+from neptune_api.api.backend import get_client_config
+from neptune_api.auth_helpers import exchange_api_key
+from neptune_api.credentials import Credentials
+from neptune_api.models import ClientConfig
+from neptune_api.types import Response
+
+from neptune_fetcher.exceptions import NeptuneFailedToFetchClientConfig
+from neptune_fetcher.internal.env import (
+    NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS,
+    NEPTUNE_VERIFY_SSL,
+)
+from neptune_fetcher.internal.retrieval.retry import handle_errors_default
+
+
+@dataclass
+class TokenRefreshingURLs:
+    authorization_endpoint: str
+    token_endpoint: str
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TokenRefreshingURLs":
+        return TokenRefreshingURLs(
+            authorization_endpoint=data["authorization_endpoint"], token_endpoint=data["token_endpoint"]
+        )
+
+
+def _wrap_httpx_json_response(httpx_response: httpx.Response) -> Response:
+    """Wrap a httpx.Response into an neptune-api Response object that is compatible
+    with backoff_retry(). Use .json() as parsed content in the result."""
+
+    return Response(
+        status_code=HTTPStatus(httpx_response.status_code),
+        content=httpx_response.content,
+        headers=httpx_response.headers,
+        parsed=httpx_response.json(),
+    )
+
+
+def get_config_and_token_urls(
+    *, credentials: Credentials, proxies: Optional[Dict[str, str]]
+) -> tuple[ClientConfig, TokenRefreshingURLs]:
+    timeout = httpx.Timeout(NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS.get())
+    with Client(
+        base_url=credentials.base_url,
+        httpx_args={"mounts": proxies},
+        verify_ssl=NEPTUNE_VERIFY_SSL.get(),
+        timeout=timeout,
+        headers={"User-Agent": _generate_user_agent()},
+    ) as client:
+        try:
+            config_response = handle_errors_default(get_client_config.sync_detailed)(client=client)
+            config = config_response.parsed
+
+            urls_response = handle_errors_default(
+                lambda: _wrap_httpx_json_response(client.get_httpx_client().get(config.security.open_id_discovery))
+            )()
+            token_urls = TokenRefreshingURLs.from_dict(urls_response.parsed)
+
+            return config, token_urls
+        except Exception as e:
+            raise NeptuneFailedToFetchClientConfig(exception=e) from e
+
+
+def create_auth_api_client(
+    *,
+    credentials: Credentials,
+    config: ClientConfig,
+    token_refreshing_urls: TokenRefreshingURLs,
+    proxies: Optional[Dict[str, str]],
+) -> AuthenticatedClient:
+    return AuthenticatedClient(
+        base_url=credentials.base_url,
+        credentials=credentials,
+        client_id=config.security.client_id,
+        token_refreshing_endpoint=token_refreshing_urls.token_endpoint,
+        api_key_exchange_callback=exchange_api_key,
+        verify_ssl=NEPTUNE_VERIFY_SSL.get(),
+        httpx_args={"mounts": proxies, "http2": False},
+        timeout=httpx.Timeout(NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS.get()),
+        headers={"User-Agent": _generate_user_agent()},
+    )
+
+
+_ILLEGAL_CHARS = str.maketrans({c: "_" for c in " ();/"})
+
+
+def _generate_user_agent() -> str:
+    import platform
+    from importlib.metadata import version
+
+    def sanitize(value: Callable[[], str]) -> str:
+        try:
+            result = value()
+            return result.translate(_ILLEGAL_CHARS)
+        except Exception:
+            return "unknown"
+
+    package_name = "neptune-fetcher"
+    package_version = sanitize(lambda: version(package_name))
+    additional_metadata = {
+        "neptune-api": sanitize(lambda: version("neptune-api")),
+        "python": sanitize(platform.python_version),
+        "os": sanitize(platform.system),
+    }
+
+    additional_metadata_str = "; ".join(f"{k}={v}" for k, v in additional_metadata.items())
+    return f"{package_name}/{package_version} ({additional_metadata_str})"

--- a/src/neptune_fetcher/internal/client.py
+++ b/src/neptune_fetcher/internal/client.py
@@ -28,11 +28,11 @@ from typing import (
 from neptune_api import AuthenticatedClient
 from neptune_api.credentials import Credentials
 
-from neptune_fetcher.internal.context import Context
-from neptune_fetcher.util import (
+from neptune_fetcher.internal.api_utils import (
     create_auth_api_client,
     get_config_and_token_urls,
 )
+from neptune_fetcher.internal.context import Context
 
 # Disable httpx logging, httpx logs requests at INFO level
 logging.getLogger("httpx").setLevel(logging.WARN)

--- a/src/neptune_fetcher/util.py
+++ b/src/neptune_fetcher/util.py
@@ -17,33 +17,13 @@ import functools as ft
 import logging
 import os
 import warnings
-from dataclasses import dataclass
-from http import HTTPStatus
 from typing import (
     Any,
     Callable,
-    Dict,
-    Optional,
     TypeVar,
 )
 
-import httpx
-from neptune_api import (
-    AuthenticatedClient,
-    Client,
-)
-from neptune_api.api.backend import get_client_config
-from neptune_api.auth_helpers import exchange_api_key
-from neptune_api.credentials import Credentials
-from neptune_api.models import ClientConfig
-from neptune_api.types import Response
-
 from neptune_fetcher.exceptions import NeptuneError
-from neptune_fetcher.internal.env import (
-    NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS,
-    NEPTUNE_VERIFY_SSL,
-)
-from neptune_fetcher.internal.retrieval.retry import handle_errors_default
 
 logger = logging.getLogger(__name__)
 
@@ -113,101 +93,6 @@ def warn_unsupported_value_type(type_: str) -> None:
         "Upgrade neptune-fetcher to access this data.",
         NeptuneWarning,
     )
-
-
-@dataclass
-class TokenRefreshingURLs:
-    authorization_endpoint: str
-    token_endpoint: str
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "TokenRefreshingURLs":
-        return TokenRefreshingURLs(
-            authorization_endpoint=data["authorization_endpoint"], token_endpoint=data["token_endpoint"]
-        )
-
-
-def _wrap_httpx_json_response(httpx_response: httpx.Response) -> Response:
-    """Wrap a httpx.Response into an neptune-api Response object that is compatible
-    with backoff_retry(). Use .json() as parsed content in the result."""
-
-    return Response(
-        status_code=HTTPStatus(httpx_response.status_code),
-        content=httpx_response.content,
-        headers=httpx_response.headers,
-        parsed=httpx_response.json(),
-    )
-
-
-def get_config_and_token_urls(
-    *, credentials: Credentials, proxies: Optional[Dict[str, str]]
-) -> tuple[ClientConfig, TokenRefreshingURLs]:
-    timeout = httpx.Timeout(NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS.get())
-    with Client(
-        base_url=credentials.base_url,
-        httpx_args={"mounts": proxies},
-        verify_ssl=NEPTUNE_VERIFY_SSL.get(),
-        timeout=timeout,
-        headers={"User-Agent": _generate_user_agent()},
-    ) as client:
-        try:
-            config_response = handle_errors_default(get_client_config.sync_detailed)(client=client)
-            config = config_response.parsed
-
-            urls_response = handle_errors_default(
-                lambda: _wrap_httpx_json_response(client.get_httpx_client().get(config.security.open_id_discovery))
-            )()
-            token_urls = TokenRefreshingURLs.from_dict(urls_response.parsed)
-
-            return config, token_urls
-        except Exception as e:
-            raise NeptuneException(f"Failed to fetch client configuration: {e}") from e
-
-
-def create_auth_api_client(
-    *,
-    credentials: Credentials,
-    config: ClientConfig,
-    token_refreshing_urls: TokenRefreshingURLs,
-    proxies: Optional[Dict[str, str]],
-) -> AuthenticatedClient:
-    return AuthenticatedClient(
-        base_url=credentials.base_url,
-        credentials=credentials,
-        client_id=config.security.client_id,
-        token_refreshing_endpoint=token_refreshing_urls.token_endpoint,
-        api_key_exchange_callback=exchange_api_key,
-        verify_ssl=NEPTUNE_VERIFY_SSL.get(),
-        httpx_args={"mounts": proxies, "http2": False},
-        timeout=httpx.Timeout(NEPTUNE_HTTP_REQUEST_TIMEOUT_SECONDS.get()),
-        headers={"User-Agent": _generate_user_agent()},
-    )
-
-
-_ILLEGAL_CHARS = str.maketrans({c: "_" for c in " ();/"})
-
-
-def _generate_user_agent() -> str:
-    import platform
-    from importlib.metadata import version
-
-    def sanitize(value: Callable[[], str]) -> str:
-        try:
-            result = value()
-            return result.translate(_ILLEGAL_CHARS)
-        except Exception:
-            return "unknown"
-
-    package_name = "neptune-fetcher"
-    package_version = sanitize(lambda: version(package_name))
-    additional_metadata = {
-        "neptune-api": sanitize(lambda: version("neptune-api")),
-        "python": sanitize(platform.python_version),
-        "os": sanitize(platform.system),
-    }
-
-    additional_metadata_str = "; ".join(f"{k}={v}" for k, v in additional_metadata.items())
-    return f"{package_name}/{package_version} ({additional_metadata_str})"
 
 
 def batched_paths(paths: list[str], batch_size: int, query_size_limit: int) -> list[list[str]]:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -11,15 +11,15 @@ from neptune_scale import Run
 
 from neptune_fetcher import ReadOnlyProject
 from neptune_fetcher.internal import identifiers
+from neptune_fetcher.internal.api_utils import (
+    create_auth_api_client,
+    get_config_and_token_urls,
+)
 from neptune_fetcher.internal.composition import concurrency
 from neptune_fetcher.internal.context import set_project
 from neptune_fetcher.internal.filters import _Filter
 from neptune_fetcher.internal.identifiers import RunIdentifier
 from neptune_fetcher.internal.retrieval.search import fetch_experiment_sys_attrs
-from neptune_fetcher.util import (
-    create_auth_api_client,
-    get_config_and_token_urls,
-)
 from tests.e2e.data import (
     FILE_SERIES_STEPS,
     NOW,


### PR DESCRIPTION
Extract code from util.py used by the both new and legacy code to internal.

## Summary by Sourcery

Extract utility functions and classes used by both legacy and new code into a dedicated module and update references accordingly.

Enhancements:
- Move shared Neptune API helper functions and classes (NeptuneException, TokenRefreshingURLs, get_config_and_token_urls, create_auth_api_client, response wrapper, user-agent generator, rethrow_neptune_error) from util.py to internal/api_shared_utils.py
- Update imports in api_client and other modules to reference the new internal/api_shared_utils location
- Clean up util.py by removing the extracted code