### PR TITLE
PY-195 Remove mentions of set_context and set_project from exceptions

### DIFF
--- a/src/neptune_query/exceptions.py
+++ b/src/neptune_query/exceptions.py
@@ -50,11 +50,10 @@ class NeptuneProjectNotProvided(NeptuneUserError):
 
 Make sure to specify a valid project in one of the following ways:
 
-- Call the `set_project()` function
-- Create a Context with the project name and pass it to the `context` argument of the fetching method
+- Pass `project` argument to the fetching method
 - Set the `NEPTUNE_PROJECT` environment variable
 
-For details, see https://docs.neptune.ai/fetcher_setup
+For details, see https://docs.neptune.ai/query_metadata
 """
         )
 
@@ -101,10 +100,9 @@ class NeptuneApiTokenNotProvided(NeptuneUserError):
 Make sure to specify a valid token in one of the following ways:
 
 - Call the `set_api_token()` function
-- Create a Context with the API token and pass it to the `context` argument of the fetching method
 - Set the `NEPTUNE_API_TOKEN` environment variable
 
-For details, see https://docs.neptune.ai/fetcher_setup
+For details, see https://docs.neptune.ai/query_metadata
 """
         )
 
@@ -118,12 +116,11 @@ class NeptuneInvalidCredentialsError(NeptuneUserError):
 The API token must be valid and the associated account must have access to the target project.
 Make sure to specify your Neptune credentials in one of the following ways:
 
-- Call the `set_api_token()` or `set_project()` functions
-- Create a Context with the API token and project, then pass it to the `context` argument of the fetching method
+- Call the `set_api_token()`
 - Set the `NEPTUNE_API_TOKEN` and `NEPTUNE_PROJECT` environment variables
 
 For details, see:
-https://docs.neptune.ai/fetcher_setup
+https://docs.neptune.ai/query_metadata
 https://docs.neptune.ai/project_access
 """
         )

--- a/src/neptune_query/exceptions.py
+++ b/src/neptune_query/exceptions.py
@@ -116,7 +116,7 @@ class NeptuneInvalidCredentialsError(NeptuneUserError):
 The API token must be valid and the associated account must have access to the target project.
 Make sure to specify your Neptune credentials in one of the following ways:
 
-- Call the `set_api_token()`
+- Call the `set_api_token()` function
 - Set the `NEPTUNE_API_TOKEN` and `NEPTUNE_PROJECT` environment variables
 
 For details, see:

--- a/src/neptune_query/exceptions.py
+++ b/src/neptune_query/exceptions.py
@@ -50,7 +50,7 @@ class NeptuneProjectNotProvided(NeptuneUserError):
 
 Make sure to specify a valid project in one of the following ways:
 
-- Pass `project` argument to the fetching method
+- Pass the project path to the `project` argument of the fetching method
 - Set the `NEPTUNE_PROJECT` environment variable
 
 For details, see https://docs.neptune.ai/query_metadata


### PR DESCRIPTION
These were removed when switching from fetcher to query

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Simplify exception messages by removing outdated set_context and set_project instructions and updating documentation links.

Enhancements:
- Remove references to set_project(), set_api_token(), and Context usage from exception guidance
- Add instruction to pass the project argument directly to fetching methods
- Update documentation links from fetcher_setup to query_metadata