### PR TITLE
PY-198 Fix output regression in neptune_fetcher.runs.download_files

### DIFF
--- a/neptune_fetcher/src/neptune_fetcher/internal/composition/download_files.py
+++ b/neptune_fetcher/src/neptune_fetcher/internal/composition/download_files.py
@@ -156,4 +156,5 @@ def download_files(
         return output_format.create_files_dataframe(
             file_list,
             sys_id_label_mapping,
+            index_column_name="experiment" if container_type == search.ContainerType.EXPERIMENT else "run",
         )


### PR DESCRIPTION
Introduced in #402 by accident

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?

## Summary by Sourcery

Bug Fixes:
- Restore correct index_column_name in downloaded files dataframe to fix output regression in neptune_fetcher.runs.download_files