### PR TITLE
fix: change expected rate limiter header to retry-after

### DIFF
--- a/src/neptune_fetcher/internal/retrieval/retry.py
+++ b/src/neptune_fetcher/internal/retrieval/retry.py
@@ -102,8 +102,8 @@ def retry_backoff(
                 if max_tries is not None and total_tries >= max_tries:
                     break
 
-                if response is not None and "x-rate-limit-retry-after-seconds" in response.headers:
-                    sleep_time = int(response.headers["x-rate-limit-retry-after-seconds"])
+                if response is not None and "retry-after" in response.headers:
+                    sleep_time = int(response.headers["retry-after"])
                     rate_limit_time_extension += sleep_time
                     backoff_tries = 0  # reset backoff tries counter when using a different strategy
                 else:

--- a/tests/unit/internal/retrieval/test_retry.py
+++ b/tests/unit/internal/retrieval/test_retry.py
@@ -45,7 +45,7 @@ def response_200(content: bytes = b"OK"):
 
 
 def response_429(content: bytes = b"Error 429", retry_after: int = 1):
-    return response(429, content=content, headers={"x-rate-limit-retry-after-seconds": str(retry_after)})
+    return response(429, content=content, headers={"retry-after": str(retry_after)})
 
 
 def response_500(content: bytes = b"Error 500"):


### PR DESCRIPTION
## Summary by Sourcery

Switch to using the standard Retry-After header for rate limit handling and adapt tests.

Bug Fixes:
- Use 'Retry-After' header instead of 'x-rate-limit-retry-after-seconds' in rate limiter logic.

Tests:
- Update unit tests to expect 'Retry-After' header instead of 'x-rate-limit-retry-after-seconds'.