### PR TITLE
[obsolete] Script to continuously sync main to neptune_query

### DIFF
--- a/.github/neptune_query/README.md
+++ b/.github/neptune_query/README.md
@@ -1,0 +1,134 @@
+# Neptune Fetcher
+
+Neptune Fetcher is a read-only API for querying metadata logged with the [Neptune Python client][neptune-client-scale]. The separation makes it safer and more efficient to fetch data from Neptune.
+
+With the Fetcher API, you can:
+
+- List experiments, runs, and attributes of a project.
+- Fetch experiment or run metadata as a data frame.
+- Define filters to fetch experiments, runs, and attributes that meet certain criteria.
+
+> [!NOTE]
+> _For the Python API corresponding to [Neptune 2.x][legacy-app], see [neptune-client][neptune-client]._
+
+## Documentation
+
+- [Fetching how-to guides][fetcher-guide]
+- [Fetcher API reference][fetcher-api-ref]
+- [Update your code from old Fetcher to Alpha][fetcher-migration]
+
+## Installation
+
+```bash
+pip install -U neptune-fetcher
+```
+
+Set your Neptune API token and project name as environment variables:
+
+```bash
+export NEPTUNE_API_TOKEN="h0dHBzOi8aHR0cHM.4kl0jvYh3Kb8...ifQ=="
+```
+
+```bash
+export NEPTUNE_PROJECT="workspace-name/project-name"
+```
+
+For help, see [Get started][setup] in the Neptune documentation.
+
+> **Note:** To change the token or project, you can [set the context][set-context] directly in the code. This way, you can work with multiple projects at the same time.
+
+## Usage
+
+Import the `alpha` module:
+
+```python
+import neptune_fetcher.alpha as npt
+```
+
+To fetch experiment metadata from your project, use the [`fetch_experiments_table()`][fetch-exp-table] function.
+
+- To filter experiments to return, use the `experiments` parameter.
+- To specify attributes to include as columns, use the `attributes` parameter.
+
+```python
+npt.fetch_experiments_table(
+    experiments=["exp_ergwq", "exp_qgguv"],
+    attributes=["metrics/train_accuracy", "metrics/train_loss"],
+)
+```
+
+```pycon
+           metrics/train_accuracy   metrics/train_loss
+                             last                 last
+experiment
+exp_ergwq                0.278149             0.336344
+exp_qgguv                0.160260             0.790268
+```
+
+To fetch values at each step, use [`fetch_metrics()`][fetch-metrics]:
+
+```python
+npt.fetch_metrics(
+    experiments=r"exp.*",
+    attributes=r".*metric.*/val_.+",
+)
+```
+
+```pycon
+  experiment  step  metrics/val_accuracy  metrics/val_loss
+0  exp_dczjz     0              0.432187          0.823375
+1  exp_dczjz     1              0.649685          0.971732
+2  exp_dczjz     2              0.760142          0.154741
+3  exp_dczjz     3              0.719508          0.504652
+4  exp_dczjz     4              0.180321          0.503800
+5  exp_hgctc     0              0.012390          0.171790
+6  exp_hgctc     1              0.392041          0.768675
+7  exp_hgctc     2                  None          0.847072
+8  exp_hgctc     3              0.479945          0.323537
+9  exp_hgctc     4              0.102646          0.055511
+```
+
+You can define detailed criteria for which experiments to search or which attributes to return.
+
+For instructions, see the [how-to guides][fetcher-guide] in the Neptune documentation:
+
+- [Listing project contents][project-explo]
+- [Fetching metadata][fetch-data]
+- [Constructing filters][construct-filters]
+- [Working with runs][runs-api]
+
+---
+
+## Old Fetcher API
+
+For documentation related to the previous version of the Fetcher API, see the `docs/old/` directory:
+
+- [docs/old/usage.md](docs/old/usage.md)
+- [docs/old/api_reference.md](docs/old/api_reference.md)
+
+To update your code to the new version, see [Migrate to Fetcher Alpha][fetcher-migration] in the Neptune documentation.
+
+---
+
+## License
+
+This project is licensed under the Apache License Version 2.0. For details, see [Apache License Version 2.0][license].
+
+[fetcher-api-ref]: https://docs.neptune.ai/fetcher/attribute
+[fetch-exp-table]: https://docs.neptune.ai/fetcher/fetch_experiments_table
+[fetch-metrics]: https://docs.neptune.ai/fetcher/fetch_metrics
+
+[construct-filters]: https://docs.neptune.ai/construct_fetching_filters
+[fetch-data]: https://docs.neptune.ai/fetch_metadata
+[fetcher-guide]: https://docs.neptune.ai/query_metadata
+[fetcher-migration]: https://docs.neptune.ai/fetcher_migration
+[project-explo]: https://docs.neptune.ai/list_project_contents
+[runs-api]: https://docs.neptune.ai/fetcher_runs_api
+[set-context]: https://docs.neptune.ai/set_fetching_context
+[setup]: https://docs.neptune.ai/setup
+
+[legacy-app]: https://app.neptune.ai/
+[neptune-client]: https://github.com/neptune-ai/neptune-client
+[neptune-client-scale]: https://github.com/neptune-ai/neptune-client-scale
+
+[license]: http://www.apache.org/licenses/LICENSE-2.0

