### PR TITLE
PY-172 run/experiments - draft

### DIFF
--- a/src/neptune_query/internal/composition/download_files.py
+++ b/src/neptune_query/internal/composition/download_files.py
@@ -72,10 +72,7 @@ def download_files(
                         signed_file=file_tuple[1],
                         target_path=_files.create_target_path(
                             destination=destination,
-                            mime_type=file_tuple[0].mime_type,
-                            experiment_label=file_tuple[0].label,
-                            attribute_path=file_tuple[0].attribute_path,
-                            step=file_tuple[0].step,
+                            file=file_tuple[0],
                         ),
                     ),
                 )

--- a/src/neptune_query/internal/output_format.py
+++ b/src/neptune_query/internal/output_format.py
@@ -24,8 +24,6 @@ from typing import (
 import numpy as np
 import pandas as pd
 
-from .. import types
-from ..exceptions import ConflictingAttributeTypes
 from . import identifiers
 from .retrieval import (
     metrics,
@@ -44,6 +42,8 @@ from .retrieval.metrics import (
     TimestampIndex,
     ValueIndex,
 )
+from .. import types
+from ..exceptions import ConflictingAttributeTypes
 
 __all__ = (
     "convert_table_to_dataframe",
@@ -95,6 +95,7 @@ def convert_table_to_dataframe(
                         row[(column_name, "last")] = _create_output_file(
                             file=agg_value,
                             label=label,
+                            index_column_name=index_column_name,
                             attribute_path=value.attribute_definition.name,
                             step=getattr(aggregation_value, "last_step", None),
                         )
@@ -107,6 +108,7 @@ def convert_table_to_dataframe(
                 row[(column_name, "")] = _create_output_file(
                     file=file_properties,
                     label=label,
+                    index_column_name=index_column_name,
                     attribute_path=value.attribute_definition.name,
                 )
             elif value.attribute_definition.type == "histogram":
@@ -331,6 +333,7 @@ def create_series_dataframe(
                     step=point.step,
                     value=_create_output_file(
                         file=point.value,
+                        index_column_name=index_column_name,
                         label=label,
                         attribute_path=run_attribute_definition.attribute_definition.name,
                         step=point.step,
@@ -455,7 +458,7 @@ def create_files_dataframe(
     rows: list[dict[str, Any]] = []
     for file, path in file_data.items():
         row = {
-            index_column_name: file.label,
+            index_column_name: file.container_label,
             "attribute": file.attribute_path,
             "step": file.step,
             "path": str(path) if path else None,
@@ -473,11 +476,15 @@ def create_files_dataframe(
 def _create_output_file(
     file: File,
     label: str,
+    index_column_name: str,
     attribute_path: str,
     step: Optional[float] = None,
 ) -> types.File:
+    run_id = label if index_column_name == "run" else None
+    experiment_name = label if index_column_name == "experiment" else None
     return types.File(
-        label=label,
+        experiment_name=experiment_name,
+        run_id=run_id,
         attribute_path=attribute_path,
         step=step,
         path=file.path,

--- a/src/neptune_query/internal/retrieval/files.py
+++ b/src/neptune_query/internal/retrieval/files.py
@@ -38,6 +38,7 @@ from neptune_api.models import (
 from neptune_query.internal.query_metadata_context import with_neptune_client_metadata
 
 from ...exceptions import NeptuneFileDownloadError
+from ...types import File
 from .. import (
     env,
     identifiers,
@@ -234,13 +235,11 @@ def download_file_complete(
         raise NeptuneFileDownloadError(details=f"Failed to download file after {max_tries} attempts.")
 
 
-def create_target_path(
-    destination: pathlib.Path, mime_type: str, experiment_label: str, attribute_path: str, step: Optional[float]
-) -> pathlib.Path:
-    relative_target_path = pathlib.Path(".") / experiment_label / attribute_path
-    if step is not None:
-        relative_target_path = relative_target_path / f"step_{step:f}"
-    extension = _guess_extension(mime_type)
+def create_target_path(destination: pathlib.Path, file: File) -> pathlib.Path:
+    relative_target_path = pathlib.Path(".") / file.container_label / file.attribute_path
+    if file.step is not None:
+        relative_target_path = relative_target_path / f"step_{file.step:f}"
+    extension = _guess_extension(file.mime_type)
 
     sanitized_parts = [_sanitize_path_part(part) for part in relative_target_path.parts]
     relative_target_path = pathlib.Path(*sanitized_parts)

--- a/src/neptune_query/internal/retrieval/split.py
+++ b/src/neptune_query/internal/retrieval/split.py
@@ -21,6 +21,7 @@ from typing import (
     TypeVar,
 )
 
+from ...types import File
 from .. import (
     env,
     identifiers,
@@ -171,7 +172,7 @@ def _ceil_div(a: int, b: int) -> int:
     return (a + b - 1) // b
 
 
-def split_files(items: list[T]) -> Generator[list[T], None, None]:
+def split_files(items: list[File]) -> Generator[list[File], None, None]:
     batch_size = env.NEPTUNE_FETCHER_FILES_BATCH_SIZE.get()
 
     for i in range(0, len(items), batch_size):

--- a/src/neptune_query/types.py
+++ b/src/neptune_query/types.py
@@ -25,18 +25,32 @@ class Histogram:
 
 @dataclass(frozen=True)
 class File:
-    label: str
+    experiment_name: Optional[str]
+    run_id: Optional[str]
     attribute_path: str
     step: Optional[float]
     path: str
     size_bytes: int
     mime_type: str
 
+    def __post_init__(self) -> None:
+        if not (self.experiment_name or self.run_id):
+            raise ValueError("Either 'experiment_name' or 'run_id' must be set for File.")
+        if self.experiment_name and self.run_id:
+            raise ValueError("Only one of 'experiment_name' or 'run_id' should be set for File.")
+
     def __repr__(self) -> str:
-        return (
-            f"File({self.label}, attribute_path={self.attribute_path}, "
-            f"step={self.step}, size={_humanize_size(self.size_bytes)}, mime_type={self.mime_type})"
-        )
+        return f"File(size={_humanize_size(self.size_bytes)}, mime_type={self.mime_type})"
+
+    @property
+    def container_label(self) -> str:
+        """Returns a label for the container based on the file's experiment name or run ID."""
+        if self.experiment_name:
+            return self.experiment_name
+        elif self.run_id:
+            return self.run_id
+        else:
+            raise ValueError("File must have either an experiment name or a run ID.")
 
 
 def _humanize_size(size_bytes: int) -> str:

--- a/tests/e2e_query/internal/composition/test_download_files.py
+++ b/tests/e2e_query/internal/composition/test_download_files.py
@@ -29,7 +29,8 @@ def test_download_files_missing(client, project, experiment_identifier, temp_dir
     result_df = download_files(
         files=[
             File(
-                label=EXPERIMENT_NAME,
+                experiment_name=EXPERIMENT_NAME,
+                run_id=None,
                 attribute_path=f"{PATH}/files/object-does-not-exist",
                 step=None,
                 path="object-does-not-exist",
@@ -65,7 +66,8 @@ def test_download_files_no_permission(client, project, experiment_identifier, te
         download_files(
             files=[
                 File(
-                    label=EXPERIMENT_NAME,
+                    experiment_name=EXPERIMENT_NAME,
+                    run_id=None,
                     attribute_path=f"{PATH}/files/file-value.txt",
                     step=None,
                     path="not-real-path",
@@ -92,7 +94,8 @@ def test_download_files_destination_file_type(client, project, experiment_identi
         download_files(
             files=[
                 File(
-                    label=EXPERIMENT_NAME,
+                    experiment_name=EXPERIMENT_NAME,
+                    run_id=None,
                     attribute_path=f"{PATH}/files/file-value.txt",
                     step=None,
                     path="not-a-real-path",

--- a/tests/unit/internal/test_output_format.py
+++ b/tests/unit/internal/test_output_format.py
@@ -202,7 +202,7 @@ def test_convert_experiment_table_to_dataframe_single_file_series():
     assert dataframe.to_dict() == {
         ("attr1", "last"): {
             "exp1": OFile(
-                label="exp1",
+                experiment_name="exp1",
                 attribute_path="attr1",
                 step=10.0,
                 path=last_file.path,
@@ -237,7 +237,7 @@ def test_convert_experiment_table_to_dataframe_single_file():
     assert dataframe_unflattened.to_dict() == {
         ("attr1", ""): {
             "exp1": OFile(
-                label="exp1",
+                experiment_name="exp1",
                 attribute_path="attr1",
                 step=None,
                 path=file.path,
@@ -721,7 +721,7 @@ def test_create_file_series_dataframe_with_absolute_timestamp():
     # Then
     downloadable_files = [
         OFile(
-            label="exp1",
+            experiment_name="exp1",
             attribute_path="path1",
             step=1.0,
             path=files[0].path,
@@ -729,7 +729,7 @@ def test_create_file_series_dataframe_with_absolute_timestamp():
             mime_type=files[0].mime_type,
         ),
         OFile(
-            label="exp1",
+            experiment_name="exp1",
             attribute_path="path2",
             step=2.0,
             path=files[1].path,
@@ -737,7 +737,7 @@ def test_create_file_series_dataframe_with_absolute_timestamp():
             mime_type=files[1].mime_type,
         ),
         OFile(
-            label="exp2",
+            experiment_name="exp2",
             attribute_path="path1",
             step=1.0,
             path=files[2].path,
@@ -1080,15 +1080,17 @@ def test_create_files_dataframe():
     # given
     file_data = {
         OFile(
-            label="experiment_1", attribute_path="attr1", step=None, path="", size_bytes=0, mime_type=""
+            experiment_name="experiment_1", attribute_path="attr1", step=None, path="", size_bytes=0, mime_type=""
         ): pathlib.Path("/path/to/file1"),
         OFile(
-            label="experiment_2", attribute_path="attr2", step=None, path="", size_bytes=0, mime_type=""
+            experiment_name="experiment_2", attribute_path="attr2", step=None, path="", size_bytes=0, mime_type=""
         ): pathlib.Path("/path/to/file2"),
         OFile(
-            label="experiment_3", attribute_path="series1", step=1.0, path="", size_bytes=0, mime_type=""
+            experiment_name="experiment_3", attribute_path="series1", step=1.0, path="", size_bytes=0, mime_type=""
         ): pathlib.Path("/path/to/file3"),
-        OFile(label="experiment_4", attribute_path="attr1", step=None, path="", size_bytes=0, mime_type=""): None,
+        OFile(
+            experiment_name="experiment_4", attribute_path="attr1", step=None, path="", size_bytes=0, mime_type=""
+        ): None,
     }
     index_column_name = "experiment"
 
@@ -1111,7 +1113,7 @@ def test_create_files_dataframe_index_name_attribute_conflict():
     # given
     file_data = {
         OFile(
-            label="experiment_1", attribute_path="experiment", step=None, path="", size_bytes=0, mime_type=""
+            experiment_name="experiment_1", attribute_path="experiment", step=None, path="", size_bytes=0, mime_type=""
         ): pathlib.Path("/path/to/file1"),
     }
     index_column_name = "experiment"


### PR DESCRIPTION
## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Replace the single File.label field with distinct experiment_name and run_id attributes, enforce mutual exclusivity, and update all code paths and tests to use the new File structure and container_label property

Enhancements:
- Refactor File dataclass to use experiment_name and run_id instead of label with validation in __post_init__ and a container_label property
- Simplify File.__repr__ and adjust create_files_dataframe and _create_output_file to derive labels based on index_column_name
- Update create_target_path and download pipeline to accept a File object and use its metadata for path construction
- Change split_files signature to specifically handle lists of File items

Tests:
- Modify unit and e2e tests to instantiate File with experiment_name and run_id instead of label