### PR TITLE
Python 3.10, user-agent change, readme, license files check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,13 @@ repos:
     rev: v1.5.4
     hooks:
       - id: insert-license
-        files: ^src/neptune_fetcher.*[^/]+\.py$
+        files: ^src/neptune_query.*[^/]+\.py$
+        args: [ "--license-filepath", ".github/license_header.txt", "--allow-past-years"]
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.4
+    hooks:
+      - id: insert-license
+        files: ^neptune_fetcher/src/neptune_fetcher.*[^/]+\.py$
         args: [ "--license-filepath", ".github/license_header.txt", "--allow-past-years"]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,12 @@ style = "semver"
 pattern = "default-unprefixed"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 
 # Base neptune package
 neptune-api = ">=0.17.0,<0.19.0"
 azure-storage-blob = "^12.7.0"
-pandas = [
-    { version = ">=1.4.0,<2.3.0", python = "<3.10" },
-    { version = ">=1.4.0", python = ">=3.10" }
-]
+pandas = ">=1.4.0"
 
 # Optional for default progress update handling
 tqdm = { version = ">=4.66.0" }
@@ -33,7 +30,7 @@ homepage = "https://neptune.ai/"
 documentation = "https://docs.neptune.ai/"
 license = "Apache License 2.0"
 name = "neptune-query"
-readme = "README.md"
+readme = "README-neptune-query.md"
 version = "0.1.0"
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -67,7 +64,7 @@ packages = [
 
 [tool.black]
 line-length = 120
-target-version = ["py39", "py310", "py311"]
+target-version = ["py310", "py311"]
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/src/neptune_query/internal/api_utils.py
+++ b/src/neptune_query/internal/api_utils.py
@@ -123,7 +123,7 @@ def _generate_user_agent() -> str:
         except Exception:
             return "unknown"
 
-    package_name = "neptune-fetcher"
+    package_name = "neptune-query"
     package_version = sanitize(lambda: version(package_name))
     additional_metadata = {
         "neptune-api": sanitize(lambda: version("neptune-api")),


### PR DESCRIPTION
* Require Python 3.10
* Update the User-agent string to neptune-query
* Switch to separate README
* Fix paths for the license check