### PR TITLE
Remove pre-optimization in fetching attribute definitions

### DIFF
--- a/tests/unit/v1/test_split.py
+++ b/tests/unit/v1/test_split.py
@@ -52,6 +52,8 @@ def test_list_attributes_patched(sys_id_length, exp_count, expected_calls):
     ):
         get_client.return_value = None
         fetch_sys_ids.return_value = iter([util.Page(sys_ids)])
+        attributes = [AttributeDefinition(name=f"{i:020d}", type="irrelevant") for i in range(100)]
+        fetch_attribute_definitions_single_filter.side_effect = lambda **kwargs: iter([util.Page(attributes)])
 
         npt.list_attributes(
             project=project,


### PR DESCRIPTION
The optimization tries to avoid multi-threading for fetching attribute definitions if only one Filter is passed to `_fetch_attribute_definitions`.

However it doesn't make the code any faster and introduces unnecessary code paths.

Updated unit tests to match the simplified code.

Tested that avoiding calling `concurrency.generate_concurrently` with one item doesn't gain any measurable performance, so I'm removing the extra code from `internal/composition/attributes.py` for simplicity.

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?