--- a/.github/neptune_query/pyproject.toml
+++ b/.github/neptune_query/pyproject.toml
@@ -1,0 +1,106 @@
+# This is pyproject.toml that will be placed in the top of the repository
+# by GitHub workflow called "sync-to-neptune-query" in branch "neptune-query"
+
+[build-system]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"
+
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "semver"
+pattern = "default-unprefixed"
+
+[tool.poetry.dependencies]
+python = "^3.10"
+
+# Base neptune package
+neptune-api = ">=0.17.0,<0.19.0"
+azure-storage-blob = "^12.7.0"
+pandas = ">=1.4.0"
+
+# Optional for default progress update handling
+tqdm = { version = ">=4.66.0" }
+
+[tool.poetry]
+authors = ["neptune.ai <contact@neptune.ai>"]
+description = "Neptune Fetcher"
+repository = "https://github.com/neptune-ai/neptune-fetcher"
+homepage = "https://neptune.ai/"
+documentation = "https://docs.neptune.ai/"
+license = "Apache License 2.0"
+name = "neptune-query"
+readme = "README.md"
+version = "0.1.0"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+keywords = [
+    "MLOps",
+    "ML Experiment Tracking",
+    "ML Model Registry",
+    "ML Model Store",
+    "ML Metadata Store",
+]
+packages = [
+    { include = "neptune_query", from = "src" },
+]
+
+[tool.poetry.urls]
+"Tracker" = "https://github.com/neptune-ai/neptune-fetcher/issues"
+"Documentation" = "https://docs.neptune.ai/"
+
+[tool.black]
+line-length = 120
+target-version = ["py38", "py39", "py310", "py311"]
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.isort]
+profile = "black"
+line_length = 120
+force_grid_wrap = 2
+
+[tool.flake8]
+max-line-length = 120
+extend-ignore = "E203"
+
+[tool.mypy]
+mypy_path = "src/"
+packages = "neptune_query"
+follow_imports = "silent"
+install_types = "True"
+non_interactive = "True"
+disallow_untyped_defs = "True"
+no_implicit_optional = "True"
+check_untyped_defs = "True"
+warn_return_any = "True"
+show_error_codes = "True"
+warn_unused_ignores = "True"
+ignore_missing_imports = "True"
+
+[tool.pytest.ini_options]
+retries = 3
+retry_delay = 2
+addopts = "--dist=loadfile"

--- a/.github/neptune_query/release.yml
+++ b/.github/neptune_query/release.yml
@@ -1,0 +1,81 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build-neptune-query:
+    runs-on: tools-gha-runners
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build dependencies
+        run: pip install poetry poetry-dynamic-versioning
+
+      - name: Build package
+        run: |
+          # TODO: Remove this workaround once https://github.com/orgs/community/discussions/4924 gets resolved
+          # poetry-dynamic-versioning requires annotated tags to them by creation time
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          echo "VERSION=${VERSION}"
+          POETRY_DYNAMIC_VERSIONING_BYPASS="$VERSION" poetry build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: neptune-query-package
+          path: dist/
+
+  test-install:
+    needs: [ build-neptune-query ]
+    runs-on: tools-gha-runners
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: neptune-query-package
+          path: dist
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install neptune-query package
+        run: pip install --force-reinstall --pre -f ./dist neptune-query
+
+      - name: List dependencies
+        run: pip list
+
+      - name: Test imports
+        run: python -c "from neptune_query import *"
+
+  publish-neptune-query:
+    needs:
+      - build-neptune-query
+      - test-install
+    runs-on: tools-gha-runners
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: neptune-query-package
+          path: dist/
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Uploading to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN_NEPTUNE_QUERY }}

