### PR TITLE
feat: guess file extension

### DIFF
--- a/src/neptune_query/internal/composition/download_files.py
+++ b/src/neptune_query/internal/composition/download_files.py
@@ -72,6 +72,7 @@ def download_files(
                         signed_file=file_tuple[1],
                         target_path=_files.create_target_path(
                             destination=destination,
+                            mime_type=file_tuple[0].mime_type,
                             experiment_label=file_tuple[0].label,
                             attribute_path=file_tuple[0].attribute_path,
                             step=file_tuple[0].step,

--- a/src/neptune_query/internal/retrieval/files.py
+++ b/src/neptune_query/internal/retrieval/files.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import hashlib
+import mimetypes
 import pathlib
 from dataclasses import dataclass
 from typing import (
@@ -232,14 +233,18 @@ def download_file_complete(
 
 
 def create_target_path(
-    destination: pathlib.Path, experiment_label: str, attribute_path: str, step: Optional[float]
+    destination: pathlib.Path, mime_type: str, experiment_label: str, attribute_path: str, step: Optional[float]
 ) -> pathlib.Path:
     relative_target_path = pathlib.Path(".") / experiment_label / attribute_path
     if step is not None:
         relative_target_path = relative_target_path / f"step_{step:f}"
+    extension = _guess_extension(mime_type)
 
     sanitized_parts = [_sanitize_path_part(part) for part in relative_target_path.parts]
     relative_target_path = pathlib.Path(*sanitized_parts)
+
+    if extension:
+        relative_target_path = relative_target_path.with_suffix(extension)
 
     return destination / relative_target_path
 
@@ -253,3 +258,7 @@ def _sanitize_path_part(part: str, max_part_length: int = 255) -> str:
         part = f"{part[:max_part_length - len(digest) - 1]}_{digest}"
 
     return part
+
+
+def _guess_extension(mime_type: str) -> Optional[str]:
+    return mimetypes.guess_extension(type=mime_type)

--- a/tests/e2e_query/internal/composition/test_download_files.py
+++ b/tests/e2e_query/internal/composition/test_download_files.py
@@ -130,7 +130,7 @@ def test_download_files_single(client, project, experiment_identifier, temp_dir)
             {
                 "experiment": EXPERIMENT_NAME,
                 "step": None,
-                f"{PATH}/files/file-value.txt": str(temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-value_txt"),
+                f"{PATH}/files/file-value.txt": str(temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-value_txt.txt"),
             }
         ]
     ).set_index(["experiment", "step"])
@@ -170,8 +170,8 @@ def test_download_files_multiple(client, project, experiment_identifier, temp_di
             {
                 "experiment": EXPERIMENT_NAME,
                 "step": None,
-                f"{PATH}/files/file-value": str(temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-value"),
-                f"{PATH}/files/file-value.txt": str(temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-value_txt"),
+                f"{PATH}/files/file-value": str(temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-value.bin"),
+                f"{PATH}/files/file-value.txt": str(temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-value_txt.txt"),
             }
         ]
     ).set_index(["experiment", "step"])
@@ -213,10 +213,10 @@ def test_download_file_series(client, project, experiment_identifier, temp_dir):
                 "experiment": EXPERIMENT_NAME,
                 "step": step,
                 f"{PATH}/files/file-series-value_0": str(
-                    temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-series-value_0/step_{int(step)}_000000"
+                    temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-series-value_0/step_{int(step)}_000000.bin"
                 ),
                 f"{PATH}/files/file-series-value_1": str(
-                    temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-series-value_1/step_{int(step)}_000000"
+                    temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-series-value_1/step_{int(step)}_000000.bin"
                 ),
             }
             for step in [0.0, 1.0, 2.0]

--- a/tests/e2e_query/v1/test_download_files.py
+++ b/tests/e2e_query/v1/test_download_files.py
@@ -38,7 +38,7 @@ def test__download_files_from_table(project, temp_dir):
     )
 
     # then
-    expected_path = (temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-value_txt").resolve()
+    expected_path = (temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-value_txt.txt").resolve()
     expected_df = pd.DataFrame(
         [
             {
@@ -83,7 +83,9 @@ def test__download_files_from_file_series(project, temp_dir):
                 "experiment": EXPERIMENT_NAME,
                 "step": step,
                 f"{PATH}/files/file-series-value_0": str(
-                    (temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-series-value_0/step_{int(step)}_000000").resolve()
+                    (
+                        temp_dir / EXPERIMENT_NAME / f"{PATH}/files/file-series-value_0/step_{int(step)}_000000.bin"
+                    ).resolve()
                 ),
             }
             for step in [0.0, 1.0, 2.0]


### PR DESCRIPTION
fixes PY-170

## Summary by Sourcery

Infer and append file extensions to downloaded files based on their MIME types

New Features:
- Guess and append file extensions in create_target_path using MIME type

Enhancements:
- Pass MIME type through download flow to enable extension guessing

Build:
- Add filetype dependency to pyproject.toml

Tests:
- Update end-to-end tests to expect file names with the correct extensions