### PR TITLE
Fix type inference - no more downloading all sys ids

### DIFF
--- a/neptune_fetcher/src/neptune_fetcher/internal/composition/download_files.py
+++ b/neptune_fetcher/src/neptune_fetcher/internal/composition/download_files.py
@@ -74,12 +74,6 @@ def download_files(
             fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
             container_type=container_type,
         )
-        if inference_result.is_run_domain_empty():
-            return output_format.create_files_dataframe(
-                [],
-                {},
-                index_column_name="experiment" if container_type == search.ContainerType.EXPERIMENT else "run",
-            )
         filter_ = inference_result.get_result_or_raise()
 
         sys_id_label_mapping: dict[identifiers.SysId, str] = {}

--- a/neptune_fetcher/src/neptune_fetcher/internal/composition/fetch_metrics.py
+++ b/neptune_fetcher/src/neptune_fetcher/internal/composition/fetch_metrics.py
@@ -88,15 +88,6 @@ def fetch_metrics(
             fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
             container_type=container_type,
         )
-        if inference_result.is_run_domain_empty():
-            return create_metrics_dataframe(
-                metrics_data={},
-                sys_id_label_mapping={},
-                index_column_name="experiment" if container_type == ContainerType.EXPERIMENT else "run",
-                timestamp_column_name="absolute_time" if include_time == "absolute" else None,
-                include_point_previews=include_point_previews,
-                type_suffix_in_column_names=type_suffix_in_column_names,
-            )
         inferred_filter = inference_result.get_result_or_raise()
 
         metrics_data, sys_id_to_label_mapping = _fetch_metrics(

--- a/neptune_fetcher/src/neptune_fetcher/internal/composition/fetch_series.py
+++ b/neptune_fetcher/src/neptune_fetcher/internal/composition/fetch_series.py
@@ -85,13 +85,6 @@ def fetch_series(
             fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
             container_type=container_type,
         )
-        if inference_result.is_run_domain_empty():
-            return create_series_dataframe(
-                series_data={},
-                sys_id_label_mapping={},
-                index_column_name="experiment" if container_type == ContainerType.EXPERIMENT else "run",
-                timestamp_column_name="absolute_time" if include_time == "absolute" else None,
-            )
         inferred_filter = inference_result.get_result_or_raise()
 
         sys_id_label_mapping: dict[identifiers.SysId, str] = {}

--- a/neptune_fetcher/src/neptune_fetcher/internal/composition/list_attributes.py
+++ b/neptune_fetcher/src/neptune_fetcher/internal/composition/list_attributes.py
@@ -66,8 +66,6 @@ def list_attributes(
             fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
             container_type=container_type,
         )
-        if inference_result.is_run_domain_empty():
-            return []
         filter_ = inference_result.get_result_or_raise()
 
         output = _components.fetch_attribute_definitions_complete(

--- a/neptune_fetcher/src/neptune_fetcher/internal/composition/list_containers.py
+++ b/neptune_fetcher/src/neptune_fetcher/internal/composition/list_containers.py
@@ -48,8 +48,6 @@ def list_containers(
             executor=executor,
             fetch_attribute_definitions_executor=fetch_attribute_definitions_executor,
         )
-        if inference_result.is_run_domain_empty():
-            return []
         filter_ = inference_result.get_result_or_raise()
 
         sys_attr_pages = search.fetch_sys_id_labels(container_type)(client, project_identifier, filter_)

--- a/neptune_fetcher/tests/e2e/internal/composition/test_type_inference.py
+++ b/neptune_fetcher/tests/e2e/internal/composition/test_type_inference.py
@@ -130,7 +130,6 @@ def test_infer_attribute_types_in_filter_no_filter(client, executor, project, ru
     result = infer_attribute_types_in_filter(client, project_identifier, None, executor, executor)
 
     # then
-    assert not result.is_run_domain_empty()
     # no exception is raised
     result.raise_if_incomplete()
 
@@ -182,7 +181,6 @@ def test_infer_attribute_types_in_filter_single(
     # then
     assert filter_before != filter_after
     assert result.result == filter_after
-    assert not result.is_run_domain_empty()
     result.raise_if_incomplete()
 
 
@@ -216,7 +214,6 @@ def test_infer_attribute_types_in_sort_by_single(
     # then
     assert attribute_before != attribute_after
     assert result.result == attribute_after
-    assert not result.is_run_domain_empty()
     result.raise_if_incomplete()
 
 
@@ -240,7 +237,6 @@ def test_infer_attribute_types_in_filter_missing(client, executor, project, filt
     )
 
     # then
-    assert not result.is_run_domain_empty()
     with pytest.raises(AttributeTypeInferenceError) as exc:
         result.raise_if_incomplete()
     assert "could not find the attribute" in str(exc.value)
@@ -268,7 +264,6 @@ def test_infer_attribute_types_in_sort_by_missing_attribute(client, executor, pr
     )
 
     # then
-    assert not result.is_run_domain_empty()
     with pytest.raises(AttributeTypeInferenceError) as exc:
         result.raise_if_incomplete()
     assert "could not find the attribute" in str(exc.value)
@@ -281,7 +276,8 @@ def test_infer_attribute_types_in_sort_by_missing_attribute(client, executor, pr
         (_Attribute(f"{PATH}/int-value"), _Filter.name_eq(EXPERIMENT_NAME + "does-not-exist")),
     ],
 )
-def test_infer_attribute_types_in_sort_by_missing_experiment(client, executor, project, attribute, experiment_filter):
+# TODO: remove this irrelevant test
+def xtest_infer_attribute_types_in_sort_by_missing_experiment(client, executor, project, attribute, experiment_filter):
     # given
     project_identifier = project.project_identifier
 
@@ -296,7 +292,6 @@ def test_infer_attribute_types_in_sort_by_missing_experiment(client, executor, p
     )
 
     # then
-    assert result.is_run_domain_empty()
     with pytest.raises(AttributeTypeInferenceError) as exc:
         result.raise_if_incomplete()
     assert "could not find the attribute" in str(exc.value)
@@ -325,7 +320,6 @@ def test_infer_attribute_types_in_filter_conflicting_types_int_string(
     )
 
     # then
-    assert not result.is_run_domain_empty()
     with pytest.raises(AttributeTypeInferenceError) as exc:
         result.raise_if_incomplete()
     exc.match(
@@ -359,7 +353,6 @@ def test_infer_attribute_types_in_filter_conflicting_types_int_float(
     )
 
     # then
-    assert not result.is_run_domain_empty()
     with pytest.raises(AttributeTypeInferenceError) as exc:
         result.raise_if_incomplete()
     exc.match(
@@ -395,7 +388,6 @@ def test_infer_attribute_types_in_sort_by_conflicting_types_int_string(
     )
 
     # then
-    assert not result.is_run_domain_empty()
     with pytest.raises(AttributeTypeInferenceError) as exc:
         result.raise_if_incomplete()
     exc.match(
@@ -431,7 +423,6 @@ def test_infer_attribute_types_in_sort_by_conflicting_types_int_float(
     )
 
     # then
-    assert not result.is_run_domain_empty()
     with pytest.raises(AttributeTypeInferenceError) as exc:
         result.raise_if_incomplete()
     exc.match(
@@ -464,7 +455,8 @@ def test_infer_attribute_types_in_sort_by_conflicting_types_int_float(
         ),
     ],
 )
-def test_infer_attribute_types_in_sort_by_conflicting_types_with_filter(
+# TODO: remove this irrelevant test
+def xtest_infer_attribute_types_in_sort_by_conflicting_types_with_filter(
     client,
     executor,
     project,
@@ -490,5 +482,4 @@ def test_infer_attribute_types_in_sort_by_conflicting_types_with_filter(
     # then
     assert attribute_before != attribute_after
     assert result.result == attribute_after
-    assert not result.is_run_domain_empty()
     result.raise_if_incomplete()


### PR DESCRIPTION
1. Added a list of known sys arguments and their types, to avoid calling API to resolve these

2. Stop fetching all sys_ids to infer artibute types

3. No longer treat empty project specially

Consequences:

1. Much quicker type inference -- no longer dependent on the size of the project, no more flood of requests to fetch all sys_ids

2. At the cost of users may now be more often asked to specify the type explicitly, for example:

   * `sort_by` inference no longer takes into account the resulting experiments/runs
   * Type interference now cannot filter types between experiments and runs

## Summary by Sourcery

Improve type inference by using a static map for sys attribute types, removing empty-project special cases, and eliminating costly sys_id downloads.

Bug Fixes:
- Prevent fetching all system IDs for type inference to reduce request floods and improve performance

Enhancements:
- Infer system attributes locally using a static KNOWN_ATTRIBUTE_TYPES map to avoid API resolution
- Remove run_domain_empty flag and eliminate special-case handling of empty projects and containers
- Streamline API usage by fetching attribute definitions directly instead of generating sys_id lists
- Default unset sort_by type to string and clean up unused parameters in inference functions

Tests:
- Update tests to remove assertions on run_domain_empty and mark irrelevant tests as skipped