--- a/.github/scripts/sync-main-to-neptune-query.sh
+++ b/.github/scripts/sync-main-to-neptune-query.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+COMMIT_MESSAGE="Update pyproject.toml for neptune-query
+
+This is an automated commit updating pyproject.toml, README.md and release.yml for the neptune-query branch."
+
+get_remote_hash() {
+  curl -s https://api.github.com/repos/neptune-ai/neptune-fetcher/commits/$1 | jq -r .sha
+}
+
+# get git repository root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+if ! [ -n "$REPO_ROOT" ]; then
+  echo "Error: Could not determine repository root."
+  exit 1
+fi
+
+# Verify we're on the same commit as origin/main
+if [ "$(git rev-parse HEAD)" != "$(get_remote_hash main)" ]; then
+  echo "Error: Local main is not in sync with origin/main."
+  exit 1
+fi
+
+# Verify the source is clean
+if ! git diff-index --quiet HEAD --; then
+  echo "Error: Working directory is not clean."
+  exit 1
+fi
+
+# Inject neptune-query versions of README.md, pyproject.toml, and release.yml
+cp "$REPO_ROOT/.github/neptune_query/pyproject.toml" "$REPO_ROOT/pyproject.toml"
+cp "$REPO_ROOT/.github/neptune_query/README.md" "$REPO_ROOT/README.md"
+cp "$REPO_ROOT/.github/neptune_query/release.yml" "$REPO_ROOT/.github/workflows/release.yml"
+git add "$REPO_ROOT/pyproject.toml" "$REPO_ROOT/README.md" "$REPO_ROOT/.github/workflows/release.yml"
+
+# Set remote with GitHub token
+git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/neptune-ai/neptune-fetcher.git
+
+# Configure Git user - doing it here, so it only works if run from GitHub Actions
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+# Commit and push
+git commit -m "$COMMIT_MESSAGE"
+git fetch origin neptune-query
+git push origin HEAD:neptune-query --force-with-lease

--- a/.github/workflows/sync-to-neptune-query.yml
+++ b/.github/workflows/sync-to-neptune-query.yml
@@ -1,0 +1,20 @@
+name: Sync all main commits to branch neptune-query
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-to-neptune-query:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sync the commit to branch neptune-query
+        run: bash .github/scripts/sync-main-to-neptune-query.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
+permissions:
+  contents: write  # Needed to push git changes


### PR DESCRIPTION
## Summary by Sourcery

Automate the sync and release process for the neptune-query branch by adding configuration, documentation, and CI workflows.

New Features:
- Introduce a Bash script and GitHub Actions workflow to continuously sync main branch commits to the neptune-query branch.

Enhancements:
- Add a dedicated pyproject.toml and top-level README for the Neptune Fetcher (neptune_query) package.
- Provide a release workflow that builds, tests install, and publishes the neptune-query package to PyPI.

CI:
- Add a sync-to-neptune-query workflow to trigger the sync script on specific branch pushes.
- Add a release workflow under .github/neptune_query to automate build, artifact upload, install test, and PyPI publishing.

## Summary by Sourcery

Set up automated synchronization of main branch updates and package release process for the neptune-query branch.

New Features:
- Add a Bash script and corresponding GitHub Actions workflow to continuously propagate main branch commits to the neptune-query branch.

Enhancements:
- Introduce a standalone pyproject.toml and top-level README for the Neptune Fetcher (neptune-query) package.

Build:
- Configure Poetry-based build system with dynamic versioning for the neptune-query package.

CI:
- Add a sync-to-neptune-query workflow triggered on main pushes.
- Add a dedicated release workflow to build, test-install, and upload artifacts.

Deployment:
- Automate publishing of the neptune-query package to PyPI on tag pushes.

Documentation:
- Include comprehensive user-facing documentation in the new Neptune Fetcher README.md.

Tests:
- Add an install-and-import verification step in the release pipeline.