### PR TITLE
Fix up docs for neptune-query

### DIFF
--- a/README-neptune-query.md
+++ b/README-neptune-query.md
@@ -43,6 +43,14 @@ Available functions:
 - `list_experiments()` &ndash; names of experiments in the target project.
 - `set_api_token()` &ndash; set the Neptune API token to use for the session.
 
+> To use the corresponding methods for runs, import the Runs API:
+>
+> ```python
+> import neptune_query.runs as nq_runs
+> ```
+>
+> You can use these methods to target individual runs by ID instead of experiment runs by name.
+
 ### Example 1: Fetch metric values
 
 To fetch values at each step, use `fetch_metrics()`.

--- a/src/neptune_query/__init__.py
+++ b/src/neptune_query/__init__.py
@@ -378,7 +378,7 @@ def download_files(
 
     - For file series, use `fetch_series()` to specify the content containing the files
     and pass the output to the `files` argument.
-    - For invdividually assigned files, use `fetch_experiments_table()`.
+    - For individually assigned files, use `fetch_experiments_table()`.
 
     Args:
         project: Path of the Neptune project, as `WorkspaceName/ProjectName`.

--- a/src/neptune_query/filters.py
+++ b/src/neptune_query/filters.py
@@ -214,22 +214,25 @@ class Attribute:
 class Filter:
     """Specifies criteria for experiments or attributes when using a fetching method.
 
+    For regular expressions, the extended syntax is supported.
+    For details, see https://docs.neptune.ai/regex/#compound-expressions
+
     Examples of filters:
-        - Name or attribute value must match regular expression.
+        - Name or attribute value must match a regex.
         - Attribute value must pass a condition, like "greater than 0.9".
         - Attribute of a given name must exist.
 
     You can negate a filter or join multiple filters with logical operators.
 
     Methods available for attribute values:
-        - `name()`: Experiment name matches an extended regular expression or a list of names
+        - `name()`: Experiment name matches a regex or a list of names
         - `eq()`: Attribute value equals
         - `ne()`: Attribute value doesn't equal
         - `gt()`: Attribute value is greater than
         - `ge()`: Attribute value is greater than or equal to
         - `lt()`: Attribute value is less than
         - `le()`: Attribute value is less than or equal to
-        - `matches()`: Experiment name matches an extended regular expression
+        - `matches()`: String attribute value matches a regex
         - `contains_all()`: Tagset contains all tags, or string contains substrings
         - `contains_none()`: Tagset doesn't contain any of the tags, or string doesn't contain the substrings
         - `exists()`: Attribute exists

--- a/src/neptune_query/runs.py
+++ b/src/neptune_query/runs.py
@@ -367,7 +367,7 @@ def download_files(
 
     - For file series, use `fetch_series()` to specify the content containing the files
     and pass the output to the `files` argument.
-    - For invdividually assigned files, use `fetch_runs_table()`.
+    - For individually assigned files, use `fetch_runs_table()`.
 
     Args:
         project: Path of the Neptune project, as `WorkspaceName/ProjectName`.


### PR DESCRIPTION
## Summary by Sourcery

Improve documentation for neptune-query by clarifying regex support, adding Runs API import guidance, and correcting typos.

Bug Fixes:
- Fix typo "invdividually" to "individually" in download_files docstrings

Enhancements:
- Clarify filter docstrings with extended regex syntax and use concise "regex" terminology
- Add README instructions for importing neptune_query.runs to target individual runs by ID