### PR TITLE
Bump neptune-api dependency for fetcher

### DIFF
--- a/neptune_fetcher/pyproject.toml
+++ b/neptune_fetcher/pyproject.toml
@@ -15,7 +15,7 @@ pattern = "default-unprefixed"
 python = "^3.9"
 
 # Base neptune package
-neptune-api = ">=0.17.0,<0.19.0"
+neptune-api = ">=0.17.0,<0.20.0"
 azure-storage-blob = "^12.7.0"
 pandas = [
     { version = ">=1.4.0,<2.3.0", python = "<3.10" },


### PR DESCRIPTION
Allow neptune-api=0.19.0

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Build:
- Update neptune-api requirement to allow versions up to <0.20.0